### PR TITLE
fix: three recovery pipeline issues — bad UA, truncation, URL fragments

### DIFF
--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -316,7 +316,13 @@ async def smart_scrape(url: str) -> dict:
     async with httpx.AsyncClient(
         follow_redirects=True,
         timeout=30,
-        headers={"User-Agent": "Mozilla/5.0 (compatible; GroktoCrawl/0.1; +https://github.com/groktocrawl)"},
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/131.0.0.0 Safari/537.36"
+            ),
+        },
     ) as client:
         # Tier 1
         result = await fetch_via_llms_txt(url, client)

--- a/scraper-svc/scraper/recovery.py
+++ b/scraper-svc/scraper/recovery.py
@@ -178,8 +178,8 @@ async def attempt_llm_recovery(url: str, page_text: str) -> dict | None:
                         "role": "user",
                         "content": (
                             f"URL fetched: {url}\n\n"
-                            f"---PAGE CONTENT (first 4000 chars)---\n"
-                            f"{page_text[:4000]}\n"
+                            f"---PAGE CONTENT---\n"
+                            f"{page_text}\n"
                             f"---END---"
                         ),
                     },
@@ -212,6 +212,9 @@ async def attempt_llm_recovery(url: str, page_text: str) -> dict | None:
 
             if action == "iframe_url" and parsed.get("url"):
                 extracted_url = parsed["url"]
+                # Strip URL fragments (#...) to avoid issues with HTTP clients
+                if "#" in extracted_url:
+                    extracted_url = extracted_url.split("#")[0]
                 logger.info("LLM recovery: retrying on extracted URL %s", extracted_url)
                 from .fetch import smart_scrape
                 return await smart_scrape(extracted_url)


### PR DESCRIPTION
## Summary

Three fixes to the recovery pipeline discovered during end-to-end testing of the iframe content detection feature (the Sci-Hub demo):

1. **Real Chrome User-Agent**: The scraper-svc's httpx client used a custom `GroktoCrawl/0.1` UA that triggers Cloudflare JS challenges. Switched to real Chrome UA, already used by the browser-svc.

2. **Remove 4000-char content truncation**: The LLM recovery prompt truncated page content to 4000 chars, but Sci-Hub's iframe is at position ~7500. The LLM couldn't see the iframe URL.

3. **Strip URL fragments**: Extracted iframe URLs may include PDF viewer fragments like `#view=FitH`. These cause Playwright to trigger downloads instead of navigation.

## Related Issue

Closes #45

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change
- [x] Manual verification done (describe)

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

Each fix was validated individually in the container during debugging.

Authored by Jasper (AI agent on behalf of Magnus Hedemark)
