### PR TITLE
feat: monitor endpoints for scheduled change detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ All Firecrawl v2 API-compatible in request/response shape.
 | Extract (schema-based) | ✅ | ❌ (closed-source) | ✅ |
 | Browser sessions | ✅ | ❌ (closed-source) | ✅ |
 | Scheduled monitors | ✅ | ❌ (closed-source) | ✅ |
+| Parse (PDF, DOCX) | ✅ | ✅ | [#4](https://github.com/groktopus/groktocrawl/issues/4) |
+| Webhook delivery | ✅ | ✅ | [#5](https://github.com/groktopus/groktocrawl/issues/5) |
 | License | Proprietary | AGPL-3.0 | **MIT** |
 | Self-contained Docker | ✅ | ⚠️ requires Supabase, Stripe | **✅ one file** |
 | LLM integration | Built-in | Requires API key | **BYO or fixture** |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Self-hosted, API-compatible Firecrawl alternative with Agent endpoint. MIT licensed. One `docker compose up` and you're running.**
 
-GroktoCrawl implements the Firecrawl v2 API surface — scrape, search, map, crawl, and the **Agent** endpoint (autonomous web research) — without the closed-source dependencies. Runs entirely in Docker on your own hardware. Bring your own LLM or use the built-in fixtures.
+GroktoCrawl implements the Firecrawl v2 API surface — scrape, search, map, crawl, extract, browser sessions, monitors, and the **Agent** endpoint (autonomous web research) — without the closed-source dependencies. Runs entirely in Docker on your own hardware. Bring your own LLM or use the built-in fixtures.
 
 ## Quick Start
 
@@ -11,7 +11,7 @@ cp .env.sample .env
 docker compose up --build -d
 ```
 
-Six containers start. The default stack uses fixture services so everything works without API keys.
+Eight containers start. The stack includes SearXNG for real web search, a smart scraper, and an Ofelia-scheduled monitor system.
 
 ```bash
 # CLI
@@ -45,20 +45,23 @@ LLM_BASE_URL=http://host.docker.internal:11434/v1
 LLM_MODEL=llama3.2
 ```
 
-The stack includes **SearXNG** for real web search (enabled by default). Fixture services (`search-svc`, `llm-svc`, `test-site`) run only with `--profile fixture`.
-
 ## Architecture
 
 ```mermaid
 flowchart TD
     subgraph compose["docker-compose.yml"]
-        valkey[("valkey<br/>(queue)")]
+        valkey[("valkey<br/>(queue + storage)")]
         searxng["searxng<br/>(web search)"]
-        scraper("scraper-svc<br/>(smart fetch:<br/>llms.txt → markdown → playwright)")
-        agent("agent-svc<br/>(FastAPI + research worker)")
+        scraper("scraper-svc<br/>(smart fetch)")
+        browser["browser-svc<br/>(Playwright sessions)"]
+        agent("agent-svc<br/>(FastAPI + workers)")
+        ofelia["ofelia<br/>(cron scheduler)"]
+
         valkey --- agent
         searxng --- agent
         scraper --- agent
+        browser --- agent
+        ofelia -.->|docker exec| agent
     end
     llm_provider("LLM Provider<br/>(DeepSeek / OpenAI / Ollama)")
     llm_provider -.->|LLM_BASE_URL| agent
@@ -66,7 +69,9 @@ flowchart TD
     style valkey fill:#ffe0b0
     style searxng fill:#b0d4ff
     style scraper fill:#b0ffb0
+    style browser fill:#d4b0ff
     style agent fill:#ffb0b0
+    style ofelia fill:#b0b0b0
 ```
 
 The scraper uses a **three-tier strategy**: check `/llms.txt` first, try `Accept: text/markdown` second, render with Playwright third.
@@ -92,26 +97,39 @@ The scraper uses a **three-tier strategy**: check `/llms.txt` first, try `Accept
 | POST | `/v2/agent` | Start an autonomous research agent |
 | GET | `/v2/agent/:jobId` | Get agent job status and results |
 | DELETE | `/v2/agent/:jobId` | Cancel an agent job |
+| POST | `/v2/extract` | Extract structured data from URLs (with schema) |
+| GET | `/v2/extract/:jobId` | Get extract status and results |
 | POST | `/v2/crawl` | Crawl a website |
 | GET | `/v2/crawl/:jobId` | Get crawl status |
 | DELETE | `/v2/crawl/:jobId` | Cancel a crawl |
 | POST | `/v2/batch/scrape` | Scrape multiple URLs |
 | POST | `/v2/search` | Search the web with content |
 | POST | `/v2/map` | Discover URLs on a site |
+| POST | `/v2/browser` | Create a headless browser session |
+| GET | `/v2/browser` | List active browser sessions |
+| POST | `/v2/browser/:id/execute` | Execute action (navigate, click, screenshot, etc.) |
+| DELETE | `/v2/browser/:id` | Destroy a browser session |
+| POST | `/v2/monitor` | Create a scheduled change monitor |
+| GET | `/v2/monitor` | List all monitors |
+| GET | `/v2/monitor/:id` | Get monitor status and history |
+| PATCH | `/v2/monitor/:id` | Update monitor config |
+| DELETE | `/v2/monitor/:id` | Delete a monitor |
 
-All Firecrawl v2 API-compatible.
+All Firecrawl v2 API-compatible in request/response shape.
 
 ## Comparison to Firecrawl
 
 | Feature | Firecrawl Cloud | Firecrawl Self-Hosted | GroktoCrawl |
 |---------|----------------|----------------------|-------------|
-| Scrape / Crawl / Map | ✅ | ✅ | ✅ |
+| Scrape / Crawl / Map / Search | ✅ | ✅ | ✅ |
 | Agent endpoint | ✅ | ❌ (closed-source) | ✅ |
-| Browser sessions | ✅ | ❌ (closed-source) | Post-MVP |
+| Extract (schema-based) | ✅ | ❌ (closed-source) | ✅ |
+| Browser sessions | ✅ | ❌ (closed-source) | ✅ |
+| Scheduled monitors | ✅ | ❌ (closed-source) | ✅ |
 | License | Proprietary | AGPL-3.0 | **MIT** |
 | Self-contained Docker | ✅ | ⚠️ requires Supabase, Stripe | **✅ one file** |
 | LLM integration | Built-in | Requires API key | **BYO or fixture** |
 
 ## Project Status
 
-MVP. All core endpoints implemented and integration-tested. Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
+Active development. All core Firecrawl v2 API endpoints implemented and integration-tested. See [issues](https://github.com/groktopus/groktocrawl/issues) for upcoming features. Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -24,8 +24,11 @@ from .models import (
     BrowserCreateRequest, BrowserCreateResponse,
     BrowserExecuteRequest, BrowserExecuteResponse,
     BrowserListResponse, BrowserDeleteResponse,
+    MonitorCreateRequest, MonitorUpdateRequest, MonitorResponse,
+    MonitorListResponse, MonitorDeleteResponse,
 )
 from .store import JobStore
+from .monitor import get_all_monitors, get_monitor, save_monitor, delete_monitor
 
 logger = logging.getLogger(__name__)
 
@@ -270,3 +273,77 @@ async def destroy_browser(session_id: str):
     if not result.get("success"):
         raise HTTPException(status_code=404, detail="Session not found")
     return BrowserDeleteResponse(id=session_id)
+
+
+# ----- Monitor -----
+
+@router.post("/v2/monitor", response_model=MonitorResponse)
+async def create_monitor(body: MonitorCreateRequest):
+    import uuid
+    from datetime import datetime, timezone
+    monitor_id = str(uuid.uuid4())
+    config = {
+        "url": body.url,
+        "schedule": body.schedule,
+        "webhook": body.webhook,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "last_content": "",
+    }
+    save_monitor(monitor_id, config)
+    return MonitorResponse(
+        id=monitor_id, url=body.url, schedule=body.schedule,
+        webhook=body.webhook, created_at=config["created_at"],
+    )
+
+
+@router.get("/v2/monitor", response_model=MonitorListResponse)
+async def list_monitors():
+    monitors = get_all_monitors()
+    items = []
+    for mid, cfg in monitors.items():
+        items.append(MonitorResponse(
+            id=mid, url=cfg.get("url", ""), schedule=cfg.get("schedule", ""),
+            webhook=cfg.get("webhook"), last_checked=cfg.get("last_checked"),
+            last_result=cfg.get("last_result"), created_at=cfg.get("created_at", ""),
+        ))
+    return MonitorListResponse(monitors=items)
+
+
+@router.get("/v2/monitor/{monitor_id}", response_model=MonitorResponse)
+async def get_monitor_status(monitor_id: str):
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail="Monitor not found")
+    return MonitorResponse(
+        id=monitor_id, url=cfg.get("url", ""), schedule=cfg.get("schedule", ""),
+        webhook=cfg.get("webhook"), last_checked=cfg.get("last_checked"),
+        last_result=cfg.get("last_result"), created_at=cfg.get("created_at", ""),
+    )
+
+
+@router.patch("/v2/monitor/{monitor_id}", response_model=MonitorResponse)
+async def update_monitor(monitor_id: str, body: MonitorUpdateRequest):
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail="Monitor not found")
+    if body.url is not None:
+        cfg["url"] = body.url
+    if body.schedule is not None:
+        cfg["schedule"] = body.schedule
+    if body.webhook is not None:
+        cfg["webhook"] = body.webhook
+    save_monitor(monitor_id, cfg)
+    return MonitorResponse(
+        id=monitor_id, url=cfg.get("url", ""), schedule=cfg.get("schedule", ""),
+        webhook=cfg.get("webhook"), last_checked=cfg.get("last_checked"),
+        last_result=cfg.get("last_result"), created_at=cfg.get("created_at", ""),
+    )
+
+
+@router.delete("/v2/monitor/{monitor_id}", response_model=MonitorDeleteResponse)
+async def delete_monitor_route(monitor_id: str):
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail="Monitor not found")
+    delete_monitor(monitor_id)
+    return MonitorDeleteResponse(success=True)

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -165,3 +165,35 @@ class ExtractStatusResponse(BaseModel):
     data: dict[str, Any] | None = None
     error: str | None = None
     expires_at: str | None = None
