### PR TITLE
feat: add /v2/extract endpoint for schema-based extraction

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -20,6 +20,7 @@ from .models import (
     BatchScrapeRequest,
     SearchRequest, SearchResponse, SearchResult,
     MapRequest, MapResponse,
+    ExtractRequest, ExtractCreateResponse, ExtractStatusResponse,
 )
 from .store import JobStore
 
@@ -157,6 +158,41 @@ async def search(request: Request, body: SearchRequest):
     finally:
         await searxng.close()
 
+
+@router.post("/v2/extract", response_model=ExtractCreateResponse)
+async def create_extract(request: Request, body: ExtractRequest):
+    """Extract structured data from provided URLs."""
+    store: JobStore = request.app.state.job_store
+    job_id = store.create_job(kind="extract", payload=body.model_dump(exclude_none=True, by_alias=True))
+    import asyncio
+    from .worker import _process_extract_async
+    asyncio.create_task(
+        _process_extract_async(
+            job_id=job_id, urls=body.urls, prompt=body.prompt, schema_=body.schema_,
+            llm_base_url=request.app.state.llm_base_url, llm_api_key=request.app.state.llm_api_key,
+            llm_model=request.app.state.llm_model, scraper_url=request.app.state.scraper_url,
+        )
+    )
+    return ExtractCreateResponse(id=job_id)
+
+
+@router.get("/v2/extract/{job_id}", response_model=ExtractStatusResponse)
+async def get_extract_status(request: Request, job_id: str):
+    """Get extract job status and results."""
+    store: JobStore = request.app.state.job_store
+    job = store.get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return ExtractStatusResponse(
+        success=True,
+        status=job.get("status", "processing"),
+        data=job.get("data"),
+        error=job.get("error"),
+        expires_at=job.get("completed_at") or job.get("created_at"),
+    )
+
+
+# ----- Map -----
 
 @router.post("/v2/map", response_model=MapResponse)
 async def map_site(request: Request, body: MapRequest):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -108,3 +108,26 @@ class MapRequest(BaseModel):
 class MapResponse(BaseModel):
     success: bool = True
     links: list[str] = Field(default_factory=list)
+
+
+class ExtractRequest(BaseModel):
+    urls: list[str] = Field(..., min_length=1, description="URLs to extract data from")
+    prompt: str | None = Field(None, max_length=10000, description="Optional instruction for extraction")
+    schema_: dict[str, Any] | None = Field(None, alias="schema", description="JSON Schema for structured output")
+    model: str = Field(default="default", description="Model hint")
+    webhook: dict[str, Any] | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ExtractCreateResponse(BaseModel):
+    success: bool = True
+    id: str
+
+
+class ExtractStatusResponse(BaseModel):
+    success: bool = True
+    status: str = "processing"  # processing | completed | failed
+    data: dict[str, Any] | None = None
+    error: str | None = None
+    expires_at: str | None = None

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -1,10 +1,6 @@
 """The agent research loop: search → scrape → think → answer.
 
-This is the core of the GroktoCrawl agent. Given a prompt, it:
-1. Searches the web (if no seed URLs provided)
-2. Scrapes the most relevant pages
-3. Feeds everything to an LLM
-4. Returns the synthesized answer
+Also provides the extract endpoint: scrape given URLs → LLM → structured data.
 """
 
 import json
