### PR TITLE
docs: document search sources/categories in CLI, README, AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ The agent service uses an OpenAI-compatible client. Swap the provider by changin
 
 **System prompt:** The agent's research behavior is defined by `SYSTEM_PROMPT` and `EXTRACT_SYSTEM_PROMPT` constants in `research.py`. These are fixed — not configurable at runtime. They instruct the LLM to evaluate source quality, synthesize across pages, detect contradictions, and cite sources.
 
+**Search parameters:** `POST /v2/search` accepts Firecrawl v2 `sources` and `categories` dimensions alongside `query` and `limit`. These are translated to SearXNG categories — see `searxng_client.py` for the translation maps and `docs/adr/0013-search-architecture-with-vertical-categories.md` for the architecture. The CLI exposes `--sources` (web, news, images, video, social) and `--categories` (research, github, pdf, etc.) flags.
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,12 +81,15 @@ The scraper uses a **three-tier strategy**: check `/llms.txt` first, try `Accept
 `groktocrawl` is a CLI tool in the repo root. It needs `requests` (`pip install requests`).
 
 ```bash
-./groktocrawl scrape <url>                  # Scrape a page to markdown
-./groktocrawl search <query> --limit 5      # Search the web
-./groktocrawl map <url> --limit 100         # Discover URLs on a site
-./groktocrawl crawl <url> --max-depth 2     # Crawl a website
-./groktocrawl agent "<prompt>"              # Autonomous research agent
-./groktocrawl --json --server <url> <cmd>   # JSON output, custom server
+./groktocrawl scrape <url>                      # Scrape a page to markdown
+./groktocrawl search <query> --limit 5          # Search the web (default: general)
+./groktocrawl search <query> --sources news     # Search news sources only
+./groktocrawl search <query> --categories research  # Search with content category (mapped to SearXNG)
+./groktocrawl search <query> --sources news --categories research  # Combined filter
+./groktocrawl map <url> --limit 100             # Discover URLs on a site
+./groktocrawl crawl <url> --max-depth 2         # Crawl a website
+./groktocrawl agent "<prompt>"                  # Autonomous research agent
+./groktocrawl --json --server <url> <cmd>       # JSON output, custom server
 ```
 
 ## API Endpoints
@@ -119,6 +122,36 @@ The scraper uses a **three-tier strategy**: check `/llms.txt` first, try `Accept
 | GET | `/v2/generate-llmstxt/:jobId` | Get generation status and result |
 
 All Firecrawl v2 API-compatible in request/response shape.
+
+### Search endpoint
+
+`POST /v2/search` accepts Firecrawl v2's two-dimensional search model:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | **Required.** Search query |
+| `limit` | `int` | Max results (default: 5) |
+| `sources` | `string[]` | Source type filter: `web`, `news`, `images`, `video`, `social` |
+| `categories` | `string[]` | Content category: `research`, `github`, `pdf`, `news`, `science`, `it`, `general` |
+
+Both `sources` and `categories` are translated to SearXNG-native categories and can be combined:
+
+| Firecrawl value | Mapped to SearXNG |
+|----------------|-------------------|
+| `sources=news` | `categories=news` |
+| `sources=images` | `categories=images` |
+| `sources=web` | `categories=general` |
+| `categories=research` | `categories=science` |
+| `categories=github` | `categories=it` |
+| `categories=pdf` | `categories=general` |
+
+Unknown values pass through to SearXNG as-is for forward compatibility. When neither
+`sources` nor `categories` is specified, defaults to `general`.
+
+Results are grouped by source type in the response:
+```json
+{"data": {"web": [...], "images": [], "news": []}}
+```
 
 ### Agent endpoint
 

--- a/groktocrawl
+++ b/groktocrawl
@@ -208,10 +208,16 @@ class Client:
         query: str,
         limit: int = 5,
         scrape: bool = False,
+        categories: Optional[list[str]] = None,
+        sources: Optional[list[str]] = None,
     ) -> Dict[str, Any]:
         data: Dict[str, Any] = {"query": query, "limit": limit}
         if scrape:
             data["scrapeOptions"] = {"formats": ["markdown"]}
+        if categories:
+            data["categories"] = categories
+        if sources:
+            data["sources"] = sources
         return self._request("POST", "/search", json_data=data)
 
     def map_urls(
@@ -382,7 +388,10 @@ def cmd_search(client: Client, args: argparse.Namespace) -> None:
         return
 
     try:
-        result = client.search(query=args.query, limit=args.limit, scrape=args.scrape_results)
+        result = client.search(
+            query=args.query, limit=args.limit, scrape=args.scrape_results,
+            categories=args.categories, sources=args.sources,
+        )
     except ApiError as e:
         die(str(e))
 
@@ -998,6 +1007,8 @@ def make_parser() -> argparse.ArgumentParser:
     p_search.add_argument("query", help="Search query")
     p_search.add_argument("--limit", "-l", type=int, default=5, help="Max results (default: 5)")
     p_search.add_argument("--scrape-results", action="store_true", help="Also scrape each result for full content")
+    p_search.add_argument("--sources", nargs="+", choices=["web", "news", "images", "video", "social"], help="Source types to search (Firecrawl v2)")
+    p_search.add_argument("--categories", nargs="+", help="Content categories: research, github, pdf, news, science, it (mapped to SearXNG equivalents)")
 
     p_map = subparsers.add_parser("map", help="Discover URLs on a site")
     p_map.add_argument("url", help="Site URL to map")


### PR DESCRIPTION
## Summary

Documents the `sources` and `categories` search parameters from #85 so that CLI users and AI agents know they exist and how to use them.

## Changes

**CLI (`groktocrawl`):**
- Added `--sources` flag (choices: web, news, images, video, social)
- Added `--categories` flag (semi-freeform: research, github, pdf, etc.)
- Wired both through `client.search()` to the API

**README.md:**
- Updated quick examples with `--sources` and `--categories` usage
- New "Search endpoint" section with parameter table, translation mapping table, and response shape documentation

**AGENTS.md:**
- Added search parameters note so AI agents working on the codebase know the API supports these parameters

Closes #85 (follow-up docs PR)