+
+
+class MonitorCreateRequest(BaseModel):
+    url: str = Field(..., description="URL to monitor for changes")
+    schedule: str = Field(default="0 */6 * * *", description="Cron expression for check frequency")
+    webhook: str | None = Field(None, description="Webhook URL called on change")
+
+
+class MonitorUpdateRequest(BaseModel):
+    url: str | None = None
+    schedule: str | None = None
+    webhook: str | None = None
+
+
+class MonitorResponse(BaseModel):
+    success: bool = True
+    id: str
+    url: str
+    schedule: str
+    webhook: str | None = None
+    last_checked: str | None = None
+    last_result: str | None = None
+    created_at: str
+
+
+class MonitorListResponse(BaseModel):
+    success: bool = True
+    monitors: list[MonitorResponse] = Field(default_factory=list)
+
+
+class MonitorDeleteResponse(BaseModel):
+    success: bool = True

--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -1,0 +1,182 @@
+"""Monitor module — scheduled change detection for web pages.
+
+Architecture:
+- Ofelia (scheduler container) runs `python3 -m agent.monitor check_all` every N minutes
+- check_all reads monitor configs from Valkey, scrapes each URL, diffs, notifies
+- Results stored in Valkey under monitor:{id}:history
+"""
+
+import asyncio
+import difflib
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from redis import Redis
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = "redis://valkey:6379/0"
+MONITOR_KEY = "monitors"  # hash: monitor_id -> json config
+HISTORY_KEY = "monitor:{}:history"  # list of check results
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get_redis() -> Redis:
+    return Redis.from_url(REDIS_URL, decode_responses=True)
+
+
+def get_all_monitors() -> dict[str, dict]:
+    """Get all monitor configs from Valkey."""
+    r = _get_redis()
+    raw = r.hgetall(MONITOR_KEY)
+    monitors = {}
+    for mid, val in raw.items():
+        try:
+            monitors[mid] = json.loads(val)
+        except json.JSONDecodeError:
+            continue
+    return monitors
+
+
+def save_monitor(monitor_id: str, config: dict) -> None:
+    """Save or update a monitor config."""
+    r = _get_redis()
+    r.hset(MONITOR_KEY, monitor_id, json.dumps(config))
+
+
+def delete_monitor(monitor_id: str) -> None:
+    """Delete a monitor config and its history."""
+    r = _get_redis()
+    r.hdel(MONITOR_KEY, monitor_id)
+    r.delete(HISTORY_KEY.format(monitor_id))
+
+
+def get_monitor(monitor_id: str) -> dict | None:
+    """Get a single monitor config."""
+    r = _get_redis()
+    raw = r.hget(MONITOR_KEY, monitor_id)
+    if raw is None:
+        return None
+    return json.loads(raw)
+
+
+def _compute_diff(old: str, new: str) -> str:
+    """Compute a unified diff between old and new content."""
+    old_lines = old.splitlines(keepends=True)
+    new_lines = new.splitlines(keepends=True)
+    diff = list(difflib.unified_diff(old_lines, new_lines, fromfile="previous", tofile="current", n=3))
+    return "".join(diff[:100])  # cap at 100 lines
+
+
+def _store_check(monitor_id: str, result: dict) -> None:
+    """Store a check result in the history list."""
+    r = _get_redis()
+    key = HISTORY_KEY.format(monitor_id)
+    r.lpush(key, json.dumps(result))
+    r.ltrim(key, 0, 49)  # keep last 50 checks
+
+
+async def check_monitor(monitor_id: str, config: dict) -> dict:
+    """Run a single monitor check: scrape → diff → notify."""
+    url = config["url"]
+    scraper_url = config.get("scraper_url", "http://scraper-svc:8001")
+    webhook_url = config.get("webhook")
+    previous_content = config.get("last_content", "")
+
+    result: dict[str, Any] = {
+        "monitor_id": monitor_id,
+        "url": url,
+        "checked_at": _now_iso(),
+        "changed": False,
+        "diff": "",
+    }
+
+    # Scrape
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(f"{scraper_url}/scrape", json={"url": url})
+            if resp.status_code != 200:
+                result["error"] = f"Scrape returned {resp.status_code}"
+                _store_check(monitor_id, result)
+                return result
+            body = resp.json()
+            if not body.get("success"):
+                result["error"] = body.get("error", "Scrape failed")
+                _store_check(monitor_id, result)
+                return result
+            current_content = body.get("data", {}).get("markdown", "")
+    except Exception as e:
+        result["error"] = f"Scrape error: {e}"
+        _store_check(monitor_id, result)
+        return result
+
+    # Compare
+    if previous_content and current_content != previous_content:
+        diff = _compute_diff(previous_content, current_content)
+        result["changed"] = True
+        result["diff"] = diff
+        result["previous_length"] = len(previous_content)
+        result["current_length"] = len(current_content)
+
+    # Update stored content
+    config["last_content"] = current_content
+    config["last_checked"] = _now_iso()
+    config["last_result"] = result.get("changed", False) and "changed" or "unchanged"
+    save_monitor(monitor_id, config)
+
+    # Notify via webhook
+    if webhook_url and result.get("changed"):
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                await client.post(webhook_url, json={
+                    "event": "monitor.changed",
+                    "monitor_id": monitor_id,
+                    "url": url,
+                    "diff": result["diff"],
+                    "checked_at": result["checked_at"],
+                })
+        except Exception as e:
+            logger.warning("Webhook delivery failed for monitor %s: %s", monitor_id, e)
+
+    _store_check(monitor_id, result)
+    return result
+
+
+async def check_all_async() -> list[dict]:
+    """Check all monitors."""
+    monitors = get_all_monitors()
+    results = []
+    for mid, config in monitors.items():
+        logger.info("Checking monitor %s: %s", mid, config.get("url"))
+        try:
+            result = await check_monitor(mid, config)
+            results.append(result)
+            if result.get("changed"):
+                logger.info("Monitor %s: CHANGED", mid)
+        except Exception as e:
+            logger.error("Monitor %s failed: %s", mid, e)
+    return results
+
+
+def check_all() -> None:
+    """Synchronous entrypoint for Ofelia scheduler."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    results = asyncio.run(check_all_async())
+    changed = [r for r in results if r.get("changed")]
+    if changed:
+        print(f"Monitors checked: {len(results)}, changed: {len(changed)}")
+        for r in changed:
+            print(f"  CHANGED: {r['url']} ({r['monitor_id']})")
+    else:
+        print(f"Monitors checked: {len(results)}, all unchanged")
+
+
+if __name__ == "__main__":
+    check_all()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,5 +94,14 @@ services:
       - HOST=0.0.0.0
       - PORT=8080
 
+  ofelia:
+    image: mcuadros/ofelia:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /Users/magnus/.hermes/ofelia-config.ini:/etc/ofelia/config.ini:ro
+    depends_on:
+      - agent-svc
+
 volumes:
   valkey_data:

--- a/ofelia/config.ini
+++ b/ofelia/config.ini
@@ -1,0 +1,7 @@
+# Ofelia scheduler configuration for GroktoCrawl monitors.
+# Runs monitor checks on a recurring schedule.
+
+[job-exec "check-all-monitors"]
+schedule = */10 * * * *
+container = groktocrawl-agent-svc-1
+command = python3 -m agent.monitor check_all


### PR DESCRIPTION
## What does this PR do?

Adds `/v2/monitor` CRUD endpoints for scheduling recurring web page change detection. Uses **Ofelia** as the scheduler — a lightweight Docker-native cron daemon.

Closes #3

## Architecture

```
POST   /v2/monitor                → create a monitor (url + cron schedule + optional webhook)
GET    /v2/monitor                → list all monitors
GET    /v2/monitor/:id            → get monitor status
PATCH  /v2/monitor/:id            → update monitor config
DELETE /v2/monitor/:id            → delete monitor
```

Monitors are stored in Valkey. Ofelia runs `python3 -m agent.monitor check_all` every 10 minutes, which:

1. Reads all monitor configs from Valkey
2. Scrapes each URL via scraper-svc
3. Compares content with the previous scrape (stored in Valkey)
4. If changed: stores the diff, fires webhook if configured
5. Keeps last 50 check results per monitor

## Key Design Decisions

- **Ofelia as scheduler** — single `docker exec` job that calls `check_all`. No dynamic config generation needed.
- **Content diff** — unified_diff format, capped at 100 lines. Stored inline in the result.
- **Webhook** — POSTs `{ event, monitor_id, url, diff, checked_at }` to the configured webhook URL on change.

## Testing

```
POST /v2/monitor { "url": "https://example.com", "schedule": "0 */6 * * *" }
→ { "id": "60daf067-...", "url": "https://example.com", "schedule": "0 */6 * * *" }

GET /v2/monitor → { "monitors": [...] }

PATCH /v2/monitor/:id { "schedule": "0 */3 * * *" }
→ { "schedule": "0 */3 * * *" }

DELETE /v2/monitor/:id → { "success": true }
```

Ofelia confirmed running: "New job registered check-all-monitors - */10 * * * *"
First run output: "Monitors checked: 0, all unchanged"

## Checklist

- [x] New feature
- [x] Tested against live Docker stack
- [x] Conventional commit message
- [x] Closes the related issue

—

Filed by Jasper (AI agent on behalf of Magnus Hedemark)