### PR TITLE
docs: add ADR convention and adapter architecture decision records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .venv/
 venv/
 __pypackages__/
+.hermes/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ groktocrawl/
 
 ## Key Architecture Decisions
 
+Architecture Decision Records (ADRs) live in `docs/adr/` and capture the context and rationale behind significant design choices. Always check the ADR index at `docs/adr/README.md` before making architectural changes — existing ADRs may document constraints or rejected alternatives that inform your approach.
+
 ### Inline async processing (no RQ worker)
 
 Jobs are processed with `asyncio.create_task()` inside the API process. This avoids needing a separate worker container. For production deployments with high throughput, restore the RQ queue and add a worker container.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,32 @@ curl http://localhost:8080/health
 - `test-site/` — fixture website for integration tests
 - `tests/` — integration tests
 
+## Architecture Decision Records
+
+Significant architectural decisions are documented as ADRs in `docs/adr/`. Each ADR follows the MADR template and covers context, decision drivers, considered options, and consequences.
+
+**Convention:**
+
+- **File name:** `NNNN-title-with-dashes.md` (sequential numbers, imperative verb phrase)
+- **Statuses:** `proposed`, `accepted`, `rejected`, `deprecated`, `superseded by ADR-NNNN`
+- **Immutability:** ADRs are never edited after acceptance. To change a decision, write a new ADR and update the old one's status.
+- **Linking:** Reference related ADRs via relative links in the Links section.
+
+**When to write an ADR:**
+
+- Adding a new integration or service
+- Changing an existing architectural pattern
+- Choosing between significant alternatives with lasting impact
+- Any decision a future contributor would want to understand *why* it was made
+
+**Workflow:**
+
+1. Create the ADR as `docs/adr/NNNN-title-with-dashes.md` (next available number)
+2. Get it reviewed as part of the PR
+3. On acceptance, update the ADR status and the table in `docs/adr/README.md`
+
+See `docs/adr/README.md` for the full index of existing ADRs.
+
 ## Commit Guidelines
 
 This project uses **Conventional Commits**:

