### PR TITLE
fix: extract search results from data.web dict instead of reading data as flat list

### DIFF
--- a/groktocrawl
+++ b/groktocrawl
@@ -321,9 +321,7 @@ def cmd_search(client: Client, args: argparse.Namespace) -> None:
     except ApiError as e:
         die(str(e))
 
-    data = result.get("data", [])
-    if not isinstance(data, list):
-        data = []
+    data = result.get("data", {}).get("web", [])
 
     if JSON_OUTPUT:
         emit("", {"results": data, "query": args.query})


### PR DESCRIPTION
## Summary

The `search` command silently drops all results because `cmd_search()` reads `result["data"]` (a dict with `web`, `images`, `news` keys) as a flat list. The fix extracts `data["web"]` from the dict, which contains the actual search result list.

Reported in #70 with full reproduction steps and API response analysis.

## Related Issue

Closes #70

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [x] (verified against live agent-svc — results below)
- [ ] New tests added for the change
- [ ] Manual verification done (describe)
- [x] (verified — search returns real results, see below)

**Manual verification:**

```
$ groktocrawl search "mesh networking" --limit 2
Search results for: mesh networking

1. Mesh networking - Wikipedia
   https://en.wikipedia.org/wiki/Mesh_networking
   A mesh network is a network topology in which the infrastructure nodes...

2. r/HomeNetworking on Reddit: Can someone explain to me about mesh WiFi?
   https://www.reddit.com/r/HomeNetworking/comments/...
```

JSON output also confirmed working: `{"results": [...], "query": "mesh networking"}`

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

Root cause: the `/v2/search` API returns `{"success": true, "data": {"web": [...], "images": [], "news": []}}`. The `data` field is a dict with sub-keys per result type. `cmd_search()` was reading it with `result.get("data", [])` expecting a flat list, then discarding it via the `isinstance(data, list)` guard. The fix: `result.get("data", {}).get("web", [])` — extracts the web result list from inside the data dict.

The same bug pattern may affect other commands that consume APIs returning `data.web` format; this fix addresses the search command specifically.

---

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
