### PR TITLE
fix: add DDoS-Guard detection to scraper-svc fetch_via_playwright()

### DIFF
--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -92,6 +92,14 @@ CLOUDFLARE_INDICATORS = [
     "challenge-platform",
 ]
 
+DDOS_GUARD_INDICATORS = [
+    "DDoS-Guard",
+    "DDOS-GUARD",
+    "ddos-guard",
+    "Checking your browser before accessing",
+    ".well-known/ddos-guard",
+]
+
 
 def _looks_suspicious(content: str) -> bool:
     """Heuristic: does the page content look like a challenge/error page?"""
@@ -99,7 +107,7 @@ def _looks_suspicious(content: str) -> bool:
         return True
     if len(content) < 100:
         return True
-    for indicator in CLOUDFLARE_INDICATORS:
+    for indicator in CLOUDFLARE_INDICATORS + DDOS_GUARD_INDICATORS:
         if indicator.lower() in content.lower():
             return True
     return False
@@ -223,9 +231,13 @@ async def fetch_via_playwright(url: str) -> dict | None:
             browser = await p.chromium.launch(headless=True)
             page = await browser.new_page()
             try:
-                await page.goto(url, wait_until="domcontentloaded", timeout=30000)
-                # Wait a bit for JS to execute
-                await page.wait_for_timeout(2000)
+                await page.goto(url, wait_until="networkidle", timeout=30000)
+                # Bot challenge detection (Cloudflare / DDoS-Guard)
+                title = await page.title()
+                current_url = page.url
+                if _looks_suspicious(title + " " + current_url):
+                    logger.info("Bot challenge detected on %s, waiting for resolution...", url)
+                    await page.wait_for_timeout(8000)
                 html = await page.content()
             finally:
                 await browser.close()


### PR DESCRIPTION
## Summary

Adds DDoS-Guard and enhanced Cloudflare challenge detection to the scraper-svc's built-in Playwright tier (`fetch_via_playwright()`). Previously the scraper-svc launched its own Playwright with `wait_until="domcontentloaded"` and a 2-second post-load wait — too fast for DDoS-Guard or slower Cloudflare challenges.

Changes:
- `wait_until="networkidle"` (waits for network to settle, not just DOM)
- Bot challenge detection: checks title + URL against Cloudflare and DDoS-Guard indicators after navigation
- 8-second resolution wait when a challenge is detected
- DDoS-Guard indicators added to `_looks_suspicious()`

## Related Issue

Closes #49

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change
- [x] Manual verification done (describe)

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

This mirrors the same DDoS-Guard detection pattern added to browser-svc in PR #48. The scraper-svc's `fetch_via_playwright()` launches its own Playwright instance and was not running through the browser-svc API, so the fix needed to be applied independently here.

Authored by Jasper (AI agent on behalf of Magnus Hedemark)
