### PR TITLE
fix: return search results grouped by source type per Firecrawl v2 spec

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -189,7 +189,7 @@ async def search(request: Request, body: SearchRequest):
             if scrape_result.get("success"):
                 markdown = scrape_result["data"].get("markdown", "")[:3000]
             search_results.append(SearchResult(url=r["url"], title=r["title"], description=r.get("description", ""), markdown=markdown))
-        return SearchResponse(data=search_results)
+        return SearchResponse(data={"web": search_results, "images": [], "news": []})
     finally:
         await searxng.close()
 

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -107,7 +107,7 @@ class SearchResult(BaseModel):
 
 class SearchResponse(BaseModel):
     success: bool = True
-    data: list[SearchResult] = Field(default_factory=list)
+    data: dict = Field(default_factory=lambda: {"web": [], "images": [], "news": []})
 
 
 class MapRequest(BaseModel):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -77,7 +77,7 @@ def test_crawl_batch_search_and_map_endpoints_exist():
     assert search.status_code == 200
     search_payload = search.json()
     assert search_payload["success"] is True
-    assert len(search_payload["data"]) >= 1
+    assert len(search_payload["data"]["web"]) >= 1
 
     map_resp = httpx.post(AGENT + "/v2/map", json={"url": TEST_SITE, "limit": 10}, timeout=120)
     assert map_resp.status_code == 200


### PR DESCRIPTION
## Summary

The `/v2/search` endpoint returns search results as a flat array (`"data": [{...}, ...]`), but the [Firecrawl v2 OpenAPI spec](https://docs.firecrawl.dev/api-reference/v2-openapi.json) specifies that `data` should be an object grouping results by source type:

```json
{"data": {"web": [{...}], "images": [], "news": []}}
```

The Firecrawl Python SDK v4 (`v2/methods/search.py:37`) does `response_data["data"].get("web")` to find results — which returns `None` on a flat array, silently producing zero results. This breaks any agent that routes `web_search` through the Firecrawl provider with groktocrawl as a self-hosted backend.

## Related Issue

Closes #65

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change
- [x] Manual verification done — response format confirmed matching Firecrawl v2 spec

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

The fix is minimal — three lines changed across three files:

1. `models.py`: `SearchResponse.data` type from `list[SearchResult]` → `dict` with default `{"web": [], "images": [], "news": []}`
2. `api.py`: Return wraps results in `{"web": search_results, "images": [], "news": []}`
3. `test_stack.py`: Assertion updated to check `data["web"]` instead of `data`

The `SearchResult` model stays the same — individual result shape is unchanged.
