### PR TITLE
feat(scraper): Valkey-backed Cloudflare cookie persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ Complete overhaul of the scraper from a fixed three-tier system to an adaptive f
 - **Substack session-frame redirect detection** — `_is_substack_redirect()` detects when Substack injects `session-attribution-frame`, `channel-frame`, or GTM noscript redirects. Detection integrated into `fetch_via_playwright()` with a 5-second wait for delayed resolution, and into `_looks_suspicious()` for LLM recovery triggering.
 - **Bot challenge re-check** — after the 8-second resolution window, the scraper re-verifies the page title/URL before proceeding, avoiding false positives from brief challenge page flashes.
 
+#### Cookie Persistence (scraper-svc)
+
+- **Valkey-backed Cloudflare cookie store** — the scraper-svc's Playwright renderer now caches and reuses `cf_clearance` cookies via the shared Valkey instance (`scraper-svc/scraper/cookie_store.py`). Cookies are stored with a 25-minute TTL, scoped to TLD+1 domain. Cross-service sharing: cookies solved by the browser-svc are immediately available to the scraper-svc, and vice versa.
+- **Cookie injection before navigation** — `fetch_via_playwright()` injects stored `cf_clearance` cookies into the browser context before navigating, potentially skipping Cloudflare challenges entirely for previously-solved domains.
+- **Cookie storage after successful scrape** — after extracting content, any new `cf_clearance` cookies are persisted to Valkey for future scrapes.
+- **Graceful degradation** — if Valkey is unavailable, the scraper continues without cookie persistence (logs a warning, returns the content normally).
+
 #### LLM Fixture
 
 - **Prompt-aware fixture** — the `llm-svc` fixture now handles recovery prompt schemas: extracts `<iframe src>` URLs from page content when the prompt mentions `iframe_url` or `recovery`, returns Cloudflare/DDoS-Guard classification data when the prompt mentions `cloudflare` or `block_type`. Makes the full pipeline demonstrable with `docker compose --profile fixture up` (no external API key needed).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,9 @@ services:
       - "8001:8001"
     environment:
       - LLM_BASE_URL=http://llm-svc:8011/v1
+      - VALKEY_HOST=valkey
+      - VALKEY_PORT=6379
+      - VALKEY_DB=0
 
   browser-svc:
     build:

--- a/scraper-svc/pyproject.toml
+++ b/scraper-svc/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "readability-lxml>=0.8.1",
     "markdownify>=0.14.0",
     "beautifulsoup4>=4.13.0",
+    "redis>=5.0",
 ]
 
 [project.optional-dependencies]

