### PR TITLE
fix: remove <br/> tags from mermaid diagram to fix GitHub rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ LLM_MODEL=llama3.2
 ```mermaid
 flowchart TD
     subgraph compose["docker-compose.yml"]
-        valkey[("valkey<br/>(queue + storage)")]
-        searxng["searxng<br/>(web search)"]
-        scraper("scraper-svc<br/>(smart fetch)")
-        browser["browser-svc<br/>(Playwright sessions)"]
-        agent("agent-svc<br/>(FastAPI + workers)")
-        ofelia["ofelia<br/>(cron scheduler)"]
+        valkey[("valkey (queue + storage)")]
+        searxng["searxng (web search)"]
+        scraper("scraper-svc (smart fetch)")
+        browser["browser-svc (Playwright sessions)"]
+        agent("agent-svc (FastAPI + workers)")
+        ofelia["ofelia (cron scheduler)"]
 
         valkey --- agent
         searxng --- agent
@@ -63,7 +63,7 @@ flowchart TD
         browser --- agent
         ofelia -.->|docker exec| agent
     end
-    llm_provider("LLM Provider<br/>(DeepSeek / OpenAI / Ollama)")
+    llm_provider("LLM Provider (DeepSeek / OpenAI / Ollama)")
     llm_provider -.->|LLM_BASE_URL| agent
 
     style valkey fill:#ffe0b0


### PR DESCRIPTION
The mermaid architecture diagram was showing as raw code instead of a rendered image — the GitHub enrichment service was stuck in a pending state.

**Root cause:** The `<br/>` HTML tags inside node labels (e.g. `"valkey<br/>(queue + storage)"`) caused GitHub's mermaid rendering service to hang. The diagram renders fine locally with `mmdc` but GitHub's enrichment never completed.

**Fix:** Replaced `"name<br/>(description)"` multi-line labels with `"name (description)"` single-line parenthetical labels. Same information, no HTML tags.

Closes the broken rendering issue — should render as a proper diagram image once merged.