### PR TITLE
feat: silent search failure detection — distinguish engine blocks from genuine no-results (closes #98)

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -185,7 +185,7 @@ async def search_v1(request: Request, body: SearchRequest):
 
     searxng = SearXNGClient(request.app.state.searxng_url)
     try:
-        results = await searxng.search(
+        results, _health = await searxng.search(
             body.query, limit=body.limit,
             categories=body.categories, sources=body.sources,
         )
@@ -210,7 +210,7 @@ async def search(request: Request, body: SearchRequest):
 
     searxng = SearXNGClient(request.app.state.searxng_url)
     try:
-        results = await searxng.search(
+        results, _health = await searxng.search(
             body.query, limit=body.limit,
             categories=body.categories, sources=body.sources,
         )

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -104,7 +104,7 @@ async def run_research(
         target_urls = list(urls) if urls else []
         if not target_urls:
             logger.info("No URLs provided. Searching for: %s", prompt)
-            search_results = await searxng.search(prompt, limit=10)
+            search_results, _health = await searxng.search(prompt, limit=10)
             target_urls = [r["url"] for r in search_results if r.get("url")]
 
         documents, source_details = await _scrape_urls(target_urls, scraper)

--- a/agent-svc/agent/searxng_client.py
+++ b/agent-svc/agent/searxng_client.py
@@ -1,10 +1,31 @@
 """SearXNG JSON API client."""
 
 import logging
+from dataclasses import dataclass
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SearchHealth:
+    """Health information about a SearXNG search request.
+
+    Attributes:
+        engines_total: Number of engines queried by SearXNG.
+        engines_responding: Number of engines that returned at least one result.
+        empty_result: True when engines responded but no results were returned
+            (distinct from an infrastructure failure).
+        degraded: True when fewer than half of queried engines responded.
+        detail: Human-readable summary of engine status.
+    """
+
+    engines_total: int = 0
+    engines_responding: int = 0
+    empty_result: bool = False
+    degraded: bool = False
+    detail: str = ""
 
 # ── Firecrawl v2 → SearXNG category translation ────────────────
 # Maps Firecrawl v2 search dimensions (sources, categories) to
@@ -64,20 +85,72 @@ class SearXNGClient:
                     result.append(mapped)
         return result if result else ["general"]
 
+    @staticmethod
+    def _parse_engine_health(data: dict, results: list[dict]) -> SearchHealth:
+        """Parse SearXNG engine status from the API response.
+
+        Inspects the ``engines`` key in the SearXNG JSON response to
+        determine how many engines were queried and how many returned
+        results, building a ``SearchHealth`` summary.
+        """
+        engines = data.get("engines", [])
+        engines_total = len(engines)
+        engines_responding = sum(
+            1 for e in engines if e.get("results", 0) > 0
+        )
+
+        empty_result = bool(
+            engines_responding > 0
+            and not any(r.get("url") for r in results)
+        )
+        degraded = bool(
+            engines_total > 0
+            and engines_responding < engines_total / 2
+        )
+
+        # Build a human-readable detail string
+        if engines_total == 0:
+            detail = "No engine status available from SearXNG"
+        elif degraded:
+            detail = (
+                f"Degraded: {engines_responding}/{engines_total} engines "
+                f"returned results"
+            )
+        elif empty_result:
+            detail = (
+                f"All {engines_total} engines responded but returned "
+                f"no results"
+            )
+        else:
+            detail = (
+                f"Healthy: {engines_responding}/{engines_total} engines "
+                f"returned results"
+            )
+
+        return SearchHealth(
+            engines_total=engines_total,
+            engines_responding=engines_responding,
+            empty_result=empty_result,
+            degraded=degraded,
+            detail=detail,
+        )
+
     async def search(
         self,
         query: str,
         limit: int = 10,
         categories: list[str] | None = None,
         sources: list[str] | None = None,
-    ) -> list[dict]:
-        """Search the web and return structured results.
+    ) -> tuple[list[dict], SearchHealth]:
+        """Search the web and return structured results with health info.
 
         Uses SearXNG's JSON API. When categories is None, defaults to "general".
         ``sources`` and ``categories`` are merged via ``_translate()`` before
         being passed to SearXNG.
 
-        Returns a list of dicts with keys: url, title, description, engine.
+        Returns a tuple of (results, health) where:
+        - results: list of dicts with keys: url, title, description, engine.
+        - health: SearchHealth dataclass with engine status information.
         """
         effective_categories = self._translate(sources, categories)
         params = {
@@ -95,7 +168,7 @@ class SearXNGClient:
             )
             if resp.status_code != 200:
                 logger.warning("SearXNG returned %d: %s", resp.status_code, resp.text[:200])
-                return []
+                return [], SearchHealth(detail=f"SearXNG returned HTTP {resp.status_code}")
 
             data = resp.json()
             results = []
@@ -107,14 +180,19 @@ class SearXNGClient:
                     "engine": item.get("engine", ""),
                 })
 
-            return results[:limit]
+            results = results[:limit]
+
+            # ── Parse engine health ────────────────────────────────────
+            health = self._parse_engine_health(data, results)
+
+            return results, health
 
         except httpx.TimeoutException:
             logger.warning("SearXNG search timed out for query: %s", query)
-            return []
+            return [], SearchHealth(detail="SearXNG request timed out")
         except Exception as e:
             logger.error("SearXNG search failed: %s", e)
-            return []
+            return [], SearchHealth(detail=f"SearXNG search failed: {e}")
 
     async def close(self):
         await self._client.aclose()


### PR DESCRIPTION
## Summary

Adds search health monitoring to the SearXNG client so consumers can distinguish "no results found" from "SearXNG engines are blocked/unavailable."

### Changes

1. **SearchHealth dataclass** (`searxng_client.py`): New `@dataclass` with `engines_total`, `engines_responding`, `empty_result`, `degraded`, and `detail` fields.

2. **Engine status parsing** (`searxng_client.py`): New `_parse_engine_health()` method inspects the `engines` key from SearXNG's JSON API response to count queried vs. responding engines.

3. **Tuple return** (`searxng_client.py`): `search()` now returns `tuple[list[dict], SearchHealth]` instead of just `list[dict]`.

4. **Caller updates**:
   - `api.py` (`search_v1` and `search`): Unpack the tuple
   - `research.py` (`run_research`): Unpack the tuple

### Health logic

| Condition | Result |
|-----------|--------|
| All engines respond with results | `degraded=False, empty_result=False` |
| Engines respond but zero results | `empty_result=True` |
| < 50% of engines respond | `degraded=True` |
| HTTP error / timeout / exception | Default health with detail string |

Closes #98