--- a/scraper-svc/scraper/app.py
+++ b/scraper-svc/scraper/app.py
@@ -4,16 +4,27 @@ Single endpoint: POST /scrape — takes a URL, returns clean markdown.
 """
 
 import logging
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, HttpUrl
 
+from .cookie_store import close_client, get_client
 from .fetch import smart_scrape
 from .meta import fetch_meta_tags
 
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="GroktoCrawl Scraper", version="0.1.0")
+
+@asynccontextmanager
+async def lifespan(app):
+    """Connect to Valkey on startup, close on shutdown (graceful if unavailable)."""
+    await get_client()
+    yield
+    await close_client()
+
+
+app = FastAPI(title="GroktoCrawl Scraper", version="0.1.0", lifespan=lifespan)
 
 
 class ScrapeRequest(BaseModel):

--- a/scraper-svc/scraper/cookie_store.py
+++ b/scraper-svc/scraper/cookie_store.py
@@ -1,0 +1,127 @@
+"""Cookie persistence for Cloudflare clearance cookies.
+
+Stores and retrieves cf_clearance cookies via Valkey so that
+Cloudflare challenges are solved once per domain per TTL window.
+
+Ported from browser-svc/browser_svc/app.py.
+Shares the same key prefix (cf:clearance:) and TTL (1500s).
+"""
+
+import json
+import logging
+import os
+import time
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+COOKIE_STORE_PREFIX = "cf:clearance:"
+COOKIE_TTL_SECONDS = 1500  # 25 minutes (under Cloudflare's typical 30m expiry)
+
+_redis_client = None  # Module-level lazy singleton
+
+
+async def get_client():
+    """Get or create the Valkey client singleton.
+
+    Returns the client if connected, or None if Valkey is unavailable
+    (graceful degradation — scraper continues without cookie persistence).
+    """
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
+
+    host = os.getenv("VALKEY_HOST", "valkey")
+    port = int(os.getenv("VALKEY_PORT", "6379"))
+    db = int(os.getenv("VALKEY_DB", "0"))
+
+    try:
+        import redis.asyncio as aioredis
+
+        _redis_client = aioredis.Redis(
+            host=host, port=port, db=db, decode_responses=True,
+        )
+        await _redis_client.ping()
+        logger.info("Connected to Valkey at %s:%s/%s for cookie store", host, port, db)
+        return _redis_client
+    except Exception as e:
+        logger.warning(
+            "Valkey unavailable at %s:%s — cookie persistence disabled (%s)",
+            host, port, e,
+        )
+        _redis_client = None
+        return None
+
+
+async def close_client():
+    """Close the Valkey client connection."""
+    global _redis_client
+    if _redis_client is not None:
+        try:
+            await _redis_client.close()
+        except Exception:
+            pass
+        _redis_client = None
+
+
+def _cookie_key(url: str) -> str:
+    """Extract TLD+1 domain for cookie scoping.
+
+    Same algorithm used by browser-svc so cookies are shared across services.
+    """
+    hostname = urlparse(url).hostname or "unknown"
+    parts = hostname.split(".")
+    if len(parts) >= 2:
+        domain = ".".join(parts[-2:])
+    else:
+        domain = parts[0]
+    return f"{COOKIE_STORE_PREFIX}{domain}"
+
+
+async def inject_cookies(url: str, context) -> None:
+    """Inject stored Cloudflare clearance cookies into a Playwright context.
+
+    Safe to call even if Valkey is unavailable — will silently no-op.
+    """
+    client = await get_client()
+    if not client:
+        return
+    try:
+        key = _cookie_key(url)
+        stored = await client.get(key)
+        if stored:
+            data = json.loads(stored)
+            await context.add_cookies(data["cookies"])
+            remaining = data.get("ttl", 0) - (time.time() - data.get("resolved_at", 0))
+            if remaining > 0:
+                logger.info(
+                    "Injected %d stored cookies for %s (%.0fs remaining)",
+                    len(data["cookies"]), url, remaining,
+                )
+    except Exception as e:
+        logger.debug("Cookie injection failed for %s: %s", url, e)
+
+
+async def store_cookies(url: str, context) -> None:
+    """Store Cloudflare clearance cookies from a Playwright context.
+
+    Only stores cf_clearance cookies. Safe to call even if Valkey is
+    unavailable — will silently no-op.
+    """
+    client = await get_client()
+    if not client:
+        return
+    try:
+        cookies = await context.cookies()
+        cf_cookies = [c for c in cookies if c.get("name") == "cf_clearance"]
+        if cf_cookies:
+            key = _cookie_key(url)
+            payload = json.dumps({
+                "cookies": cf_cookies,
+                "resolved_at": time.time(),
+                "ttl": COOKIE_TTL_SECONDS,
+            })
+            await client.setex(key, COOKIE_TTL_SECONDS, payload)
+            logger.info("Stored %d cf_clearance cookies for %s", len(cf_cookies), url)
+    except Exception as e:
+        logger.debug("Cookie storage failed for %s: %s", url, e)

--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -268,6 +268,7 @@ async def fetch_via_playwright(url: str) -> dict | None:
     """
     try:
         from playwright.async_api import async_playwright, TimeoutError
+        from .cookie_store import inject_cookies, store_cookies
         from .stealth import create_stealth_browser, create_stealth_context
 
         async with async_playwright() as p:
@@ -275,6 +276,9 @@ async def fetch_via_playwright(url: str) -> dict | None:
             context = await create_stealth_context(browser)
             page = await context.new_page()
             try:
+                # Inject cached Cloudflare clearance cookies before navigation
+                await inject_cookies(url, context)
+
                 # Navigate — try networkidle first, fall back to domcontentloaded
                 # on timeout (Substack has persistent analytics connections that
                 # prevent networkidle from ever firing)
@@ -312,6 +316,8 @@ async def fetch_via_playwright(url: str) -> dict | None:
             markdown = html_to_markdown(html)
             if markdown and len(markdown) > 50:
                 logger.info("Tier 3 hit: playwright render for %s", url)
