### PR TITLE
fix: Epoch 4 — multi-source fallback chain and domain exploration strategy

### DIFF
--- a/skills/groktocrawl/SKILL.md
+++ b/skills/groktocrawl/SKILL.md
@@ -9,8 +9,9 @@ description: >-
 license: MIT
 metadata:
   author: groktopus
-  version: "1.3.1"
+  version: "1.3.2"
   changelog:
+    "1.3.2": "Add multi-source research fallback chain (search→scrape→browser→agent) and domain exploration strategy (llms.txt→map→crawl→search site:)
     "1.3.1": "Add extracting structured data section with prompt guidance and error recovery across commands"
     "1.3.0": "Add full structured extraction workflow with session ID plumbing, browser session lifecycle reference, and multi-step research workflow example"
     "1.2.0": "Add browser session lifecycle guidance, structured extraction examples, search backend config reference, and cross-command chaining patterns"
@@ -63,6 +64,35 @@ groktocrawl agent "Summarize the key findings from this PDF and compare with the
 ```
 The agent will fetch and analyze both sources independently.
 
+## Multi-source research with fallback chain
+
+When researching a topic, no single source type is guaranteed complete. Use this fallback chain when the first approach produces insufficient results:
+
+```bash
+# Level 1: Search for leads
+groktocrawl search "p5.js 2.0 release WebGPU changes" --limit 5 --json
+
+# Level 2a: If search results are shallow (blogspam, summaries) → scrape primary sources
+groktocrawl scrape https://p5js.org/download/
+
+# Level 2b: If scrape returns under 500 chars → try browser for JS-rendered content
+SESSION=$(groktocrawl browser create --ttl 120 | grep -o '"[a-f0-9]\{24\}"' | head -1 | tr -d '"')
+groktocrawl browser exec "$SESSION" navigate --url "https://p5js.org/download/"
+groktocrawl browser exec "$SESSION" executeScript --script "document.body.innerText"
+
+# Level 3: Cross-reference and synthesize all sources
+groktocrawl agent "Compare the features from the p5.js release notes at https://p5js.org/download/ with community summaries. What changed in WebGPU support? Are there breaking changes?"
+```
+
+**When to escalate:**
+- Search returns few results → try `site:domain.com <topic>` or switch search backends
+- Scrape returns under 500 chars → browser (JS rendering needed)
+- Scrape returns 403/blocked → browser with stealth mode or try curl
+- Browser fails → check session TTL has not expired (create fresh if needed)
+- Multiple sources give conflicting info → `agent` command to compare and reconcile
+
+**Cross-referencing for verification:** When you need to verify a specific claim across multiple sources, do not rely on a single source type. Fetch the claim from an official source (scrape/browser), cross-reference with community/analysis sources (search), and feed both into an `agent` for comparison. This is especially important for technical specifications, version changes, and breaking changes.
+
 ## Extracting structured data
 
 The `extract` command (`groktocrawl extract <url> --prompt "..."`) uses the LLM to return structured data from a page. It works best on static HTML pages with clear content patterns.
@@ -83,6 +113,45 @@ groktocrawl extract https://example.com/products --prompt "product names, prices
 **When to use extract vs browser + executeScript:**
 - `extract` — quick extraction from static HTML when you know roughly what you want
 - `browser + executeScript` — JS-rendered pages, precise CSS selectors, when you need control over the extraction logic
+
+## Domain exploration strategy
+
+When exploring an unfamiliar website for comprehensive coverage, use this systematic approach rather than one-off `scrape` calls:
+
+```bash
+# Phase 1: Discover the site's surface
+# Try llms.txt first (agent-friendly docs), then sitemap.xml
+curl -sL https://example.com/llms.txt
+# OR
+groktocrawl scrape https://example.com/sitemap.xml
+
+# Phase 2: Breadth-first URL inventory with map
+groktocrawl map https://example.com/docs --limit 100
+
+# Phase 3: Depth-first content extraction with crawl
+# Pick a subpath from the map output
+groktocrawl crawl https://example.com/docs/api --max-depth 2 --limit 50
+
+# Phase 4: Gap detection with search site: prefix
+groktocrawl search "site:example.com tutorial" --limit 5 --json
+```
+
+**Deciding between map, crawl, and search:**
+
+| Goal | Tool | Why |
+|------|------|-----|
+| List all URLs on a site | `map` | Fast, breadth-first, returns URLs only — good for inventorying |
+| Extract full page content from a section | `crawl` | Depth-first, returns markdown — good for documentation, blogs |
+| Find pages about a specific topic on the site | `search site:` | Query-driven — good for targeted discovery |
+| Find the agent-friendly entry point | `curl /llms.txt` | Fastest — one request, full site map in structured text |
+
+**Depth strategy:**
+- `--max-depth 1`: Single level only (page + its immediate links). Use for landing pages, index pages.
+- `--max-depth 2`: Page + one level of links. Use for documentation sites with a table of contents.
+- `--max-depth 3+`: Full subsite crawl. Use for deep hierarchies. Always pair with `--limit` to bound the crawl.
+- No limit: Only for small, well-understood sites (under ~200 pages).
+
+**When map + crawl together:** Start with `map` to understand site structure (breadth-first, low cost), then `crawl` specific subpaths for content (depth-first, higher cost). This avoids crawling irrelevant sections.
 
 ## Pitfalls
 


### PR DESCRIPTION
## Summary

Epoch 4 of the SkillOpt cycle on the groktocrawl SKILL.md — budget decayed to 2 training rollouts.

## Changes (v1.3.1 → v1.3.2)

**1. Multi-source research with fallback chain** (new section after When-to-use-which)

Adds a structured escalation pattern when researching a topic where the first source type is incomplete:

- Level 1: **search** for leads
- Level 2a: **scrape** primary sources (if search is shallow)
- Level 2b: **browser** for JS-rendered content (if scrape returns <500 chars)
- Level 3: **agent** to cross-reference and synthesize all sources
- Escalation triggers, cross-referencing for verification guidance

**2. Domain exploration strategy** (new section before Pitfalls)

Adds a systematic approach to exploring unfamiliar websites:

- Phase 1: llms.txt/sitemap discovery
- Phase 2: map for breadth-first URL inventory
- Phase 3: crawl for depth-first content extraction
- Phase 4: search `site:` prefix for gap detection
- Decision table (map vs crawl vs search vs curl/llms.txt)
- Depth strategy guidelines (`--max-depth 1/2/3+`)

## Validation

All 3 held-out validation tasks pass — both edits are additive with no modifications to existing scrape/search/browser guidance.

## QA

- [x] Changelog updated
- [x] Version bumped to 1.3.2 (patch, per convention)
- [x] Synced to active skill at ~/.hermes/skills/groktocrawl/SKILL.md
- [x] Validated against hold-out tasks: val-1 (scrape), val-2 (search), val-3 (scrape)

---
_SkillOpt Epoch 4 — budget: 2/2 used. Epoch 1: v1.2.0 | Epoch 2: v1.3.0 | Epoch 3: v1.3.1 | Epoch 4: v1.3.2_