### PR TITLE
feat: enhance agent skill with decision table, tool selection order, and pitfalls

### DIFF
--- a/skills/groktocrawl/SKILL.md
+++ b/skills/groktocrawl/SKILL.md
@@ -100,7 +100,48 @@ The CLI resolves the server URL in this order:
 
 The CLI requires `requests` (Python package). Install with `pip install requests` if not already present. Python 3.8+.
 
+## When to use which command
+
+See [references/triggers.md](references/triggers.md) for a full decision table. The short version:
+
+- **2+ sources needing synthesis** → `agent`
+- **Single URL** → `scrape`
+- **Search results** → `search`
+- **Interactive page (clicks, forms)** → `browser`
+- **API endpoints, binary downloads** → `curl`
+
+## Pitfalls
+
+### Agent auto-search can pick up irrelevant sources
+
+The `agent` command's auto-search may return low-quality or unrelated results for niche or domain-specific topics. When results look off:
+1. `search` to find specific quality URLs
+2. `scrape` each one
+3. Synthesize the results yourself
+
+For academic/research topics, pre-filter with `site:.edu`, `site:.gov`, or `site:arxiv.org` in your agent prompt or search query.
+
+### scrape fails on non-HTML content
+
+`scrape` is optimized for HTML pages. It will not produce useful output for XML sitemaps, RSS feeds, or raw JSON APIs. Use `curl` directly for those:
+
+```bash
+curl -sL "https://example.com/sitemap-posts.xml"
+```
+
+### Binary content returns a download, not markdown
+
+The scraper auto-detects PDFs, EPUBs, and images by Content-Type and returns a download payload (filename, size, content_type). Use `curl` with a real browser User-Agent to download binary files:
+
+```bash
+curl -L -A "Mozilla/5.0 ..." -H "Referer: <origin>" -o file.pdf "<url>"
+```
+
+### SPA-like symptoms may just be stale URLs
+
+Substack 404 pages render as a large SPA app shell — same appearance as a rendering failure (no `<article>`, thin body, publication-name-only title). Before debugging scraping, verify the URL is current using the publication's archive at `/api/v1/archive?limit=5`. If the slug isn't in the archive, the URL is dead.
+
 ## Related files
 
-- [references/triggers.md](references/triggers.md) — Keywords and patterns that should activate this skill
+- [references/triggers.md](references/triggers.md) — Decision table: which command when
 - [assets/examples.md](assets/examples.md) — Extended usage examples for every subcommand

--- a/skills/groktocrawl/references/triggers.md
+++ b/skills/groktocrawl/references/triggers.md
@@ -1,21 +1,32 @@
-# When to use the groktocrawl skill
+# When to use which groktocrawl command
 
 ## Decision table
 
-| User says… | Use this command | Why |
-|------------|-----------------|-----|
-| "Scrape this URL" / "Get me the content of this page" | `scripts/groktocrawl scrape <url>` | Single page, no synthesis needed |
-| "Search for X" / "Find information about Y" | `scripts/groktocrawl search "<query>"` | Raw results, no cross-source synthesis |
-| "Research X" / "Tell me about Y" / "What happened at Z" | `scripts/groktocrawl agent "<prompt>"` | Needs search, scrape, and synthesis |
-| "Compare A and B" | `scripts/groktocrawl agent "Compare A and B"` | Multi-source synthesis |
-| "Find all URLs on this site" / "Map this site" | `scripts/groktocrawl map <url>` | URL discovery only |
-| "Crawl this site" / "Get all pages from this site" | `scripts/groktocrawl crawl <url>` | Full site scrape |
-| "Extract data from these URLs" | `scripts/groktocrawl extract <urls...>` | Structured extraction, no search |
-| "Open a browser" / "Take a screenshot" / "Click this button" | `scripts/groktocrawl browser create/exec/destroy` | Interactive browser session |
-| "Parse this PDF" / "Extract text from this document" | Use `curl -X POST .../v2/parse -F "file=@..."` | Not yet a CLI subcommand |
-| "Watch this page for changes" / "Monitor this URL" | Use `curl` to `/v2/monitor` | Not yet a CLI subcommand |
-| "Generate llms.txt for this site" | `curl -X POST .../v2/generate-llmstxt` | Not yet a CLI subcommand |
+| Need | Command | Why |
+|------|---------|-----|
+| Single page content | `scrape <url>` | One fetch, no synthesis |
+| Web search, raw results | `search "<query>"` | Just the search hits |
+| Multi-source research | `agent "<prompt>"` | Searches, scrapes, and synthesizes |
+| Compare A vs B | `agent "Compare A and B"` | Needs reading multiple pages |
+| Discover site URLs | `map <url>` | URL discovery only |
+| Full site scrape | `crawl <url>` | Recursive site extraction |
+| Structured data from URLs | `extract <url>...` | Schema-guided extraction |
+| Interactive page (clicks, forms) | `browser create/exec/destroy` | Headless browser session |
+| Document parsing (PDF, DOCX) | `curl -X POST .../v2/parse` | No CLI subcommand yet |
+| Change monitoring | `curl` to `/v2/monitor` | No CLI subcommand yet |
+| Generate llms.txt | `curl` to `/v2/generate-llmstxt` | No CLI subcommand yet |
 
 ## Rule of thumb
 
-If the answer requires reading 2+ sources and connecting them, use `agent`. If you just need to find content or scrape a single page, use `scrape` or `search`.
+If the answer needs **2+ sources connected together**, use `agent`.
+If you just need content from a single page, use `scrape`.
+If you need results from a search engine, use `search`.
+
+## Tool selection order
+
+When fetching content from the web, prefer in this order:
+
+1. **`agent`** — multi-source research that needs search + scrape + synthesis
+2. **`scrape`** — any single URL: HTML pages, markdown docs, JSON endpoints, raw text
+3. **`search`** — web search with optional content scraping
+4. **`curl`** — only for the service's own API endpoints (`/v2/parse`, `/v2/monitor`, etc.) and raw binary downloads (PDFs, images) discovered during research


### PR DESCRIPTION
Adds three improvements to the bundled AgentSkills skill:

### triggers.md rewrite
- Fuller decision table covering all commands (scrape, search, agent, map, crawl, extract, browser, parse, monitor, generate-llmstxt)
- Rule-of-thumb summary (2+ sources → agent, single page → scrape, etc.)
- Tool selection order with rationale

### SKILL.md additions
- 'When to use which command' quick reference section
- Pitfalls section with four entries:
  - Agent auto-search noise and fallback strategy
  - Scrape failure on non-HTML content (sitemaps, RSS, JSON)
  - Binary content download detection
  - Substack SPA vs stale URL diagnosis

None of the additions reference PR numbers, dates, or implementation internals — they're clean, portable guidance that stays current across versions.