### PR TITLE
fix: make compose config portable and enable SearXNG JSON

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - "8081:8080"
     volumes:
-      - /Users/magnus/.hermes/searxng-settings.yml:/etc/searxng/settings.yml:ro
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
     environment:
       - SEARXNG_BASE_URL=http://localhost:8081/
     cap_add:
@@ -111,7 +111,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /Users/magnus/.hermes/ofelia-config.ini:/etc/ofelia/config.ini:ro
+      - ./ofelia/config.ini:/etc/ofelia/config.ini:ro
     depends_on:
       - agent-svc
 

--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -16,6 +16,9 @@ server:
 search:
   safe_search: 0
   autocomplete: ""
+  formats:
+    - html
+    - json
 
 engines:
   - name: duckduckgo


### PR DESCRIPTION
## Summary
- replace contributor-specific absolute Compose mounts with repo-relative config paths
- enable SearXNG JSON output while keeping HTML enabled

## Why
The default Compose file currently mounts SearXNG and Ofelia configs from `/Users/magnus/.hermes/...`, which makes `docker compose up` fail on other machines.

GroktoCrawl's search API also depends on SearXNG JSON output. Without `json` in `search.formats`, SearXNG returns HTTP 403 for `format=json`, so `/v2/search` does not work out of the box.

## Validation
- `docker compose config --quiet`
- `docker compose up -d searxng`
- `curl http://localhost:8081/search?q=groktocrawl&format=html` -> HTTP 200
- `curl http://localhost:8081/search?q=groktocrawl&format=json` -> HTTP 200
- `curl -X POST http://localhost:8080/v2/search -H 'Content-Type: application/json' -d '{"query":"groktocrawl","limit":2}'` -> returns web results
