### PR TITLE
feat: detect embedded iframe content and escalate to LLM recovery

### DIFF
--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -105,6 +105,45 @@ def _looks_suspicious(content: str) -> bool:
     return False
 
 
+# ── Embedded content detection ─────────────────────────────────
+# Extensions and domain patterns that suggest an iframe/embed points
+# to downloadable document content rather than another web page.
+EMBEDDED_CONTENT_EXTENSIONS = {
+    ".pdf", ".epub", ".doc", ".docx", ".xls", ".xlsx",
+    ".ppt", ".pptx", ".zip", ".tar", ".gz",
+}
+EMBEDDED_CONTENT_DOMAINS = {
+    "sci-hub", "sci.bban", "docdrop", "academia",
+    "researchgate", "arxiv.org", "cdn.",
+}
+
+
+def _has_embedded_content(html: str) -> bool:
+    """Check if page HTML contains iframe/embed/object pointing to document content.
+
+    Uses lightweight string matching — no HTML parser needed.
+    Returns True if the page appears to be a portal to document content elsewhere.
+    """
+    if not html:
+        return False
+    html_lower = html.lower()
+    # Quick reject: no iframe, embed, or object tags at all
+    if not any(tag in html_lower for tag in ("<iframe", "<embed", "<object")):
+        return False
+    # Check for document extensions in src/data attributes
+    for ext in EMBEDDED_CONTENT_EXTENSIONS:
+        if ext in html_lower:
+            return True
+    # Check for known document-serving domains
+    for domain in EMBEDDED_CONTENT_DOMAINS:
+        if domain in html_lower:
+            return True
+    # Check for common document URL patterns
+    if "/pdf/" in html_lower or "/download/" in html_lower:
+        return True
+    return False
+
+
 def _looks_like_markdown(text: str) -> bool:
     """Heuristic: does the response look like markdown vs HTML?"""
     if not text:
@@ -195,7 +234,12 @@ async def fetch_via_playwright(url: str) -> dict | None:
             markdown = html_to_markdown(html)
             if markdown and len(markdown) > 50:
                 logger.info("Tier 3 hit: playwright render for %s", url)
-                return {"markdown": markdown, "source": "playwright", "url": url}
+                return {
+                    "markdown": markdown,
+                    "source": "playwright",
+                    "url": url,
+                    "raw_html_start": html[:2000],
+                }
     except ImportError:
         logger.warning("Playwright not installed; skipping Tier 3")
     except Exception as e:
@@ -286,8 +330,13 @@ async def smart_scrape(url: str) -> dict:
 
     # Tier 3 (no shared client needed)
     result = await fetch_via_playwright(url)
-    if result and not _looks_suspicious(result.get("markdown", "")):
-        return result
+    if result:
+        content_good = not _looks_suspicious(result.get("markdown", ""))
+        content_embedded = _has_embedded_content(result.get("raw_html_start", ""))
+        if content_good and not content_embedded:
+            return result  # genuinely good content, return immediately
+        logger.info("Tier 3 content flagged: suspicious=%s, embedded=%s",
+                     not content_good, content_embedded)
 
     # Tier 3.5: FlareSolverr for hard Cloudflare challenges
     if result:

--- a/scraper-svc/scraper/recovery.py
+++ b/scraper-svc/scraper/recovery.py
@@ -33,6 +33,10 @@ Analyze what happened. Choose ONE of these actions:
 (c) **bot_challenge** — the page is a Cloudflare or similar bot challenge.
 (d) **irrecoverable** — the fetch genuinely failed and there is no alternative path.
 
+Note: This page was flagged for potentially having embedded document content
+(iframes, embeds, or objects pointing to PDFs or documents). If you see an
+iframe with a document URL, choose action (a) and extract the iframe's src.
+
 Respond with valid JSON matching this schema:
 {
   "action": "iframe_url" | "extracted_content" | "bot_challenge" | "irrecoverable",


### PR DESCRIPTION
## Summary

Adds embedded content detection to the scraper pipeline. When Playwright renders a page containing an `<iframe>`, `<embed>`, or `<object>` pointing to document content (PDF, EPUB, known doc-serving domains), the page is flagged for LLM recovery instead of being returned as-is. The LLM extracts the iframe URL and retries the scrape against the real content.

## Related Issue

Closes #40

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change
- [ ] Manual verification done (describe)

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

This is a thin detection layer that reuses the existing LLM recovery infrastructure (Tier 4). The three changes:
1. `_has_embedded_content()` — checks raw HTML for iframe/embed/object pointing to document URLs
2. `raw_html_start` in Playwright result — first 2000 chars of raw HTML preserved for the check
3. Updated `smart_scrape()` trigger — pages with embedded document content now fall through to Tiers 3.5/4

The LLM recovery prompt already supports `iframe_url` extraction — just wasn't being triggered for pages that look "normal" but have the real content behind an iframe.

Authored by Jasper (AI agent on behalf of Magnus Hedemark)