@@ -26,6 +22,15 @@ Rules:
 - Be concise but thorough.
 - Format your answer in clean markdown."""
 
+EXTRACT_SYSTEM_PROMPT = """You are GroktoCrawl, a structured data extraction agent.
+Your job is to extract the requested information from the provided web content.
+
+Rules:
+- Extract data based ONLY on the content provided below.
+- If the content doesn't contain the requested information, return an empty result.
+- If a schema is provided, respond with valid JSON matching that schema exactly.
+- Format your answer in clean markdown if no schema is provided."""
+
 
 async def run_research(
     prompt: str,
@@ -37,82 +42,90 @@ async def run_research(
     llm_api_key: str = "",
     llm_model: str = "gpt-4o-mini",
 ) -> dict:
-    """Execute the research loop.
-
-    Returns:
-        dict with keys: result (str), sources (list[str]), source_details (list[dict])
-    """
+    """Execute the research loop: search → scrape → think → answer."""
     searxng = SearXNGClient(searxng_url)
     scraper = ScraperClient(scraper_url)
     llm = LLMClient(llm_base_url, llm_api_key, llm_model)
 
     try:
-        # Step 1: Determine URLs to scrape
         target_urls = list(urls) if urls else []
         if not target_urls:
             logger.info("No URLs provided. Searching for: %s", prompt)
             search_results = await searxng.search(prompt, limit=10)
             target_urls = [r["url"] for r in search_results if r.get("url")]
-            logger.info("Found %d candidate URLs", len(target_urls))
 
-        # Step 2: Scrape the top URLs
-        documents = []
-        source_details = []
-
-        # Limit to top 5 for MVP
-        for url in target_urls[:5]:
-            logger.info("Scraping: %s", url)
-            result = await scraper.scrape(url)
-            if result.get("success") and result.get("data", {}).get("markdown"):
-                md = result["data"]["markdown"]
-                doc = f"Source: {url}\n\n{md[:8000]}"  # Truncate per source
-                documents.append(doc)
-                source_details.append({
-                    "url": url,
-                    "source": result["data"].get("source", "unknown"),
-                    "char_count": len(md),
-                })
-            else:
-                logger.warning("Failed to scrape %s: %s", url, result.get("error"))
-
-        # Step 3: Call the LLM with gathered context
+        documents, source_details = await _scrape_urls(target_urls, scraper)
         context = "\n\n---\n\n".join(documents) if documents else ""
+
         if not context:
-            return {
-                "result": "I was unable to find or scrape any relevant web pages to answer your question.",
-                "sources": [],
-                "source_details": [],
-            }
+            return {"result": "I was unable to find or scrape any relevant web pages to answer your question.", "sources": [], "source_details": []}
 
-        answer = await llm.generate(
-            system_prompt=SYSTEM_PROMPT,
-            user_prompt=prompt,
-            context=context,
-            schema=schema,
-        )
-
-        # If schema was requested, try to parse as JSON
-        if schema:
-            try:
-                # Strip markdown code fences if present
-                cleaned = answer.strip()
-                if cleaned.startswith("```json"):
-                    cleaned = cleaned[7:]
-                if cleaned.startswith("```"):
-                    cleaned = cleaned[3:]
-                if cleaned.endswith("```"):
-                    cleaned = cleaned[:-3]
-                json.loads(cleaned)  # validate it's parseable
-            except (json.JSONDecodeError, Exception) as e:
-                logger.warning("LLM response not valid JSON despite schema: %s", e)
-
-        return {
-            "result": answer,
-            "sources": [s["url"] for s in source_details],
-            "source_details": source_details,
-        }
-
+        answer = await llm.generate(system_prompt=SYSTEM_PROMPT, user_prompt=prompt, context=context, schema=schema)
+        _validate_json_if_schema(answer, schema)
+        return {"result": answer, "sources": [s["url"] for s in source_details], "source_details": source_details}
     finally:
         await searxng.close()
         await scraper.close()
         await llm.close()
+
+
+async def run_extract(
+    urls: list[str],
+    prompt: str | None = None,
+    schema: dict | None = None,
+    scraper_url: str = "http://scraper-svc:8001",
+    llm_base_url: str = "https://api.openai.com/v1",
+    llm_api_key: str = "",
+    llm_model: str = "gpt-4o-mini",
+) -> dict:
+    """Extract structured data from given URLs. No search step."""
+    scraper = ScraperClient(scraper_url)
+    llm = LLMClient(llm_base_url, llm_api_key, llm_model)
+
+    try:
+        documents, source_details = await _scrape_urls(urls, scraper)
+        context = "\n\n---\n\n".join(documents) if documents else ""
+
+        if not context:
+            return {"result": "No content could be extracted from the provided URLs.", "sources": [], "source_details": []}
+
+        user_prompt = prompt or "Extract the requested information from the provided content."
+        answer = await llm.generate(system_prompt=EXTRACT_SYSTEM_PROMPT, user_prompt=user_prompt, context=context, schema=schema)
+        _validate_json_if_schema(answer, schema)
+        return {"result": answer, "sources": [s["url"] for s in source_details], "source_details": source_details}
+    finally:
+        await scraper.close()
+        await llm.close()
+
+
+async def _scrape_urls(urls: list[str], scraper: ScraperClient) -> tuple[list[str], list[dict]]:
+    """Scrape URLs and return (documents, source_details)."""
+    documents = []
+    source_details = []
+    for url in urls[:5]:
+        logger.info("Scraping: %s", url)
+        result = await scraper.scrape(url)
+        if result.get("success") and result.get("data", {}).get("markdown"):
+            md = result["data"]["markdown"]
+            documents.append(f"Source: {url}\n\n{md[:8000]}")
+            source_details.append({"url": url, "source": result["data"].get("source", "unknown"), "char_count": len(md)})
+        else:
+            logger.warning("Failed to scrape %s: %s", url, result.get("error"))
+    return documents, source_details
+
+
+def _validate_json_if_schema(answer: str, schema: dict | None) -> None:
+    """If a schema was provided, attempt to parse the answer as JSON."""
+    if not schema:
+        return
+    try:
+        cleaned = answer.strip()
+        if cleaned.startswith("```json"):
+            cleaned = cleaned[7:]
+        if cleaned.startswith("```"):
+            cleaned = cleaned[3:]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3]
+        json.loads(cleaned)
+    except (json.JSONDecodeError, Exception) as e:
+        logger.warning("LLM response not valid JSON despite schema: %s", e)

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import Any
 
-from .research import run_research
+from .research import run_research, run_extract
 from .scraper_client import ScraperClient
 from .store import JobStore
 
@@ -82,6 +82,29 @@ async def _process_batch_scrape_async(job_id: str, urls: list[str], scraper_url:
         store.fail_job(job_id, str(e))
     finally:
         await scraper.close()
+
+
+async def _process_extract_async(
+    job_id: str,
+    urls: list[str],
+    prompt: str | None,
+    schema_: dict[str, Any] | None,
+    llm_base_url: str,
+    llm_api_key: str,
+    llm_model: str,
+    scraper_url: str,
+) -> None:
+    store = JobStore(get_env("VALKEY_URL", "redis://valkey:6379/0"))
+    try:
+        result = await run_extract(
+            urls=urls, prompt=prompt, schema=schema_,
+            scraper_url=scraper_url, llm_base_url=llm_base_url,
+            llm_api_key=llm_api_key, llm_model=llm_model,
+        )
+        store.complete_job(job_id, result)
+    except Exception as e:
+        logger.exception("Extract job %s failed", job_id)
+        store.fail_job(job_id, str(e))
 
 
 def process_agent_job(


### PR DESCRIPTION
## What does this PR do?

Adds the `/v2/extract` endpoint — given URLs and an optional JSON schema, scrape the pages and extract structured data using the configured LLM. No search step, unlike the agent endpoint.

Closes #1

## Changes

- **models.py** — `ExtractRequest`, `ExtractCreateResponse`, `ExtractStatusResponse`
- **research.py** — `run_extract()` (scrape-only, no search), `_scrape_urls()` helper, `_validate_json_if_schema()` helper, refactored `run_research()` to use shared helpers
- **worker.py** — `_process_extract_async()` handler
- **api.py** — `POST /v2/extract` and `GET /v2/extract/:jobId` routes

## Why separate from agent?

The agent does search → scrape → synthesize. Extract does scrape → synthesize only. When you already know which URLs to extract from, the search step is wasted tokens and time.

## Testing

```
POST /v2/extract { "urls": ["https://blog.google/..."] }
→ { "id": "job_xxx" }

GET /v2/extract/job_xxx
→ { "status": "completed", "data": { "result": "...", "sources": [...] } }
```

Verfied end-to-end against the live stack with DeepSeek + SearXNG.

## Checklist

- [x] New feature
- [x] Tested against live Docker stack
- [x] Conventional commit message
- [x] Closes the related issue

—

Filed by Jasper (AI agent on behalf of Magnus Hedemark)