### PR TITLE
feat(scraper): stealth Playwright config with bot challenge and Substack detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,11 @@ Complete overhaul of the scraper from a fixed three-tier system to an adaptive f
 #### DDoS-Guard Detection
 
 - **Browser-svc**: DDoS-Guard JS challenge detection alongside Cloudflare — title checks for "DDoS-Guard", URL checks for `/.well-known/ddos-guard/`.
-- **Scraper-svc**: `fetch_via_playwright()` now uses `networkidle` wait and checks for bot challenges post-navigation, with an 8-second resolution window.
+- **Scraper-svc bot challenge detection**: `fetch_via_playwright()` now uses `networkidle` wait and checks for bot challenges post-navigation, with an 8-second resolution window.
+- **Stealth scraper-svc Playwright config** — the scraper-svc's Tier 3 renderer now uses the same stealth configuration as browser-svc: `--disable-blink-features=AutomationControlled`, real Chrome 131 User-Agent, 1920x1080 viewport, `en-US` locale, `America/New_York` timezone, and `navigator.webdriver` override via `add_init_script()`. Additional fingerprint hardening: `navigator.plugins` array population, `navigator.languages` override, `window.chrome` presence, and WebGL vendor/renderer spoofing. See `scraper-svc/scraper/stealth.py`.
+- **`networkidle` → `domcontentloaded` timeout fallback** — when `networkidle` exceeds 30s (caused by persistent analytics connections on sites like Substack), the scraper falls back to `domcontentloaded` and proceeds with the rendered content instead of failing.
+- **Substack session-frame redirect detection** — `_is_substack_redirect()` detects when Substack injects `session-attribution-frame`, `channel-frame`, or GTM noscript redirects. Detection integrated into `fetch_via_playwright()` with a 5-second wait for delayed resolution, and into `_looks_suspicious()` for LLM recovery triggering.
+- **Bot challenge re-check** — after the 8-second resolution window, the scraper re-verifies the page title/URL before proceeding, avoiding false positives from brief challenge page flashes.
 
 #### LLM Fixture
 

--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -83,7 +83,7 @@ def _make_download_payload(url: str, content: bytes, content_type: str) -> dict:
     }
 
 
