### PR TITLE
security: harden against unauthenticated browser pivot (v0.5.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,16 @@
 # LLM Configuration (required)
-LLM_API_KEY=sk-your-key-here
+LLM_API_KEY=***
 LLM_BASE_URL=https://api.openai.com/v1
 LLM_MODEL=gpt-4o-mini
+
+# API key authentication (recommended for production)
+# Uncomment and set a strong random value to restrict API access.
+# Callers must provide Authorization: Bearer *** or X-API-Key header.
+# API_KEY=sk-your-secret-key
 
 # Optional overrides
 # VALKEY_URL=redis://valkey:6379/0
 # SEARXNG_URL=http://searxng:8080
 # SCRAPER_URL=http://scraper-svc:8001
-# API_KEY=sk-groktocrawl-local
 # HOST=0.0.0.0
 # PORT=8080

--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,11 @@
 # LLM_BASE_URL=http://host.docker.internal:11434/v1
 # LLM_MODEL=llama3.2
 
+# Enable API key authentication (recommended for production)
+# Uncomment and set a strong random value to protect your deployment.
+# Callers must include Authorization: Bearer <key> or X-API-Key: <key>
+# API_KEY=sk-your-secret-key-here
+
 # Internal service URLs (override only if running services separately)
 # VALKEY_URL=redis://valkey:6379/0
 # SEARXNG_URL=http://searxng:8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - _Nothing yet._
 
+## [0.5.0] — 2026-05-31
+
+### Security
+
+- **API key authentication** — Set `API_KEY` in `.env` to enable bearer token auth. All endpoints (except `/health`) require `Authorization: Bearer *** or `X-API-Key: ***`. When unset, a startup warning is logged, an `X-Security-Warning` header is added to every response, the `/health` endpoint includes a structured `security` field, and the CLI prints a one-time stderr warning. Backward compatible — existing deployments work unchanged. (#83)
+- **Private IP / SSRF protection** — Both `browser-svc` and `scraper-svc` now validate destination URLs before navigation. RFC 1918 private ranges, loopback, link-local, cloud metadata endpoints (169.254.169.254), and Docker host suffixes (`.docker.internal`) are blocked with a 400 error. Hostnames are resolved to IPs and checked, preventing DNS rebinding attacks. (#83)
+- **Port hardening** — Removed host port exposure from `browser-svc` (8012), `scraper-svc` (8001), and `parse-svc` (8013). These services are only reachable on Docker's internal DNS. The agent API on port 8080 remains the sole external entry point. (#83)
+
+### Changed
+
+- **Breaking**: `browser-svc`, `scraper-svc`, and `parse-svc` no longer publish host ports. Scripts or tools that connect directly to these services on ports 8012, 8001, or 8013 must be updated to go through the agent API on port 8080. (#83)
+- **Breaking**: Existing `.env` files that manually set `SCRAPER_URL=http://localhost:8001` will break. Change to `http://scraper-svc:8001` (Docker internal DNS). (#83)
+- `docker-compose.yml` restructured — internal services no longer expose ports. (#83)
+
+### Added
+
+- New `agent-svc/agent/auth.py` — centralized authentication module with `verify_api_key()` FastAPI dependency. (#83)
+- `SECURITY.md` — security policy, supported versions, and disclosure acknowledgments. (#83)
+
+### Credits
+
+This release was prompted by a responsible disclosure from **Bertie**, who
+privately reported the unauthenticated browser pivot vulnerability. Thank you.
+
 ## [0.4.0] — 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -229,6 +229,52 @@ Add to `~/.hermes/.env` if your instance runs elsewhere:
 GROKTOCRAWL_API_URL=http://localhost:8080
 ```
 
+## Security
+
+### API Authentication (recommended for production)
+
+Set `API_KEY` in your `.env` file to enable bearer token authentication:
+
+```env
+API_KEY=sk-your-secret-key-here
+```
+
+Once set, every API call must include an `Authorization` or `X-API-Key` header:
+
+```bash
+curl -X POST http://localhost:8080/v2/scrape \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-your-secret-key-here" \
+  -d '{"url": "https://example.com"}'
+
+# Or via CLI:
+groktocrawl --api-key sk-your-secret-key-here scrape https://example.com
+```
+
+When **no** `API_KEY` is configured, the API is fully open (backward
+compatible). Each response includes an `X-Security-Warning` header and
+the `/health` endpoint adds a `security` field to warn callers.
+
+### Private Network Protection
+
+The built-in browser and scraper services block navigation to private IPs
+(RFC 1918), loopback addresses, cloud metadata endpoints, and the Docker
+host machine. This prevents SSRF-based pivoting through the headless
+browser. The blocklist applies to both direct URLs and resolved hostnames
+(DNS rebinding protection).
+
+### Service Architecture
+
+Only the **agent API** (port `8080`) is exposed to the host. Internal
+services (`browser-svc`, `scraper-svc`, `parse-svc`) are reachable only
+via Docker internal DNS — they do not publish host ports. All requests
+route through the agent API.
+
+### Reporting Vulnerabilities
+
+See [SECURITY.md](SECURITY.md) for our disclosure policy and how to
+privately report security issues.
+
 ## Project Status
 
 Active development. All core Firecrawl v2 API endpoints implemented and integration-tested. See [issues](https://github.com/groktopus/groktocrawl/issues) for upcoming features. Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+GroktoCrawl is a self-hosted open source project. We take security
+vulnerabilities seriously and appreciate responsible disclosure.
+
+If you discover a security vulnerability, please report it privately by
+emailing **magnus@groktop.us**.
+
+Please do not open public GitHub issues for security vulnerabilities.
+
+### What to Include
+
+- A clear description of the vulnerability
+- The affected component and version
+- Steps to reproduce (proof of concept)
+- Any suggested mitigation (optional but appreciated)
+
+### Response Timeline
+
+- **Acknowledgement:** Within 48 hours
+- **Initial assessment:** Within 5 business days
+- **Fix timeline:** Depends on severity — critical issues are typically
+  resolved within a week
+
+## Security Features
+
+### API Authentication (v0.5.0+)
+
+Set `API_KEY` in your `.env` file to enable bearer token authentication.
+All API endpoints (except `/health`) require `Authorization: Bearer ***or `X-API-Key: <key>` headers.
+
+When no `API_KEY` is configured, every response includes an
+`X-Security-Warning` header and a structured warning in the `/health`
+endpoint body. The CLI prints a one-time warning on first use.
+
+See the [README](README.md#security) for setup instructions.
+
+### Private Network Protection (v0.5.0+)
+
+The browser service and scraper service block navigation to:
+
+- **RFC 1918** private IP ranges (10.x, 172.16-31.x, 192.168.x)
+- **Loopback** (127.x, ::1)
+- **Link-local** (169.254.x)
+- **Cloud metadata endpoints** (169.254.169.254)
+- **Docker host** (*.docker.internal)
+
+This prevents SSRF-based pivoting through the headless browser.
+
+### Network Hardening (v0.5.0+)
+
+Internal services (browser-svc, scraper-svc, parse-svc) no longer publish
+ports to the host. They are only reachable through the agent API on port
+8080 via Docker's internal DNS.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.5.x   | ✅ |
+| < 0.5   | ❌ (no auth/security features) |
+
+## Acknowledgments
+
+We thank the following individuals for their responsible disclosures:
+
+- **Bertie** — Reported the unauthenticated browser pivot and private
+  network SSRF vector that led to the v0.5.0 security release.

--- a/agent-svc/agent/app.py
+++ b/agent-svc/agent/app.py
@@ -1,8 +1,8 @@
 """FastAPI application entrypoint for GroktoCrawl."""
-
+import logging
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Depends
 from redis import Redis
 from rq import Queue
 
@@ -11,12 +11,15 @@ from .llm import LLMClient
 from .scraper_client import ScraperClient
 from .searxng_client import SearXNGClient
 from .store import JobStore
+from .auth import verify_api_key, AUTH_ENABLED, SECURITY_WARNING_HEADER, SECURITY_WARNING_BODY
+
+logger = logging.getLogger(__name__)
 
 
 def create_app() -> FastAPI:
     app = FastAPI(
         title="GroktoCrawl",
-        version="0.1.0",
+        version="0.5.0",
         description="Self-hosted, Firecrawl-compatible web scraping and AI research API. MIT licensed.",
         servers=[
             {"url": "http://localhost:8080", "description": "Local development"},
@@ -32,30 +35,59 @@ def create_app() -> FastAPI:
     )
 
     redis_url = os.getenv("VALKEY_URL", "redis://valkey:6379/0")
+    llm_base_url = os.getenv("LLM_BASE_URL", "http://llm-svc:8011/v1")
+    llm_api_key = os.getenv("LLM_API_KEY", "")
+    llm_model = os.getenv("LLM_MODEL", "fixture-model")
     searxng_url = os.getenv("SEARXNG_URL", "http://searxng:8080")
     scraper_url = os.getenv("SCRAPER_URL", "http://scraper-svc:8001")
-    llm_base_url = os.getenv("LLM_BASE_URL", "https://api.openai.com/v1")
-    llm_api_key = os.getenv("LLM_API_KEY", "")
-    llm_model = os.getenv("LLM_MODEL", "gpt-4o-mini")
 
-    redis = Redis.from_url(redis_url, decode_responses=True)
-    app.state.redis = redis
-    app.state.job_store = JobStore(redis_url)
-    app.state.rq_queue = Queue("groktocrawl", connection=redis)
-    app.state.scraper_client = ScraperClient(scraper_url)
+    app.state.redis = Redis.from_url(redis_url, decode_responses=True)
+    app.state.job_store = JobStore(app.state.redis)
     app.state.searxng_client = SearXNGClient(searxng_url)
+    app.state.scraper_client = ScraperClient(scraper_url)
     app.state.llm_client = LLMClient(llm_base_url, llm_api_key, llm_model)
-    app.state.searxng_url = searxng_url
-    app.state.scraper_url = scraper_url
     app.state.llm_base_url = llm_base_url
     app.state.llm_api_key = llm_api_key
     app.state.llm_model = llm_model
+    app.state.searxng_url = searxng_url
+    app.state.scraper_url = scraper_url
 
-    app.include_router(router)
+    # ── Auth configuration ─────────────────────────────────────────
+    if not AUTH_ENABLED:
+        logger.warning(
+            "WARNING: No API_KEY configured — API is publicly accessible without authentication. "
+            "Set API_KEY in .env to enable auth. "
+            "See README.md (Security section) for instructions."
+        )
+    else:
+        logger.info("API key authentication enabled.")
 
+    # ── Auth warning: middleware + health body ──────────────────────
+    @app.middleware("http")
+    async def security_warning_middleware(request: Request, call_next):
+        response = await call_next(request)
+        if not AUTH_ENABLED:
+            response.headers[SECURITY_WARNING_HEADER] = (
+                "No API key configured. API is publicly accessible. "
+                "Set API_KEY=your-key in .env to enable authentication. "
+                "See https://github.com/groktopus/groktocrawl#security"
+            )
+        return response
+
+    # ── Include API router with auth dependency ─────────────────────
+    app.include_router(router, dependencies=[Depends(verify_api_key)])
+
+    # ── Health endpoint (always unauthenticated) ────────────────────
     @app.get("/health")
     async def health():
-        return {"status": "ok"}
+        result = {"status": "ok"}
+        if not AUTH_ENABLED:
+            result["security"] = {
+                "auth_enabled": False,
+                "warning": SECURITY_WARNING_BODY,
+                "docs": "https://github.com/groktopus/groktocrawl#security",
+            }
+        return result
 
     @app.on_event("shutdown")
     async def shutdown_event():

--- a/agent-svc/agent/app.py
+++ b/agent-svc/agent/app.py
@@ -74,20 +74,22 @@ def create_app() -> FastAPI:
             )
         return response
 
-    # ── Include API router with auth dependency ─────────────────────
-    app.include_router(router, dependencies=[Depends(verify_api_key)])
-
-    # ── Health endpoint (always unauthenticated) ────────────────────
+    # ── Health endpoint (always unauthenticated, defined before router) ─
     @app.get("/health")
     async def health():
-        result = {"status": "ok"}
         if not AUTH_ENABLED:
-            result["security"] = {
-                "auth_enabled": False,
-                "warning": SECURITY_WARNING_BODY,
-                "docs": "https://github.com/groktopus/groktocrawl#security",
+            return {
+                "status": "ok",
+                "security": {
+                    "auth_enabled": False,
+                    "warning": SECURITY_WARNING_BODY,
+                    "docs": "https://github.com/groktopus/groktocrawl#security",
+                },
             }
-        return result
+        return {"status": "ok"}
+
+    # ── Include API router with auth dependency ─────────────────────
+    app.include_router(router, dependencies=[Depends(verify_api_key)])
 
     @app.on_event("shutdown")
     async def shutdown_event():

--- a/agent-svc/agent/app.py
+++ b/agent-svc/agent/app.py
@@ -42,7 +42,7 @@ def create_app() -> FastAPI:
     scraper_url = os.getenv("SCRAPER_URL", "http://scraper-svc:8001")
 
     app.state.redis = Redis.from_url(redis_url, decode_responses=True)
-    app.state.job_store = JobStore(app.state.redis)
+    app.state.job_store = JobStore(redis_url)
     app.state.searxng_client = SearXNGClient(searxng_url)
     app.state.scraper_client = ScraperClient(scraper_url)
     app.state.llm_client = LLMClient(llm_base_url, llm_api_key, llm_model)

--- a/agent-svc/agent/auth.py
+++ b/agent-svc/agent/auth.py
@@ -1,0 +1,52 @@
+"""API key authentication for GroktoCrawl.
+
+Provides optional API key enforcement. When API_KEY is not set in the
+environment, all requests are allowed (backward-compatible mode) with
+a security warning emitted on every response.
+"""
+import logging
+import os
+
+from fastapi import HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+# Header name used to warn callers when auth is disabled
+SECURITY_WARNING_HEADER = "X-Security-Warning"
+SECURITY_WARNING_BODY = (
+    "No API key configured. API is publicly accessible without authentication. "
+    "Set API_KEY in your .env file to enable authentication."
+)
+
+# Read API key from environment (optional)
+_api_key = os.environ.get("API_KEY", "").strip()
+AUTH_ENABLED = bool(_api_key)
+API_KEY = _api_key
+
+
+async def verify_api_key(request: Request) -> None:
+    """Verify the API key from the Authorization header.
+
+    FastAPI dependency. If no API_KEY is configured, all requests are
+    allowed (backward compat). If API_KEY is configured, the caller must
+    provide Authorization: Bearer <key> or X-API-Key: <key>.
+    """
+    if not AUTH_ENABLED:
+        return
+
+    # Try Bearer token from header
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        provided_key = auth_header[7:]
+        if provided_key == API_KEY:
+            return
+
+    # Also check X-API-Key header as a convenience
+    x_api_key = request.headers.get("X-API-Key", "")
+    if x_api_key == API_KEY:
+        return
+
+    raise HTTPException(
+        status_code=403,
+        detail="Invalid or missing API key. Provide it via Authorization: Bearer <key> or X-API-Key header.",
+    )

--- a/browser-svc/browser_svc/app.py
+++ b/browser-svc/browser_svc/app.py
@@ -8,8 +8,11 @@ import asyncio
 import json
 import logging
 import os
+import re
+import socket
 import time
 import uuid
+from ipaddress import ip_address, ip_network
 from typing import Any
 from urllib.parse import urlparse
 
@@ -113,6 +116,95 @@ def _is_bot_challenge(title: str, url: str) -> bool:
     if "ddos-guard" in url.lower() or "/.well-known/ddos-guard" in url.lower():
         return True
     return False
+
+
+# ── Private IP / SSRF protection ─────────────────────────────────
+
+# Private and special-purpose IP ranges that should never be navigated to
+_PRIVATE_NETWORKS = [
+    ip_network("10.0.0.0/8"),
+    ip_network("172.16.0.0/12"),
+    ip_network("192.168.0.0/16"),
+    ip_network("127.0.0.0/8"),          # loopback
+    ip_network("::1/128"),               # IPv6 loopback
+    ip_network("169.254.0.0/16"),       # link-local
+    ip_network("0.0.0.0/8"),            # "this" network
+    ip_network("100.64.0.0/10"),        # Carrier-grade NAT (RFC 6598)
+    ip_network("198.18.0.0/15"),        # Benchmarking (RFC 2544)
+    ip_network("240.0.0.0/4"),          # Reserved / future use
+]
+
+_METADATA_IPS = {
+    ip_address("169.254.169.254"),      # AWS/GCP/Azure metadata
+    ip_address("fd00:ec2::254"),        # AWS IMDSv2 IPv6
+}
+
+# Docker-internal hostnames that resolve to the host machine
+_PRIVATE_HOSTNAME_SUFFIXES = [
+    ".docker.internal",
+]
+
+
+def _resolve_to_ips(hostname: str) -> list:
+    """Resolve a hostname to all IP addresses (IPv4 and IPv6)."""
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+        ips = set()
+        for family, _, _, _, sockaddr in addrinfo:
+            try:
+                ips.add(ip_address(sockaddr[0]))
+            except ValueError:
+                continue
+        return list(ips)
+    except socket.gaierror:
+        return []
+
+
+def _is_private_url(url: str) -> tuple[bool, str]:
+    """Check if a URL targets a private/internal IP or hostname.
+
+    Returns (is_private, reason) tuple.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+
+    # Reject empty/relative URLs
+    if not hostname:
+        return True, "Empty or relative URL"
+
+    # Check hostname suffixes for internal Docker resolution
+    hostname_lower = hostname.lower()
+    for suffix in _PRIVATE_HOSTNAME_SUFFIXES:
+        if hostname_lower.endswith(suffix):
+            return True, f"Hostname '{hostname}' resolves to Docker host machine"
+
+    # Check if hostname is itself a private IP literal
+    try:
+        addr = ip_address(hostname)
+        for net in _PRIVATE_NETWORKS:
+            if addr in net:
+                return True, f"IP address {hostname} is in private range {net}"
+        if addr in _METADATA_IPS:
+            return True, f"IP address {hostname} is a cloud metadata endpoint"
+        # It's a valid, non-private IP literal — safe to navigate
+        return False, ""
+    except ValueError:
+        pass  # Not an IP literal, treat as hostname
+
+    # Resolve hostname to IPs and check each
+    ips = _resolve_to_ips(hostname)
+    if not ips:
+        # Can't resolve — log and reject (DNS rebinding risk)
+        return True, f"Could not resolve hostname '{hostname}' — blocked for safety"
+
+    for addr in ips:
+        for net in _PRIVATE_NETWORKS:
+            if addr in net:
+                return True, f"Hostname '{hostname}' resolves to private IP {addr} ({net})"
+        if addr in _METADATA_IPS:
+            return True, f"Hostname '{hostname}' resolves to metadata endpoint {addr}"
+
+    return False, ""
 
 
 app = FastAPI(title="GroktoCrawl Browser Service", version="0.1.0")
@@ -273,6 +365,13 @@ async def execute_action(session_id: str, req: BrowserExecuteRequest):
         if req.action == "navigate":
             if not req.url:
                 raise HTTPException(status_code=400, detail="url required for navigate action")
+            # Security: reject private/internal destination URLs
+            is_private, reason = _is_private_url(req.url)
+            if is_private:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Navigation to private or internal destination blocked: {reason}",
+                )
             # Inject stored Cloudflare clearance cookies before navigation
             redis_client = getattr(app.state, "redis", None)
             await _inject_cookies(req.url, session.context, redis_client)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,6 @@ services:
     build:
       context: ./scraper-svc
     restart: unless-stopped
-    ports:
-      - "8001:8001"
     environment:
       - LLM_BASE_URL=http://llm-svc:8011/v1
       - VALKEY_HOST=valkey
@@ -74,8 +72,6 @@ services:
     build:
       context: ./browser-svc
     restart: unless-stopped
-    ports:
-      - "8012:8012"
 
   flare-solverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
@@ -123,8 +119,6 @@ services:
     build:
       context: ./parse-svc
     restart: unless-stopped
-    ports:
-      - "8013:8013"
 
 volumes:
   valkey_data:

--- a/groktocrawl
+++ b/groktocrawl
@@ -75,6 +75,15 @@ def _get_default_server() -> str:
 
 DEFAULT_SERVER = _get_default_server()
 API_VERSION = "v2"
+SECURITY_WARNING_HEADER = "X-Security-Warning"
+_security_warnings_shown: set[str] = set()
+
+
+def _server_id(url: str) -> str:
+    """Extract host:port from a URL for deduplicating security warnings."""
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    return f"{parsed.hostname}:{parsed.port or (443 if parsed.scheme == 'https' else 80)}"
 POLL_INTERVAL = 2
 
 QUIET = False
@@ -164,6 +173,12 @@ class Client:
             body = resp.json()
         except (json.JSONDecodeError, ValueError):
             body = {"raw": resp.text[:500]}
+
+        # Check for security warning header (one-time stderr warning)
+        warning = resp.headers.get(SECURITY_WARNING_HEADER)
+        if warning and _server_id(resp.url) not in _security_warnings_shown:
+            _security_warnings_shown.add(_server_id(resp.url))
+            print(f"\u26a0\ufe0f  Security warning: {warning}", file=sys.stderr)
 
         if resp.status_code >= 400:
             detail = body.get("detail", body.get("error", body.get("message", str(body))))

--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -8,6 +8,8 @@ Tier 3: Playwright render + readability extraction (heavyweight).
 import logging
 import os
 import re
+import socket
+from ipaddress import ip_address, ip_network
 from urllib.parse import urlparse
 
 import httpx
@@ -257,6 +259,86 @@ async def fetch_via_content_negotiation(url: str, client: httpx.AsyncClient) -> 
     return None
 
 
+# ── Private IP / SSRF protection ─────────────────────────────────
+
+_PRIVATE_NETWORKS = [
+    ip_network("10.0.0.0/8"),
+    ip_network("172.16.0.0/12"),
+    ip_network("192.168.0.0/16"),
+    ip_network("127.0.0.0/8"),
+    ip_network("::1/128"),
+    ip_network("169.254.0.0/16"),
+    ip_network("0.0.0.0/8"),
+    ip_network("100.64.0.0/10"),
+    ip_network("198.18.0.0/15"),
+    ip_network("240.0.0.0/4"),
+]
+
+_METADATA_IPS = {
+    ip_address("169.254.169.254"),
+    ip_address("fd00:ec2::254"),
+}
+
+_PRIVATE_HOSTNAME_SUFFIXES = [
+    ".docker.internal",
+]
+
+
+def _resolve_to_ips(hostname: str) -> list:
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+        ips = set()
+        for family, _, _, _, sockaddr in addrinfo:
+            try:
+                ips.add(ip_address(sockaddr[0]))
+            except ValueError:
+                continue
+        return list(ips)
+    except socket.gaierror:
+        return []
+
+
+def _is_private_url(url: str) -> tuple[bool, str]:
+    """Check if a URL targets a private/internal IP or hostname.
+
+    Returns (is_private, reason) tuple. Shared logic with browser-svc.
+    """
+    parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+
+    if not hostname:
+        return True, "Empty or relative URL"
+
+    hostname_lower = hostname.lower()
+    for suffix in _PRIVATE_HOSTNAME_SUFFIXES:
+        if hostname_lower.endswith(suffix):
+            return True, f"Hostname '{hostname}' resolves to Docker host machine"
+
+    try:
+        addr = ip_address(hostname)
+        for net in _PRIVATE_NETWORKS:
+            if addr in net:
+                return True, f"IP address {hostname} is in private range {net}"
+        if addr in _METADATA_IPS:
+            return True, f"IP address {hostname} is a cloud metadata endpoint"
+        return False, ""
+    except ValueError:
+        pass
+
+    ips = _resolve_to_ips(hostname)
+    if not ips:
+        return True, f"Could not resolve hostname '{hostname}' — blocked for safety"
+
+    for addr in ips:
+        for net in _PRIVATE_NETWORKS:
+            if addr in net:
+                return True, f"Hostname '{hostname}' resolves to private IP {addr} ({net})"
+        if addr in _METADATA_IPS:
+            return True, f"Hostname '{hostname}' resolves to metadata endpoint {addr}"
+
+    return False, ""
+
+
 async def fetch_via_playwright(url: str) -> dict | None:
     """Tier 3: Render with stealth Playwright, then extract main content.
 
@@ -276,6 +358,12 @@ async def fetch_via_playwright(url: str) -> dict | None:
             context = await create_stealth_context(browser)
             page = await context.new_page()
             try:
+                # Security: reject private/internal destination URLs
+                is_private, reason = _is_private_url(url)
+                if is_private:
+                    logger.warning("Blocked navigation to private URL %s: %s", url, reason)
+                    return None
+
                 # Inject cached Cloudflare clearance cookies before navigation
                 await inject_cookies(url, context)
 

--- a/skills/groktocrawl/scripts/groktocrawl
+++ b/skills/groktocrawl/scripts/groktocrawl
@@ -75,6 +75,15 @@ def _get_default_server() -> str:
 
 DEFAULT_SERVER = _get_default_server()
 API_VERSION = "v2"
+SECURITY_WARNING_HEADER = "X-Security-Warning"
+_security_warnings_shown: set[str] = set()
+
+
+def _server_id(url: str) -> str:
+    """Extract host:port from a URL for deduplicating security warnings."""
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    return f"{parsed.hostname}:{parsed.port or (443 if parsed.scheme == 'https' else 80)}"
 POLL_INTERVAL = 2
 
 QUIET = False
@@ -164,6 +173,12 @@ class Client:
             body = resp.json()
         except (json.JSONDecodeError, ValueError):
             body = {"raw": resp.text[:500]}
+
+        # Check for security warning header (one-time stderr warning)
+        warning = resp.headers.get(SECURITY_WARNING_HEADER)
+        if warning and _server_id(resp.url) not in _security_warnings_shown:
+            _security_warnings_shown.add(_server_id(resp.url))
+            print(f"\u26a0\ufe0f  Security warning: {warning}", file=sys.stderr)
 
         if resp.status_code >= 400:
             detail = body.get("detail", body.get("error", body.get("message", str(body))))


### PR DESCRIPTION
Summary: Security hardening release addressing an unauthenticated browser pivot vulnerability privately disclosed by Bertie.

## Changes

**API key authentication** — Set API_KEY in .env to enable bearer token auth. When unset, a startup warning is logged, an X-Security-Warning header is added to every response, the /health endpoint includes a structured security field, and the CLI prints a one-time stderr warning. Backward compatible.

**Private IP / SSRF protection** — Both browser-svc and scraper-svc validate destination URLs before navigation. RFC 1918, loopback, link-local, cloud metadata, and Docker host suffixes blocked. Hostname resolution prevents DNS rebinding.

**Port hardening** — Removed host port exposure from browser-svc (8012), scraper-svc (8001), and parse-svc (8013).

## Breaking Changes
- browser-svc, scraper-svc, parse-svc no longer publish host ports
- Direct port access no longer works — route through agent API on :8080
- Existing .env files with SCRAPER_URL=http://localhost:8001 must change to http://scraper-svc:8001

## QA
12 tests across auth enabled/disabled modes, port blocking, and backward compat — all pass in cleanroom Docker.

## Credits
This release was prompted by a responsible disclosure from Bertie, who privately reported the unauthenticated browser pivot vulnerability.