### PR TITLE
feat: add download subcommand for binary content

### DIFF
--- a/groktocrawl
+++ b/groktocrawl
@@ -9,7 +9,8 @@ Commands:
   map      Discover URLs on a site
   crawl    Crawl a website
   agent    Start an autonomous research agent
-
+  download Download binary content (PDF, EPUB, image, etc.) to disk
+  extract  Extract structured data from URLs
 Global flags:
   --server <url>   API URL (default: GROKTOCRAWL_API_URL env or http://localhost:8080)
   --json           Machine-readable JSON output
@@ -478,6 +479,111 @@ def cmd_agent(client: Client, args: argparse.Namespace) -> None:
 
 
 
+
+def cmd_download(client: Client, args: argparse.Namespace) -> None:
+    """Download binary content (PDF, EPUB, image, etc.) from a URL."""
+    import os
+    from urllib.parse import urlparse
+
+    from requests import get as http_get
+
+    url = args.url
+    output = args.output
+    extract_text = getattr(args, 'extract_text', False)
+
+    if client.dry_run:
+        emit(f"[dry-run] Would download {url}", {"dry_run": True, "command": "download", "url": url})
+        return
+
+    log(f"Downloading {url}...")
+    try:
+        resp = http_get(
+            url,
+            stream=True,
+            timeout=60,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/131.0.0.0 Safari/537.36"
+                ),
+            },
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        die(f"Download failed: {e}")
+
+    content_type = resp.headers.get("content-type", "application/octet-stream").split(";")[0].strip()
+
+    # Derive filename if not provided
+    if not output:
+        parsed = urlparse(url)
+        path = parsed.path.rstrip("/")
+        basename = path.split("/")[-1] if path else "download"
+        if "." not in basename:
+            ext_map = {
+                "application/pdf": ".pdf",
+                "application/epub+zip": ".epub",
+                "application/zip": ".zip",
+                "image/png": ".png",
+                "image/jpeg": ".jpg",
+                "image/gif": ".gif",
+                "image/webp": ".webp",
+                "text/csv": ".csv",
+                "application/json": ".json",
+            }
+            ext = ext_map.get(content_type, "")
+            basename = f"{basename}{ext}" if ext else basename
+        output = basename
+
+    # Write content to disk
+    content = resp.content
+    with open(output, "wb") as f:
+        f.write(content)
+
+    log(f"Saved {len(content)} bytes to {output} (type: {content_type})")
+
+    # Optional text extraction
+    if extract_text:
+        text = None
+        try:
+            if content_type == "application/pdf":
+                try:
+                    import fitz
+                    doc = fitz.open(stream=content, filetype="pdf")
+                    text = "\n".join(page.get_text() for page in doc)
+                except ImportError:
+                    warn("PyMuPDF not installed. Install with: pip install pymupdf")
+            elif content_type == "application/epub+zip":
+                try:
+                    import ebooklib
+                    from ebooklib import epub
+                    from bs4 import BeautifulSoup
+                    from io import BytesIO
+                    book = epub.read_epub(BytesIO(content))
+                    chapters = []
+                    for item in book.get_items():
+                        if item.get_type() == ebooklib.ITEM_DOCUMENT:
+                            soup = BeautifulSoup(item.get_content(), "html.parser")
+                            chapters.append(soup.get_text())
+                    text = "\n".join(chapters)
+                except ImportError:
+                    warn("ebooklib not installed. Install with: pip install ebooklib beautifulsoup4")
+        except Exception as e:
+            warn(f"Text extraction failed: {e}")
+
+        if text:
+            text_path = output.rsplit(".", 1)[0] + ".txt"
+            with open(text_path, "w") as f:
+                f.write(text)
+            log(f"Extracted text ({len(text)} chars) to {text_path}")
+
+    # JSON output
+    if JSON_OUTPUT:
+        emit("", {"success": True, "filename": output, "size": len(content), "content_type": content_type})
+
+
+
 def cmd_extract(client: Client, args: argparse.Namespace) -> None:
     if client.dry_run:
         emit(f"[dry-run] Would extract from {args.urls}", {"dry_run": True, "command": "extract"})
@@ -665,6 +771,11 @@ def make_parser() -> argparse.ArgumentParser:
     p_agent.add_argument("--urls", nargs="+", help="Seed URLs to focus research")
     p_agent.add_argument("--no-poll", action="store_true", help="Don't poll for results")
 
+    p_download = subparsers.add_parser("download", help="Download binary content (PDF, EPUB, image, etc.) to disk")
+    p_download.add_argument("url", help="URL to download")
+    p_download.add_argument("-o", "--output", help="Save path (default: auto-derived from URL)")
+    p_download.add_argument("--extract-text", action="store_true", help="Also extract text for supported types (PDF, EPUB)")
+
     p_extract = subparsers.add_parser("extract", help="Extract structured data from URLs")
     p_extract.add_argument("urls", nargs="+", help="URLs to extract data from")
     p_extract.add_argument("--prompt", help="Extraction prompt")
@@ -744,6 +855,7 @@ def main() -> None:
         "map": cmd_map,
         "crawl": cmd_crawl,
         "agent": cmd_agent,
+        "download": cmd_download,
         "extract": cmd_extract,
         "browser": cmd_browser,
         "active": cmd_active,


### PR DESCRIPTION
## Summary

Adds `groktocrawl download <url>` — download binary content (PDF, EPUB, images, etc.) directly to disk without going through the HTML-to-markdown pipeline.

## Related Issue

Closes #25

## Example Usage

```bash
groktocrawl download https://arxiv.org/pdf/2401.12345
groktocrawl download https://example.com/paper.pdf -o research.pdf
groktocrawl download https://example.com/doc.epub --extract-text
```

## Type of Change

- [x] ✨ New feature

## Checklist

- [x] Syntax validated
- [x] `--help` output verified for both `groktocrawl` and `groktocrawl download`
- [x] Follows existing CLI patterns (argparse, Client, dry-run, JSON)