+                # Store any new cf_clearance cookies for future scrapes
+                await store_cookies(url, context)
                 return {
                     "markdown": markdown,
                     "source": "playwright",

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -7,6 +7,8 @@ Run with: python3 -m pytest tests/test_stealth.py -v
 import sys
 import os
 
+import pytest
+
 # Ensure the scraper module is importable
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scraper-svc"))
 
@@ -182,3 +184,85 @@ class TestLooksSuspicious:
         func = self._import_func()
         assert not func("The quick brown fox jumps over the lazy dog. " * 10)
         assert not func("Article content with multiple paragraphs. " * 20)
+
+
+class TestCookieKey:
+    """Test _cookie_key() TLD+1 domain extraction."""
+
+    @staticmethod
+    def _import_func():
+        from scraper.cookie_store import _cookie_key
+        return _cookie_key
+
+    def test_standard_substack(self):
+        func = self._import_func()
+        assert func("https://heathercoxrichardson.substack.com/p/june-1-2025") == "cf:clearance:substack.com"
+
+    def test_standard_com_domain(self):
+        func = self._import_func()
+        assert func("https://www.example.com/page") == "cf:clearance:example.com"
+
+    def test_co_uk_domain(self):
+        func = self._import_func()
+        # Note: simple TLD+1 algorithm extracts last 2 dot-parts.
+        # For .co.uk this gives "co.uk" not "example.co.uk".
+        # This is a known limitation shared with browser-svc.
+        key = func("https://blog.example.co.uk/article")
+        assert key.startswith("cf:clearance:")
+        assert "co.uk" in key
+
+    def test_ip_address(self):
+        func = self._import_func()
+        key = func("http://192.168.1.1/admin")
+        assert key.startswith("cf:clearance:")
+
+    def test_localhost(self):
+        func = self._import_func()
+        key = func("http://localhost:8080/health")
+        assert key.startswith("cf:clearance:")
+
+    def test_single_label(self):
+        func = self._import_func()
+        key = func("http://internal-service/page")
+        assert key.startswith("cf:clearance:")
+
+
+class TestCookieStoreGraceful:
+    """Test that cookie functions don't raise when Valkey is unavailable.
+
+    These tests verify graceful degradation — the scraper should continue
+    working without cookie persistence if no Valkey instance is running.
+    """
+
+    @staticmethod
+    def _import_inject():
+        from scraper.cookie_store import inject_cookies
+        return inject_cookies
+
+    @staticmethod
+    def _import_store():
+        from scraper.cookie_store import store_cookies
+        return store_cookies
+
+    @pytest.mark.asyncio
+    async def test_inject_no_valkey(self):
+        """inject_cookies should not raise when Valkey is unavailable."""
+        func = self._import_inject()
+        # No Valkey running — should log and return None gracefully
+        result = await func("https://example.com", None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_store_no_valkey(self):
+        """store_cookies should not raise when Valkey is unavailable."""
+        func = self._import_store()
+        result = await func("https://example.com", None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_inject_empty_context(self):
+        """inject_cookies should handle a context with no cookies gracefully."""
+        func = self._import_inject()
+        # Even with no Valkey, passing None context should not crash
+        result = await func("https://example.com", {})
+        assert result is None


### PR DESCRIPTION
## Summary

Add Valkey-backed Cloudflare `cf_clearance` cookie persistence to the scraper-svc's Playwright renderer, so challenges are solved once per domain per 25-minute window — with cross-service sharing (browser-svc cookies are immediately available to scraper-svc and vice versa).

**Key changes:**
1. New `scraper-svc/scraper/cookie_store.py` — ported from browser-svc: lazy Valkey singleton, `_cookie_key()` for TLD+1 domain scoping, `inject_cookies()` before navigation, `store_cookies()` after successful extraction
2. FastAPI lifespan in `app.py` — connects Valkey on startup, closes on shutdown (graceful if unavailable)
3. `fetch_via_playwright()` wired with inject-store calls
4. `redis>=5.0` dependency added
5. `VALKEY_HOST`/`PORT`/`DB` env vars in docker-compose.yml
6. 9 new tests covering cookie key parsing and graceful degradation

## Related Issue

Closes #52

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [x] New tests added for the change: 9 new test cases (cookie key parsing, graceful degradation)
- [x] Manual verification done (describe)

**Manual verification:**
- Syntax validation: all modified files pass `ast.parse()`
- Full test suite: 29/29 tests pass (20 stealth + 9 cookie store tests)
- Graceful degradation verified: `get_client()` returns `None` when Valkey is unreachable, `inject_cookies()`/`store_cookies()` no-op without raising
- Cross-service key compatibility confirmed: same `cf:clearance:` prefix and `_cookie_key()` algorithm as browser-svc

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

**Graceful degradation:** This is the most important design property. If Valkey is unavailable (not running, wrong host/port, auth failure), the scraper logs a warning and continues exactly as it did before — no cookie caching, no errors.

**Multi-part TLD limitation:** The `_cookie_key()` algorithm extracts the last 2 dot-parts of the hostname. For `.co.uk` domains this gives `co.uk` rather than `example.co.uk`. This is a known limitation shared with browser-svc. A public suffix list could fix it but would add a dependency for a rare edge case.

**No `depends_on: valkey`** in docker-compose.yml — the scraper-svc doesn't need Valkey to serve scrapes. It connects if available and gracefully degrades if not.

---

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