--- a/docs/adr/0001-adapter-registry-pre-pipeline-hook.md
+++ b/docs/adr/0001-adapter-registry-pre-pipeline-hook.md
@@ -1,0 +1,46 @@
+# Adapter Registry Pre-Pipeline Hook
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: GroktoCrawl's `smart_scrape()` runs a linear three-tier pipeline (llms.txt → content negotiation → Playwright render) that fails on JS-heavy SPAs like YouTube. Adding site-specific handlers must not degrade the existing path.
+
+## Context and Problem Statement
+
+The `smart_scrape()` function in `scraper-svc/scraper/fetch.py` implements a generic scraping strategy that works well for static HTML sites but cannot extract content from JavaScript-heavy single-page applications. YouTube, Twitter/X, and Wikipedia's dynamic layouts are common targets that return empty results.
+
+The simplest fix — adding `if "youtube.com"` checks directly into `smart_scrape()` — would turn a clean pipeline into a rat's nest of special cases over time. We need a mechanism to route specific URLs to specialized handlers without modifying the core pipeline code.
+
+## Decision Drivers
+
+* Must not break existing scrape behavior for sites that already work
+* Must allow new site handlers to be added without modifying existing code
+* Must be transparent to the CLI and API — `scrape <url>` should just work
+* Adapter failure must not block the generic pipeline from trying
+
+## Considered Options
+
+* **A. Pre-pipeline registry hook** — Check the adapter registry before any HTTP requests. Adapters handle their own fetching entirely.
+* **B. Post-T2 hook** — Let the cheap tiers (llms.txt, content negotiation) run first, only route to adapter if they fail.
+* **C. Inline if/else chain** — Add site detection directly in `smart_scrape()`.
+
+## Decision Outcome
+
+Chosen option: **A. Pre-pipeline registry hook**, because adapters target sites where the generic pipeline already fails — running llms.txt first just adds latency and complexity for no benefit.
+
+### Positive Consequences
+
+* Zero risk to existing functionality — adapters are purely additive
+* Full control for adapters (they can use APIs like youtube-transcript-api that don't even HTTP GET the URL)
+* Transparent to the CLI — no new subcommands or flags needed
+
+### Negative Consequences
+
+* Adapter failure adds latency to the generic path. Mitigated by per-adapter timeouts (see ADR-0007).
+* Skips the `/llms.txt` optimization for sites that might have it — but adapter-targeted sites are SPAs where this doesn't apply.
+
+## Links
+
+* Refined by [ADR-0007: Adapter Timeout and Circuit Breaker](0007-adapter-timeout-and-circuit-breaker.md)
+* Refined by [ADR-0009: Zero CLI Surface Changes](0009-zero-cli-surface-changes.md)

--- a/docs/adr/0002-regex-dispatch-with-priority.md
+++ b/docs/adr/0002-regex-dispatch-with-priority.md
@@ -1,0 +1,43 @@
+# Regex Dispatch with Priority
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: Multiple adapters may match the same URL (e.g., a general `twitter.com` adapter and a specific Spaces adapter both matching `twitter.com/i/spaces/...`). We need a deterministic way to resolve which adapter handles a given URL.
+
+## Context and Problem Statement
+
+URL patterns overlap. A single URL could match multiple adapters' regex patterns. The dispatch mechanism needs to handle this without ambiguity or race conditions.
+
+## Decision Drivers
+
+* Must be deterministic — same URL always routes to the same adapter
+* Must support overlapping URL patterns (site-wide handlers vs specific sub-path handlers)
+* Must be fast — the check happens on every `scrape` call
+* Must allow adapters to be added without modifying the registry logic
+
+## Considered Options
+
+* **A. Static regex list per adapter with priority ordering** — Each adapter declares `patterns: list[re.Pattern]` and a `priority: int`. Registry sorts by descending priority, iterates in order, first match wins.
+* **B. Concurrent try-all, first success wins** — Fire every adapter at the URL simultaneously, take the first result.
+* **C. URL-parse map** — Use `urlparse(url).netloc` as a dict key for O(1) lookup.
+
+## Decision Outcome
+
+Chosen option: **A. Static regex list with priority ordering**, because it's deterministic, fast, and handles overlapping patterns cleanly.
+
+### Positive Consequences
+
+* Priority lets site-specific supersets (e.g., Twitter Spaces) win over broad handlers (e.g., general Twitter/X)
+* Deterministic — no race conditions
+* Fast — regex matching on URL strings is microseconds
+
+### Negative Consequences
+
+* Regex maintenance burden. Mitigated by using well-tested patterns and unit-testing pattern matching.
+* URL-parse optimization (prefix filter before regex) can be added later if profiling shows it matters.
+
+## Links
+
+* Defined by [ADR-0001: Pre-pipeline Registry Check](0001-adapter-registry-pre-pipeline-hook.md)

--- a/docs/adr/0003-per-adapter-fallback-chain.md
+++ b/docs/adr/0003-per-adapter-fallback-chain.md
@@ -1,0 +1,44 @@
+# Per-Adapter Fallback Chain
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: Different sites have different content extraction paths. YouTube's primary extraction (transcript API) is fundamentally different from Twitter's (API → nitter → browser). A shared fallback system would be too abstract to be useful.
+
+## Context and Problem Statement
+
+Each adapter needs to try multiple strategies to extract content (API call, third-party service, browser render, etc.), in order of preference. The fallback chain is site-specific — what works for YouTube (transcript API → yt-dlp → browser) is different from what works for Twitter.
+
+The framework should provide reusable helpers without dictating fallback structure.
+
+## Decision Drivers
+
+* Each adapter must own its fallback chain — the adapter knows best what to try first
+* Common patterns (browser extraction, LLM extraction) should be shareable
+* If all adapter strategies fail, the generic pipeline should still get a chance
+
+## Considered Options
+
+* **A. Per-adapter internal fallback** — Each adapter implements its own `scrape()` with a try/except chain internally. Framework provides shared helper functions.
+* **B. Shared fallback pipeline in registry** — Registry runs a common fallback chain across all adapters (try all adapters, then generic).
+* **C. Two-level fallback** — Per-adapter internal chain + registry-level fallback to generic pipeline.
+
+## Decision Outcome
+
+Chosen option: **C. Two-level fallback**. The adapter tries its own strategies first. If all fail (raises `AdapterError`), the registry moves to the next matching adapter or falls through to the generic pipeline. Shared helpers (`try_browser_extraction()`, `try_llm_extraction()`) live in `_helpers.py` for reuse.
+
+### Positive Consequences
+
+* Clear ownership — each adapter evolves independently
+* Generic pipeline acts as the ultimate fallback — no content gap
+* Shared helpers avoid code duplication without imposing structure
+
+### Negative Consequences
+
+* Potential for duplicated patterns across adapters. Mitigated by extracting common patterns into `_helpers.py` as they emerge.
+
+## Links
+
+* Defined by [ADR-0001: Pre-pipeline Registry Check](0001-adapter-registry-pre-pipeline-hook.md)
+* Refined by [ADR-0007: Adapter Timeout and Circuit Breaker](0007-adapter-timeout-and-circuit-breaker.md)

--- a/docs/adr/0004-two-phase-result-markdown-and-metadata.md
+++ b/docs/adr/0004-two-phase-result-markdown-and-metadata.md
@@ -1,0 +1,42 @@
+# Two-Phase Result (Markdown + Metadata)
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: Site-specific adapters can extract structured metadata (video title, channel, views, duration) that the generic markdown-only pipeline cannot. The result format needs to carry both content and structured data.
+
+## Context and Problem Statement
+
+The generic scrape pipeline returns flat markdown. A YouTube adapter can extract structured metadata (title, channel, views, duration, publish date) that should be available to API consumers. We need a result format that carries both the markdown body and structured metadata without breaking backward compatibility.
+
+## Decision Drivers
+
+* Must not break existing API consumers that expect markdown
+* Structured metadata should be available to API consumers that want it
+* The CLI should work without changes — metadata is a bonus, not a requirement
+
+## Considered Options
+
+* **A. YAML frontmatter prepended to markdown** — Adapter returns `AdapterResult(markdown=body, metadata=dict)`. Framework auto-prepends YAML frontmatter to markdown before returning. CLI sees markdown with frontmatter.
+* **B. Separate API response fields** — Add a `metadata` field to the `ScrapeData` model. CLI strips it and shows markdown only; `--json` output includes both.
+* **C. Both** — Frontmatter in the markdown body for CLI/agent consumption, plus a separate `metadata` field in the API response for programmatic consumers.
+
+## Decision Outcome
+
+Chosen option: **C. Both**. The scraper merges metadata into YAML frontmatter on the markdown body. The `ScrapeData` model also carries a separate `metadata: dict` field. The CLI user sees frontmatter in the output; programmatic consumers use `--json` to get structured metadata.
+
+### Positive Consequences
+
+* Backward compatible — existing consumers that ignore frontmatter still get clean markdown
+* CLI users get structured data without extra flags
+* Programmatic consumers can access metadata via `--json` or the API directly
+
+### Negative Consequences
+
+* Slight complexity in the merge step (frontmatter prepend)
+* The `ScrapeData` model in agent-svc needs an optional `metadata` field added
+
+## Links
+
+* Implemented by [ADR-0009: Zero CLI Surface Changes](0009-zero-cli-surface-changes.md)

--- a/docs/adr/0005-in-repo-adapters-with-entry-point-path-reserved.md
+++ b/docs/adr/0005-in-repo-adapters-with-entry-point-path-reserved.md
@@ -1,0 +1,43 @@
+# In-Repo Adapters with Entry-Point Path Reserved
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: Adapters need to live somewhere in the codebase. The decision of where affects discoverability, versioning, and extensibility.
+
+## Context and Problem Statement
+
+New adapter files need a home. The location choice has long-term consequences for how adapters are discovered, versioned, and extended by third parties.
+
+## Decision Drivers
+
+* Adapters must be versioned with the codebase they target (API surface changes)
+* Adding a new adapter must be easy for the project maintainer
+* The architecture should not preclude third-party adapters in the future
+* Minimal infrastructure overhead for v1
+
+## Considered Options
+
+* **A. In-repo (`scraper-svc/scraper/adapters/`)** — Built-in adapters shipped with the codebase. Discovered by import at startup.
+* **B. Entry-point plugins (pip-installable)** — Adapters register via `pyproject.toml` entry points under `groktocrawl.adapters`.
+* **C. Config-file based** — Users write `~/.groktocrawl/adapters.yaml` mapping domains to handler scripts.
+
+## Decision Outcome
+
+Chosen option: **A. In-repo for v1**, with the adapter interface designed so that entry-point loading (option B) can be added in v2 without changing any adapter code.
+
+### Positive Consequences
+
+* Versioned with the codebase, reviewed in the same PRs
+* Simple discoverability — all adapters in one directory
+* Quick to implement, easy to test
+
+### Negative Consequences
+
+* Adding a new adapter requires a code change and PR
+* Third parties cannot add adapters without forking. Mitigated by designing the `SiteAdapter` interface and `AdapterRegistry` dispatch logic so that entry-point loading is a drop-in addition in v2.
+
+## Links
+
+* Defined by [ADR-0006: Auto-Registration via @adapter Decorator](0006-auto-registration-via-adapter-decorator.md)

--- a/docs/adr/0006-auto-registration-via-adapter-decorator.md
+++ b/docs/adr/0006-auto-registration-via-adapter-decorator.md
@@ -1,0 +1,41 @@
+# Auto-Registration via @adapter Decorator
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: Each adapter needs to register itself with the `AdapterRegistry` without requiring a central config file or manual registration call in `app.py`.
+
+## Context and Problem Statement
+
+Every time someone adds a new adapter, they should not have to also edit a registry config, update a list, or wire it into the application startup. Registration should be automatic and local to the adapter file.
+
+## Decision Drivers
+
+* Adding a new adapter should require exactly one new file (plus tests)
+* Registration must be explicit — no metaclass magic or automatic discovery of all classes in a module
+* The mechanism should not prevent future entry-point-based loading of external adapters
+
+## Considered Options
+
+* **A. @adapter decorator** — A decorator that wraps a `SiteAdapter` subclass and auto-registers it into a module-level registry list at import time.
+* **B. Metaclass** — A metaclass on `SiteAdapter` that auto-registers all subclasses.
+* **C. Manual registration in app.py** — Each adapter is explicitly registered in the application's startup code.
+
+## Decision Outcome
+
+Chosen option: **A. @adapter decorator**, because it's explicit, local to the adapter file, and avoids metaclass complexity.
+
+### Positive Consequences
+
+* Registration is visible in the adapter file itself — no hidden magic
+* Simple to test — registry state is deterministic after imports
+* Works naturally with entry-point loading in v2 (the decorator can also populate an entry-point-compatible registry)
+
+### Negative Consequences
+
+* Import order matters — adapters must be imported for registration to trigger. Mitigated by having `adapters/__init__.py` explicitly import all known adapter modules at startup.
+
+## Links
+
+* Implemented by [ADR-0005: In-Repo Adapters](0005-in-repo-adapters-with-entry-point-path-reserved.md)

--- a/docs/adr/0007-adapter-timeout-and-circuit-breaker.md
+++ b/docs/adr/0007-adapter-timeout-and-circuit-breaker.md
@@ -1,0 +1,37 @@
+# Adapter Timeout and Circuit Breaker
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: A misbehaving adapter (rate-limited API, network hang, slow browser render) must not hold up the scrape pipeline for longer than a bounded duration.
+
+## Context and Problem Statement
+
+The adapter registry is checked before the generic pipeline. If an adapter hangs (e.g., YouTube API rate-limited, yt-dlp stuck on a large video), the user waits. Without timeouts, a single bad adapter call can make `scrape <url>` appear broken even when the generic pipeline would have worked fine.
+
+## Decision Drivers
+
+* Worst-case latency should be bounded (configurable, per-adapter)
+* Timeout should be per-adapter call, not per-adapter lifecycle
+* No sophisticated circuit breaker for v1 (tripping after N failures) — keep it simple
+
+## Considered Options
+
+* **A. Per-adapter timeout with wrapper helper** — `AdapterContext` provides a `with_timeout(coro, default=15)` helper. All framework-provided calls inside adapters use it.
+* **B. Global timeout in the registry** — The registry wraps every adapter `scrape()` call in a single global timeout.
+* **C. No timeout (trust the adapter)** — Adapters are responsible for their own time management.
+
+## Decision Outcome
+
+Chosen option: **A. Per-adapter timeout with configurable defaults**, because different adapters have different latency profiles (YouTube transcript API is fast, browser fallback is slow).
+
+### Positive Consequences
+
+* Bounded latency — worst case adds 15s per adapter attempt
+* Configurable per-site via `.env` (e.g., `ADAPTER_YOUTUBE_TIMEOUT=30`)
+* Defaults are sane (15s) and documented in README.md
+
+### Negative Consequences
+
+* No circuit breaker (tripping after N consecutive failures). Mitigated: defer to v2 if needed, and the registry already falls through to the generic pipeline on `AdapterError` or timeout.

--- a/docs/adr/0008-three-layer-testing-strategy.md
+++ b/docs/adr/0008-three-layer-testing-strategy.md
@@ -1,0 +1,42 @@
+# Three-Layer Testing Strategy
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: Adapters are inherently more brittle than generic scraping because they depend on external APIs and site structures that change without notice.
+
+## Context and Problem Statement
+
+A YouTube adapter that works today may break tomorrow if YouTube changes its transcript API response format, its oEmbed endpoint, or its page DOM structure. We need a testing strategy that catches regressions fast without requiring network access for every test run.
+
+## Decision Drivers
+
+* CI must be fast — most tests run without network access
+* API breakage must be detected quickly, not silently
+* Test maintenance should be minimal
+
+## Considered Options
+
+* **A. Contract tests (schema validation) + VCR recordings** — Layer 1: unit tests that validate output schema against known inputs. Layer 2: recorded API responses replayed in CI. Layer 3: weekly live API tests.
+* **B. Always hit real APIs** — Every test run makes real network calls to YouTube/Twitter/Wikipedia APIs.
+* **C. Mock everything** — All external dependencies are mocked at the HTTP layer.
+
+## Decision Outcome
+
+Chosen option: **A. Three-layer strategy**. Layer 1 (contract tests) run in milliseconds and validate output shape. Layer 2 (VCR-recorded) run in seconds and catch regressions against known API responses. Layer 3 (live) runs weekly in CI to detect API drift.
+
+### Positive Consequences
+
+* Fast CI — Layer 1+2 run in <5s per adapter
+* Early warning of API changes via Layer 3
+* Recordings can be refreshed automatically via scheduled CI job
+
+### Negative Consequences
+
+* VCR recordings require periodic maintenance. Mitigated by automating re-recording in a weekly CI job.
+* Live tests require API keys (YouTube Data API, Twitter OAuth). Mitigated by documenting required env vars.
+
+## Links
+
+* Defined by [ADR-0004: Two-Phase Result](0004-two-phase-result-markdown-and-metadata.md) (output schema that contract tests validate against)

--- a/docs/adr/0009-zero-cli-surface-changes.md
+++ b/docs/adr/0009-zero-cli-surface-changes.md
@@ -1,0 +1,37 @@
+# Zero CLI Surface Changes
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2025-06-05
+
+Technical Story: The adapter architecture must be transparent to users. `groktocrawl scrape <url>` should work identically for all URLs — users should not need to know whether an adapter exists for a given site.
+
+## Context and Problem Statement
+
+If adapters require new CLI flags (`--adapter youtube`), new subcommands (`groktocrawl youtube-transcript <url>`), or manual URL classification before scraping, the user experience degrades. The CLI surface should remain stable regardless of how many adapters are added.
+
+## Decision Drivers
+
+* Backward compatibility with existing CLI usage and scripts
+* Users should not need to learn about adapters to use them
+* API consumers (including the `agent` pipeline) should benefit automatically
+
+## Considered Options
+
+* **A. No CLI changes** — Adapter routing happens entirely in `smart_scrape()` in scraper-svc. The CLI, agent-svc route handler, and `agent` pipeline are unaware of adapters.
+* **B. --adapter flag** — Optional `--adapter youtube` flag to force a specific adapter. `auto` (default) uses the registry; `generic` skips adapters and uses the raw pipeline.
+* **C. New subcommands** — `groktocrawl youtube <url>` as a separate entry point for site-specific extraction.
+
+## Decision Outcome
+
+Chosen option: **A. No CLI changes**. The only code change is a 3-line registry check at the top of `smart_scrape()` in scraper-svc. The CLI, agent-svc route handler, and `agent` pipeline all call the same `/v2/scrape` endpoint — they all benefit automatically.
+
+### Positive Consequences
+
+* Fully backward compatible — existing scripts and workflows unchanged
+* No documentation changes needed for existing users
+* The `agent` pipeline (which calls `/v2/scrape` for content) automatically gets richer results from adapted sites
+
+### Negative Consequences
+
+* No way to force adapter selection from the CLI. If an adapter returns poor results for a specific URL, the user cannot bypass it without modifying env vars. Mitigated: this is an acceptable tradeoff for v1 — the registry already falls through to the generic pipeline if the adapter fails.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,34 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for GroktoCrawl.
+
+## What is an ADR?
+
+An Architecture Decision Record captures an important architectural decision made along with its context and consequences. ADRs are immutable — existing records are never edited. If a decision changes, a new ADR is created and the old one is marked as superseded.
+
+## Convention
+
+- **Location:** `docs/adr/`
+- **Naming:** `NNNN-title-with-dashes.md` (sequential numbers, imperative verb phrase)
+- **Template:** [MADR](https://github.com/architecture-decision-record/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-of-the-madr-project) — structured with Status, Deciders, Date, Context, Decision Drivers, Considered Options, Outcome, and Links
+- **Immutability:** ADRs are immutable. To change a decision, write a new ADR and update the old one's status to `superseded by ADR-NNNN`.
+- **Linking:** ADRs reference each other via relative links (`[ADR-0001](0001-adapter-registry-pre-pipeline-hook.md)`)
+- **Statuses:** `proposed`, `accepted`, `rejected`, `deprecated`, `superseded by ADR-NNNN`
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| 0001 | [Adapter Registry Pre-Pipeline Hook](0001-adapter-registry-pre-pipeline-hook.md) | accepted |
+| 0002 | [Regex Dispatch with Priority](0002-regex-dispatch-with-priority.md) | accepted |
+| 0003 | [Per-Adapter Fallback Chain](0003-per-adapter-fallback-chain.md) | accepted |
+| 0004 | [Two-Phase Result (Markdown + Metadata)](0004-two-phase-result-markdown-and-metadata.md) | accepted |
+| 0005 | [In-Repo Adapters with Entry-Point Path Reserved](0005-in-repo-adapters-with-entry-point-path-reserved.md) | accepted |
+| 0006 | [Auto-Registration via @adapter Decorator](0006-auto-registration-via-adapter-decorator.md) | accepted |
+| 0007 | [Adapter Timeout and Circuit Breaker](0007-adapter-timeout-and-circuit-breaker.md) | accepted |
+| 0008 | [Three-Layer Testing Strategy](0008-three-layer-testing-strategy.md) | accepted |
+| 0009 | [Zero CLI Surface Changes](0009-zero-cli-surface-changes.md) | accepted |
+
+## For Contributors
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
## Summary

Establishes the Architecture Decision Record convention for GroktoCrawl and logs the first 9 ADRs covering the adapter registry pattern for site-specific content handlers.

## Changes

- **`docs/adr/`** — New directory with 9 ADRs + README index documenting the adapter architecture
- **`CONTRIBUTING.md`** — Added ADR convention section (when to write, naming, workflow)
- **`AGENTS.md`** — Added ADR reference for AI agents to check before making architectural changes
- **`.gitignore`** — Added `.hermes/` to local-dev exclusions

## ADR Index

| ADR | Title | Status |
|-----|-------|--------|
| 0001 | Adapter Registry Pre-Pipeline Hook | accepted |
| 0002 | Regex Dispatch with Priority | accepted |
| 0003 | Per-Adapter Fallback Chain | accepted |
| 0004 | Two-Phase Result (Markdown + Metadata) | accepted |
| 0005 | In-Repo Adapters with Entry-Point Path Reserved | accepted |
| 0006 | Auto-Registration via @adapter Decorator | accepted |
| 0007 | Adapter Timeout and Circuit Breaker | accepted |
| 0008 | Three-Layer Testing Strategy | accepted |
| 0009 | Zero CLI Surface Changes | accepted |

## Next Steps

This PR documents the design only. Implementation (YouTube adapter + framework code) will follow in subsequent PRs.

Closes #88
