### PR TITLE
feat: add DDoS-Guard detection alongside Cloudflare challenge handling

### DIFF
--- a/browser-svc/browser_svc/app.py
+++ b/browser-svc/browser_svc/app.py
@@ -89,18 +89,32 @@ CLOUDFLARE_INDICATORS = [
     "challenge-platform",
 ]
 
+DDOS_GUARD_INDICATORS = [
+    "DDoS-Guard",
+    "DDOS-GUARD",
+    "ddos-guard",
+    "Checking your browser before accessing",
+    ".well-known/ddos-guard",
+]
 
-def _is_cloudflare_challenge(title: str, url: str) -> bool:
-    """Heuristic: does the page indicate a Cloudflare challenge?"""
+
+def _is_bot_challenge(title: str, url: str) -> bool:
+    """Heuristic: does the page indicate a bot challenge (Cloudflare or DDoS-Guard)?"""
+    # Cloudflare checks
     for indicator in CLOUDFLARE_INDICATORS:
         if indicator.lower() in title.lower():
             return True
     if "cf_chl" in url.lower() or "challenge-platform" in url.lower():
         return True
+    # DDoS-Guard checks
+    for indicator in DDOS_GUARD_INDICATORS:
+        if indicator.lower() in title.lower():
+            return True
+    if "ddos-guard" in url.lower() or "/.well-known/ddos-guard" in url.lower():
+        return True
     return False
 
 
-app = FastAPI(title="GroktoCrawl Browser Service", version="0.1.0")
 app = FastAPI(title="GroktoCrawl Browser Service", version="0.1.0")
 
 # In-memory session store
@@ -264,16 +278,16 @@ async def execute_action(session_id: str, req: BrowserExecuteRequest):
             await _inject_cookies(req.url, session.context, redis_client)
 
             await page.goto(req.url, wait_until="networkidle", timeout=req.timeout)
-            # Cloudflare challenge detection — wait for JS challenge to resolve
+            # Bot challenge detection (Cloudflare / DDoS-Guard) — wait for JS challenge to resolve
             title = await page.title()
             current_url = page.url
-            if _is_cloudflare_challenge(title, current_url):
+            if _is_bot_challenge(title, current_url):
                 logger.info("Cloudflare challenge detected on %s, waiting for resolution...", req.url)
                 await page.wait_for_timeout(8000)
                 title = await page.title()
                 current_url = page.url
-                if _is_cloudflare_challenge(title, current_url):
-                    logger.warning("Cloudflare challenge persisted after wait for %s", req.url)
+                if _is_bot_challenge(title, current_url):
+                    logger.warning("Bot challenge persisted after wait for %s", req.url)
 
             # Store Cloudflare cookies after successful navigation
             await _store_cookies(req.url, session.context, redis_client)


### PR DESCRIPTION
## Summary

Adds DDoS-Guard detection to the browser service alongside the existing Cloudflare challenge detection. DDoS-Guard is a Russian CDN protection service (used by `sci-hub.ru`) with its own JS challenge mechanism that looks different from Cloudflare's.

## Related Issue

Closes #47

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change
- [x] Manual verification done (describe)

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

Changes:
- `_is_cloudflare_challenge()` renamed to `_is_bot_challenge()` — handles both Cloudflare and DDoS-Guard
- `DDOS_GUARD_INDICATORS` list — title and URL patterns for DDoS-Guard detection
- Fixed duplicate `app = FastAPI(...)` line left from a previous merge conflict resolution
- DDoS-Guard uses different titles ("DDoS-Guard", "DDOS-GUARD") and URLs (`/.well-known/ddos-guard/`) than Cloudflare

Authored by Jasper (AI agent on behalf of Magnus Hedemark)