-# ── Suspicious content detection (for LLM recovery trigger) ────
+# ── Bot challenge detection (title/URL level) ──────────────────
 CLOUDFLARE_INDICATORS = [
     "Just a moment",
     "Checking your browser",
@@ -100,6 +100,45 @@ DDOS_GUARD_INDICATORS = [
     ".well-known/ddos-guard",
 ]
 
+# ── Substack session/channel frame redirect detection ──────────
+SUBSTACK_REDIRECT_PATTERNS = [
+    "substack.com/session-attribution-frame",
+    "substack.com/channel-frame",
+    "substack.com/iframe",
+    "googletagmanager.com/ns.html",
+]
+
+# ── Bot challenge and redirect detection (title/URL level) ─────
+
+
+def _is_bot_challenge(title: str, url: str) -> bool:
+    """Check if the page title or URL indicates a bot challenge page.
+
+    Mirrors browser-svc's _is_bot_challenge() logic.
+    """
+    for indicator in CLOUDFLARE_INDICATORS:
+        if indicator.lower() in title.lower():
+            return True
+    if "cf_chl" in url.lower() or "challenge-platform" in url.lower():
+        return True
+    for indicator in DDOS_GUARD_INDICATORS:
+        if indicator.lower() in title.lower():
+            return True
+    if "ddos-guard" in url.lower() or "/.well-known/ddos-guard" in url.lower():
+        return True
+    return False
+
+
+def _is_substack_redirect(url: str) -> bool:
+    """Check if the URL indicates a Substack session/channel frame redirect."""
+    for pattern in SUBSTACK_REDIRECT_PATTERNS:
+        if pattern in url.lower():
+            return True
+    return False
+
+
+# ── Suspicious content detection (for LLM recovery trigger) ────
+
 
 def _looks_suspicious(content: str) -> bool:
     """Heuristic: does the page content look like a challenge/error page?"""
@@ -107,7 +146,7 @@ def _looks_suspicious(content: str) -> bool:
         return True
     if len(content) < 100:
         return True
-    for indicator in CLOUDFLARE_INDICATORS + DDOS_GUARD_INDICATORS:
+    for indicator in CLOUDFLARE_INDICATORS + DDOS_GUARD_INDICATORS + SUBSTACK_REDIRECT_PATTERNS:
         if indicator.lower() in content.lower():
             return True
     return False
@@ -219,25 +258,52 @@ async def fetch_via_content_negotiation(url: str, client: httpx.AsyncClient) -> 
 
 
 async def fetch_via_playwright(url: str) -> dict | None:
-    """Tier 3: Render with Playwright, then extract main content.
+    """Tier 3: Render with stealth Playwright, then extract main content.
+
+    Uses the same stealth configuration as browser-svc to avoid headless
+    detection by Substack, Cloudflare JS challenges, and similar mechanisms.
 
     This requires playwright and chromium to be installed.
     Falls back gracefully if playwright is not available.
     """
     try:
-        from playwright.async_api import async_playwright
+        from playwright.async_api import async_playwright, TimeoutError
+        from .stealth import create_stealth_browser, create_stealth_context
 
         async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=True)
-            page = await browser.new_page()
+            browser = await create_stealth_browser(p)
+            context = await create_stealth_context(browser)
+            page = await context.new_page()
             try:
-                await page.goto(url, wait_until="networkidle", timeout=30000)
-                # Bot challenge detection (Cloudflare / DDoS-Guard)
+                # Navigate — try networkidle first, fall back to domcontentloaded
+                # on timeout (Substack has persistent analytics connections that
+                # prevent networkidle from ever firing)
+                try:
+                    await page.goto(url, wait_until="networkidle", timeout=30000)
+                except TimeoutError:
+                    logger.info("networkidle timed out for %s, falling back to domcontentloaded", url)
+                    await page.goto(url, wait_until="domcontentloaded", timeout=15000)
+
+                # Check for bot challenges (Cloudflare / DDoS-Guard)
                 title = await page.title()
                 current_url = page.url
-                if _looks_suspicious(title + " " + current_url):
+                if _is_bot_challenge(title, current_url):
                     logger.info("Bot challenge detected on %s, waiting for resolution...", url)
                     await page.wait_for_timeout(8000)
+                    title = await page.title()
+                    current_url = page.url
+                    if _is_bot_challenge(title, current_url):
+                        logger.warning("Bot challenge persisted after wait for %s", url)
+
+                # Check for Substack session/channel frame redirect
+                if _is_substack_redirect(current_url):
+                    logger.info("Substack redirect detected on %s (-> %s), waiting for content...", url, current_url)
+                    # Substack sometimes resolves after a longer wait
+                    await page.wait_for_timeout(5000)
+                    current_url = page.url
+                    if _is_substack_redirect(current_url):
+                        logger.warning("Substack redirect persisted for %s", url)
+
                 html = await page.content()
             finally:
                 await browser.close()
@@ -371,6 +437,30 @@ async def smart_scrape(url: str) -> dict:
         recovery_result = await attempt_llm_recovery(url, page_content)
         if recovery_result:
             return recovery_result
+
+    # Check for specific failure modes to provide actionable error messages
+    if result:
+        raw_html = result.get("raw_html_start", "")
+        redirected_url = ""
+        # Extract redirected URL from raw HTML if available (Substack embeds it)
+        import re as _re
+        substack_match = _re.search(r'substack\.com/[^"\'\\s]+', raw_html)
+        if substack_match:
+            redirected_url = f" (redirected to {substack_match.group()})"
+
+        if _is_substack_redirect(raw_html):
+            return {
+                "error": (
+                    f"Could not extract content from {url}{redirected_url}. "
+                    f"Substack blocked the headless browser. "
+                    f"Try: groktocrawl browser exec <id> navigate --url <url> "
+                    f"then browser exec <id> executeScript "
+                    f"--script \"document.querySelector('article').innerText\""
+                ),
+                "markdown": "",
+                "source": "none",
+                "url": url,
+            }
 
     return {
         "error": f"Could not extract content from {url}",

--- a/scraper-svc/scraper/stealth.py
+++ b/scraper-svc/scraper/stealth.py
@@ -1,0 +1,135 @@
+"""Stealth configuration for Playwright browser automation.
+
+Provides a reusable set of browser launch arguments, context settings, and
+initialization scripts that mask headless Chromium automation signals.
+
+Ported from browser-svc/browser_svc/app.py with additional fingerprinting
+hardening (plugins, languages, chrome.runtime, WebGL).
+
+Usage:
+    from .stealth import create_stealth_browser, create_stealth_context
+
+    async with async_playwright() as p:
+        browser = await create_stealth_browser(p)
+        context = await create_stealth_context(browser)
+        page = await context.new_page()
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# ── Real Chrome User-Agent ─────────────────────────────────────
+REAL_CHROME_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/131.0.0.0 Safari/537.36"
+)
+
+# ── Browser launch arguments ────────────────────────────────────
+STEALTH_BROWSER_ARGS = [
+    "--disable-blink-features=AutomationControlled",
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-features=IsolateOrigins,site-per-process",
+    "--disable-web-security",
+    "--disable-features=BlockInsecurePrivateNetworkRequests",
+]
+
+# ── Browser context settings ────────────────────────────────────
+STEALTH_CONTEXT_KWARGS = {
+    "viewport": {"width": 1920, "height": 1080},
+    "user_agent": REAL_CHROME_UA,
+    "locale": "en-US",
+    "timezone_id": "America/New_York",
+    "permissions": ["geolocation"],
+    "geolocation": {"latitude": 40.7128, "longitude": -74.0060},
+}
+
+# ── Init script to hide automation signals ─────────────────────
+STEALTH_INIT_SCRIPT = """() => {
+    // Hide webdriver property
+    Object.defineProperty(navigator, 'webdriver', {
+        get: () => undefined
+    });
+
+    // Populate plugins array (headless Chromium has empty array)
+    Object.defineProperty(navigator, 'plugins', {
+        get: () => [
+            { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer' },
+            { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai' },
+            { name: 'Native Client', filename: 'internal-nacl-plugin' },
+        ]
+    });
+
+    // Set languages
+    Object.defineProperty(navigator, 'languages', {
+        get: () => ['en-US', 'en']
+    });
+
+    // Chrome runtime presence (some sites check this)
+    window.chrome = {
+        runtime: {},
+        loadTimes: function() {},
+        csi: function() {},
+        app: {}
+    };
+
+    // Override permissions query to hide headless
+    if (navigator.permissions && navigator.permissions.query) {
+        const originalQuery = navigator.permissions.query.bind(navigator.permissions);
+        navigator.permissions.query = (desc) => {
+            if (desc.name === 'notifications' || desc.name === 'clipboard-read') {
+                return Promise.resolve({ state: 'granted' });
+            }
+            return originalQuery(desc);
+        };
+    }
+
+    // WebGL vendor/renderer spoofing
+    const getParameterProxyHandler = {
+        apply: function(target, thisArg, args) {
+            const param = args[0];
+            if (param === 37445) return 'Intel Inc.';       // UNMASKED_VENDOR_WEBGL
+            if (param === 37446) return 'Intel Iris OpenGL Engine';  // UNMASKED_RENDERER_WEBGL
+            return Reflect.apply(target, thisArg, args);
+        }
+    };
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl');
+    if (gl) {
+        const originalGetParameter = gl.getParameter.bind(gl);
+        gl.getParameter = new Proxy(originalGetParameter, getParameterProxyHandler);
+    }
+}"""
+
+
+async def create_stealth_browser(playwright):
+    """Launch a Chromium browser with stealth configuration.
+
+    Args:
+        playwright: An async_playwright instance.
+
+    Returns:
+        A Browser instance configured to avoid headless detection.
+    """
+    logger.debug("Launching stealth Chromium browser")
+    return await playwright.chromium.launch(
+        headless=True,
+        args=STEALTH_BROWSER_ARGS,
+    )
+
+
+async def create_stealth_context(browser):
+    """Create a browser context with stealth settings.
+
+    Args:
+        browser: A Browser instance from create_stealth_browser.
+
+    Returns:
+        A BrowserContext with realistic fingerprint settings.
+    """
+    logger.debug("Creating stealth browser context")
+    context = await browser.new_context(**STEALTH_CONTEXT_KWARGS)
+    await context.add_init_script(STEALTH_INIT_SCRIPT)
+    return context

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -1,0 +1,184 @@
+"""Tests for stealth Playwright configuration and bot detection logic.
+
+These test the core detection functions that don't need a running Docker stack.
+Run with: python3 -m pytest tests/test_stealth.py -v
+"""
+
+import sys
+import os
+
+# Ensure the scraper module is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scraper-svc"))
+
+
+def test_stealth_module_imports():
+    """Verify the stealth module imports and exposes expected functions."""
+    from scraper.stealth import (
+        create_stealth_browser,
+        create_stealth_context,
+        STEALTH_BROWSER_ARGS,
+        STEALTH_CONTEXT_KWARGS,
+        STEALTH_INIT_SCRIPT,
+        REAL_CHROME_UA,
+    )
+    assert callable(create_stealth_browser)
+    assert callable(create_stealth_context)
+    assert "--disable-blink-features=AutomationControlled" in STEALTH_BROWSER_ARGS
+    assert "user_agent" in STEALTH_CONTEXT_KWARGS
+    assert STEALTH_CONTEXT_KWARGS["user_agent"] == REAL_CHROME_UA
+    assert "viewport" in STEALTH_CONTEXT_KWARGS
+    assert STEALTH_CONTEXT_KWARGS["viewport"] == {"width": 1920, "height": 1080}
+    assert "locale" in STEALTH_CONTEXT_KWARGS
+    assert STEALTH_CONTEXT_KWARGS["locale"] == "en-US"
+    assert "webdriver" in STEALTH_INIT_SCRIPT  # Object.defineProperty(navigator, 'webdriver')
+    assert "plugins" in STEALTH_INIT_SCRIPT    # Object.defineProperty(navigator, 'plugins')
+    assert "chrome" in STEALTH_INIT_SCRIPT     # window.chrome
+    assert "getParameter" in STEALTH_INIT_SCRIPT  # WebGL spoofing
+
+
+def test_stealth_browser_args_comprehensive():
+    """Verify all expected stealth browser args are present."""
+    from scraper.stealth import STEALTH_BROWSER_ARGS
+    expected_args = [
+        "--disable-blink-features=AutomationControlled",
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+    ]
+    for arg in expected_args:
+        assert arg in STEALTH_BROWSER_ARGS, f"Missing expected arg: {arg}"
+
+
+def test_stealth_context_has_realistic_fingerprint():
+    """Verify stealth context has realistic browser fingerprint settings."""
+    from scraper.stealth import STEALTH_CONTEXT_KWARGS
+    # Should have realistic viewport
+    assert STEALTH_CONTEXT_KWARGS["viewport"]["width"] >= 1280
+    assert STEALTH_CONTEXT_KWARGS["viewport"]["height"] >= 720
+    # Should have locale and timezone
+    assert STEALTH_CONTEXT_KWARGS.get("locale")
+    assert STEALTH_CONTEXT_KWARGS.get("timezone_id")
+
+
+def test_stealth_init_script_syntax():
+    """Verify the init script is valid JavaScript syntax (basic check)."""
+    from scraper.stealth import STEALTH_INIT_SCRIPT
+    # Should be a string containing a function
+    assert STEALTH_INIT_SCRIPT.startswith("() =>")
+    # Should contain key stealth patches
+    assert "webdriver" in STEALTH_INIT_SCRIPT
+    assert "plugins" in STEALTH_INIT_SCRIPT
+    assert "languages" in STEALTH_INIT_SCRIPT
+    assert "chrome" in STEALTH_INIT_SCRIPT
+    # Should have matching braces
+    open_braces = STEALTH_INIT_SCRIPT.count("{")
+    close_braces = STEALTH_INIT_SCRIPT.count("}")
+    assert open_braces == close_braces, f"Unbalanced braces: {open_braces} vs {close_braces}"
+
+
+def test_stealth_ua_matches_chrome_131():
+    """Verify the User-Agent string is a real Chrome 131 UA."""
+    from scraper.stealth import REAL_CHROME_UA
+    assert "Chrome/131" in REAL_CHROME_UA
+    assert "Mozilla/5.0" in REAL_CHROME_UA
+    assert "Windows NT" in REAL_CHROME_UA
+    assert "Safari/537.36" in REAL_CHROME_UA
+
+
+class TestBotChallengeDetection:
+    """Test _is_bot_challenge() for Cloudflare and DDoS-Guard patterns."""
+
+    @staticmethod
+    def _import_func():
+        from scraper.fetch import _is_bot_challenge
+        return _is_bot_challenge
+
+    def test_cloudflare_js_challenge_title(self):
+        func = self._import_func()
+        assert func("Just a moment...", "https://example.com")
+        assert func("Checking your browser before accessing", "https://example.com")
+        assert func("DDoS protection by Cloudflare", "https://example.com")
+
+    def test_cloudflare_challenge_url(self):
+        func = self._import_func()
+        assert func("Example", "https://example.com/cdn-cgi/challenge-platform/")
+        assert func("Example", "https://example.com/?cf_chl_tk=abc")
+
+    def test_ddos_guard_challenge_title(self):
+        func = self._import_func()
+        assert func("DDoS-Guard", "https://example.com")
+        assert func("Checking your browser before accessing the site", "https://example.com")
+
+    def test_ddos_guard_challenge_url(self):
+        func = self._import_func()
+        assert func("Example", "https://example.com/.well-known/ddos-guard/")
+        assert func("Example", "https://example.com/?ddos-guard")
+
+    def test_normal_page_not_detected(self):
+        func = self._import_func()
+        assert not func("Welcome to my blog", "https://blog.example.com/posts/hello-world")
+        assert not func("Heather Cox Richardson", "https://heathercoxrichardson.substack.com/p/june-1-2025")
+        assert not func("The Free Press", "https://www.thefp.com/p/some-article")
+
+
+class TestSubstackRedirectDetection:
+    """Test _is_substack_redirect() for Substack session/channel frame patterns."""
+
+    @staticmethod
+    def _import_func():
+        from scraper.fetch import _is_substack_redirect
+        return _is_substack_redirect
+
+    def test_session_attribution_frame(self):
+        func = self._import_func()
+        assert func("https://substack.com/session-attribution-frame?origin=...")
+
+    def test_channel_frame(self):
+        func = self._import_func()
+        assert func("https://substack.com/channel-frame?channel=...")
+
+    def test_gtm_redirect(self):
+        func = self._import_func()
+        assert func("https://www.googletagmanager.com/ns.html?id=GTM-TFQLSP2")
+
+    def test_normal_substack_url_not_detected(self):
+        func = self._import_func()
+        assert not func("https://heathercoxrichardson.substack.com/p/june-1-2025")
+        assert not func("https://simonsarris.substack.com/p/some-article")
+
+    def test_empty_url_not_detected(self):
+        func = self._import_func()
+        assert not func("")
+        assert not func("https://example.com")
+
+
+class TestLooksSuspicious:
+    """Test _looks_suspicious() includes Substack patterns and existing checks."""
+
+    @staticmethod
+    def _import_func():
+        from scraper.fetch import _looks_suspicious
+        return _looks_suspicious
+
+    def test_empty_content_suspicious(self):
+        func = self._import_func()
+        assert func("")
+        assert func(None)  # type: ignore
+
+    def test_short_content_suspicious(self):
+        func = self._import_func()
+        assert func("Hello")
+
+    def test_cloudflare_indicators(self):
+        func = self._import_func()
+        assert func("Just a moment... checking your browser")
+        assert func("DDoS protection by Cloudflare")
+
+    def test_substack_indicators(self):
+        func = self._import_func()
+        assert func("substack.com/session-attribution-frame")
+        assert func("substack.com/channel-frame")
+
+    def test_normal_content_not_suspicious(self):
+        func = self._import_func()
+        assert not func("The quick brown fox jumps over the lazy dog. " * 10)
+        assert not func("Article content with multiple paragraphs. " * 20)


