### PR TITLE
feat: translate Firecrawl v2 sources/categories to SearXNG-native categories

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -185,7 +185,10 @@ async def search_v1(request: Request, body: SearchRequest):
 
     searxng = SearXNGClient(request.app.state.searxng_url)
     try:
-        results = await searxng.search(body.query, limit=body.limit, categories=body.categories)
+        results = await searxng.search(
+            body.query, limit=body.limit,
+            categories=body.categories, sources=body.sources,
+        )
         return {
             "success": True,
             "data": [
@@ -207,12 +210,23 @@ async def search(request: Request, body: SearchRequest):
 
     searxng = SearXNGClient(request.app.state.searxng_url)
     try:
-        results = await searxng.search(body.query, limit=body.limit, categories=body.categories)
+        results = await searxng.search(
+            body.query, limit=body.limit,
+            categories=body.categories, sources=body.sources,
+        )
         search_results = [
             SearchResult(url=r["url"], title=r["title"], description=r.get("description", ""))
             for r in results
         ]
-        return SearchResponse(data={"web": search_results, "images": [], "news": []})
+        # Route results to the correct top-level key based on sources filter
+        data: dict[str, list] = {"web": [], "images": [], "news": []}
+        if body.sources:
+            for src in body.sources:
+                if src in data:
+                    data[src] = search_results
+        else:
+            data["web"] = search_results
+        return SearchResponse(data=data)
     finally:
         await searxng.close()
 

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -97,6 +97,7 @@ class SearchRequest(BaseModel):
     query: str
     limit: int = 5
     categories: list[str] | None = None
+    sources: list[str] | None = None
 
 
 class SearchResult(BaseModel):

--- a/agent-svc/agent/searxng_client.py
+++ b/agent-svc/agent/searxng_client.py
@@ -6,6 +6,29 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# ── Firecrawl v2 → SearXNG category translation ────────────────
+# Maps Firecrawl v2 search dimensions (sources, categories) to
+# SearXNG-native category names. Unknown values pass through for
+# forward compatibility. See ADR-0013 and issue #85.
+
+_SOURCES_MAP = {
+    "news": "news",
+    "images": "images",
+    "web": "general",
+    "video": "videos",
+    "social": "general",
+}
+
+_CATEGORIES_MAP = {
+    "research": "science",
+    "github": "it",
+    "pdf": "general",
+    "news": "news",
+    "science": "science",
+    "it": "it",
+    "general": "general",
+}
+
 
 class SearXNGClient:
     """Client for the SearXNG search engine JSON API."""
@@ -17,25 +40,53 @@ class SearXNGClient:
             headers={"User-Agent": "GroktoCrawl/0.1", "Accept": "text/html,application/json", "X-Forwarded-For": "127.0.0.1"},
         )
 
-    async def search(self, query: str, limit: int = 10, categories: list[str] | None = None) -> list[dict]:
+    @staticmethod
+    def _translate(
+        sources: list[str] | None,
+        categories: list[str] | None,
+    ) -> list[str]:
+        """Translate Firecrawl v2 sources/categories to SearXNG category names.
+
+        Merges both dimensions into a single SearXNG categories list.
+        Unknown values pass through for forward compatibility.
+        Returns ``[\"general\"]`` if no mapping produces a category.
+        """
+        result: list[str] = []
+        if sources:
+            for s in sources:
+                mapped = _SOURCES_MAP.get(s, s)
+                if mapped and mapped not in result:
+                    result.append(mapped)
+        if categories:
+            for c in categories:
+                mapped = _CATEGORIES_MAP.get(c, c)
+                if mapped and mapped not in result:
+                    result.append(mapped)
+        return result if result else ["general"]
+
+    async def search(
+        self,
+        query: str,
+        limit: int = 10,
+        categories: list[str] | None = None,
+        sources: list[str] | None = None,
+    ) -> list[dict]:
         """Search the web and return structured results.
 
         Uses SearXNG's JSON API. When categories is None, defaults to "general".
-        Multiple categories (e.g. ["news", "science"]) are comma-separated per
-        the SearXNG API convention.
+        ``sources`` and ``categories`` are merged via ``_translate()`` before
+        being passed to SearXNG.
 
         Returns a list of dicts with keys: url, title, description, engine.
         """
+        effective_categories = self._translate(sources, categories)
         params = {
             "q": query,
             "format": "json",
             "language": "en",
             "pageno": 1,
         }
-        if categories:
-            params["categories"] = ",".join(categories)
-        else:
-            params["categories"] = "general"
+        params["categories"] = ",".join(effective_categories)
 
         try:
             resp = await self._client.get(


### PR DESCRIPTION
## Summary

Adds a translation layer between Firecrawl v2's two-dimensional search model (`sources` + `categories`) and SearXNG's flat category system. This unblocks Firecrawl v2 SDK clients (like Hermes Agent's `web_search` tool) that send `sources` and `categories` parameters.

## Changes

**`agent-svc/agent/models.py`** — +1 line
- Added `sources: list[str] | None = None` to `SearchRequest`

**`agent-svc/agent/searxng_client.py`** — +49 lines
- `_SOURCES_MAP` — translates Firecrawl sources (`news`, `images`, `web`, `video`, `social`) to SearXNG categories
- `_CATEGORIES_MAP` — translates Firecrawl categories (`research`→`science`, `github`→`it`, `pdf`→`general`)
- `_translate()` static method — merges both dimensions into a single SearXNG categories list, unknown values pass through
- `search()` method now accepts `sources` parameter

**`agent-svc/agent/api.py`** — +20 lines
- Both `/v1/search` and `/v2/search` pass `sources` through to the client
- `/v2/search` routes results to the correct top-level key (`data.news`, `data.images`, `data.web`) based on the `sources` filter

## Test Results

| Test | Input | Expected | Result |
|------|-------|----------|--------|
| Basic (no filters) | `{"query": "raspberry pi"}` | `data.web` has results | ✅ |
| News sources | `{"sources": ["news"]}` | `data.news` has results | ✅ |
| Research category | `{"categories": ["research"]}` | Maps to `science`, returns results | ✅ |
| GitHub category | `{"categories": ["github"]}` | Maps to `it`, returns results | ✅ |
| v1 backward compat | `POST /v1/search` | Flat list, unchanged | ✅ |

## Scope

- **No new dependencies** — pure Python dict mapping
- **~76 lines total** across 3 files
- **v1 endpoint unchanged** — backward compatible
- **Unknown values pass through** — forward compatible with SearXNG

Closes #85
