### PR TITLE
feat: LLM-assisted recovery when standard fetch fails

### DIFF
--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -81,6 +81,28 @@ def _make_download_payload(url: str, content: bytes, content_type: str) -> dict:
     }
 
 
+# ── Suspicious content detection (for LLM recovery trigger) ────
+CLOUDFLARE_INDICATORS = [
+    "Just a moment",
+    "Checking your browser",
+    "DDoS protection by",
+    "cf-browser-verification",
+    "challenge-platform",
+]
+
+
+def _looks_suspicious(content: str) -> bool:
+    """Heuristic: does the page content look like a challenge/error page?"""
+    if not content:
+        return True
+    if len(content) < 100:
+        return True
+    for indicator in CLOUDFLARE_INDICATORS:
+        if indicator.lower() in content.lower():
+            return True
+    return False
+
+
 def _looks_like_markdown(text: str) -> bool:
     """Heuristic: does the response look like markdown vs HTML?"""
     if not text:
@@ -229,8 +251,16 @@ async def smart_scrape(url: str) -> dict:
 
     # Tier 3 (no shared client needed)
     result = await fetch_via_playwright(url)
-    if result:
+    if result and not _looks_suspicious(result.get("markdown", "")):
         return result
+
+    # Tier 4: LLM-assisted recovery when content looks suspicious
+    if result:
+        logger.info("Tier 4: attempting LLM recovery for %s", url)
+        from .recovery import attempt_llm_recovery
+        recovery_result = await attempt_llm_recovery(url, result.get("markdown", ""))
+        if recovery_result:
+            return recovery_result
 
     return {
         "error": f"Could not extract content from {url}",

--- a/scraper-svc/scraper/recovery.py
+++ b/scraper-svc/scraper/recovery.py
@@ -1,0 +1,146 @@
+"""LLM-assisted recovery tier for failed scrapes.
+
+When all three standard tiers fail, the scraper can use an LLM to analyze
+the failed response and suggest a recovery path — extract an iframe URL,
+identify a bot challenge, or find an alternative access route.
+
+Configured via env vars:
+  LLM_BASE_URL      (default: http://llm-svc:4001/v1)
+  LLM_API_KEY       (optional)
+  LLM_MODEL         (default: gpt-4o-mini)
+  RECOVERY_LLM_TIMEOUT (default: 15 — seconds)
+"""
+
+import json
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+RECOVERY_TIMEOUT = int(os.getenv("RECOVERY_LLM_TIMEOUT", "15"))
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://llm-svc:4001/v1")
+LLM_API_KEY = os.getenv("LLM_API_KEY", "")
+LLM_MODEL = os.getenv("LLM_MODEL", "gpt-4o-mini")
+
+RECOVERY_SYSTEM_PROMPT = """You are a web scraping recovery assistant. The scraper tried to fetch a URL and got a page that is clearly not the target content.
+
+Analyze what happened. Choose ONE of these actions:
+
+(a) **iframe_url** — the real content is at an alternative URL visible in the page (e.g., iframe src, data-src, a download link). Extract the exact URL.
+(b) **extracted_content** — the actual text/content is embedded in the page despite extraction failing. Return up to 2000 characters.
+(c) **bot_challenge** — the page is a Cloudflare or similar bot challenge.
+(d) **irrecoverable** — the fetch genuinely failed and there is no alternative path.
+
+Respond with valid JSON matching this schema:
+{
+  "action": "iframe_url" | "extracted_content" | "bot_challenge" | "irrecoverable",
+  "url": "<if action is iframe_url, the extracted URL>",
+  "content": "<if action is extracted_content, up to 2000 chars>",
+  "challenge_type": "<if action is bot_challenge: cloudflare_js, cloudflare_captcha, other>",
+  "reason": "<if action is irrecoverable: explanation>"
+}"""
+
+RECOVERY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": ["iframe_url", "extracted_content", "bot_challenge", "irrecoverable"],
+        },
+        "url": {"type": "string"},
+        "content": {"type": "string"},
+        "challenge_type": {"type": "string"},
+        "reason": {"type": "string"},
+    },
+    "required": ["action"],
+}
+
+
+async def attempt_llm_recovery(url: str, page_text: str) -> dict | None:
+    """Try to recover from a failed scrape using LLM analysis.
+
+    Args:
+        url: The original URL that was scraped.
+        page_text: The content received (markdown or raw text, up to 4000 chars).
+
+    Returns:
+        A result dict if recovery succeeded, or None on failure/timeout.
+    """
+    if not page_text:
+        logger.debug("LLM recovery skipped: no page content to analyze")
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=RECOVERY_TIMEOUT) as client:
+            body = {
+                "model": LLM_MODEL,
+                "messages": [
+                    {"role": "system", "content": RECOVERY_SYSTEM_PROMPT},
+                    {
+                        "role": "user",
+                        "content": (
+                            f"URL fetched: {url}\n\n"
+                            f"---PAGE CONTENT (first 4000 chars)---\n"
+                            f"{page_text[:4000]}\n"
+                            f"---END---"
+                        ),
+                    },
+                ],
+                "temperature": 0.1,
+                "max_tokens": 1024,
+                "response_format": {"type": "json_object"},
+            }
+
+            headers = {"Content-Type": "application/json"}
+            if LLM_API_KEY:
+                headers["Authorization"] = f"Bearer {LLM_API_KEY}"
+
+            resp = await client.post(
+                f"{LLM_BASE_URL}/chat/completions",
+                headers=headers,
+                json=body,
+            )
+
+            if resp.status_code != 200:
+                logger.warning("LLM recovery API error %d for %s", resp.status_code, url)
+                return None
+
+            result = resp.json()
+            content = result["choices"][0]["message"]["content"]
+            parsed = json.loads(content)
+            action = parsed.get("action")
+
+            logger.info("LLM recovery for %s: action=%s", url, action)
+
+            if action == "iframe_url" and parsed.get("url"):
+                extracted_url = parsed["url"]
+                logger.info("LLM recovery: retrying on extracted URL %s", extracted_url)
+                from .fetch import smart_scrape
+                return await smart_scrape(extracted_url)
+
+            elif action == "extracted_content" and parsed.get("content"):
+                return {
+                    "markdown": parsed["content"],
+                    "source": "llm-recovery",
+                    "url": url,
+                }
+
+            elif action == "bot_challenge":
+                return {
+                    "error": f"Bot challenge detected: {parsed.get('challenge_type', 'unknown')}",
+                    "markdown": "",
+                    "source": "llm-recovery",
+                    "url": url,
+                }
+
+            else:
+                return None
+
+    except (httpx.TimeoutException, httpx.ConnectError):
+        logger.debug("LLM recovery timed out or unavailable for %s", url)
+        return None
+    except (json.JSONDecodeError, KeyError, Exception) as e:
+        logger.warning("LLM recovery failed for %s: %s", url, e)
+        return None


### PR DESCRIPTION
## Summary

Adds a Tier 4 recovery layer that uses an LLM to analyze failed page content and attempt recovery. When the standard pipeline returns a Cloudflare challenge page, error page, or other suspicious content, the scraper sends the failed page to a configured LLM to diagnose and potentially recover.

## Related Issue

Closes #28

## Type of Change

- [x] ✨ New feature

## Test Plan

- [x] Syntax verification on both files
- [ ] Integration: scrape a Cloudflare-protected URL, verify LLM recovery is attempted
- [ ] Graceful degradation: if LLM is unavailable, falls through to original error