### PR DESCRIPTION
## Summary

Bring the scraper-svc's Tier 3 Playwright renderer up to parity with the browser-svc's stealth configuration, enabling it to bypass headless detection on Substack, Cloudflare JS challenges, and similar bot protection.

**Core changes:**
1. New `scraper-svc/scraper/stealth.py` module — shared stealth config (browser launch args, context settings, `add_init_script` with WebGL/plugins/languages fingerprinting)
2. `fetch_via_playwright()` now uses stealth config instead of vanilla `headless=True`
3. `networkidle` → `domcontentloaded` timeout fallback for sites with persistent analytics (Substack)
4. `_is_bot_challenge()` ported from browser-svc for proper Cloudflare/DDoS-Guard title/URL detection
5. `_is_substack_redirect()` for session/channel frame pattern detection
6. Friendlier error messages in `smart_scrape()` suggesting the browser-svc workaround for Substack

## Related Issue

Closes #52

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change
- [x] Manual verification done (describe)

**Manual verification performed:**
- Source code comparison: browser-svc's stealth config (`app.py:228-249`) verified against new stealth module — all settings matched
- Syntax validation: both `fetch.py` and `stealth.py` pass `ast.parse()`
- Substack session-frame redirect detection: `_is_substack_redirect()` tested against known patterns (`session-attribution-frame`, `channel-frame`, `googletagmanager.com/ns.html`)
- Bot challenge detection: `_is_bot_challenge()` mirrors browser-svc logic exactly

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

**The stealth module intentionally lives inside scraper-svc, not as a shared package.** Both services currently have their own copy of the stealth config. If a third service needs it later, extraction to a `shared/` package is straightforward.

**The Substack detection is intentionally informative, not silently retrying through browser-svc.** The error message tells users the working path (`groktocrawl browser exec <id> ... executeScript`). Adding an automatic browser-svc fallback is a future enhancement that needs architectural discussion.

**Integration tests** (Step 7 of the plan) are still being built — they require a Docker stack with stealth verification sites and a sample Substack page. Coming in a follow-up commit on this branch.

---

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
