### PR TITLE
fix: correct health endpoint state attribute name

### DIFF
--- a/agent-svc/agent/app.py
+++ b/agent-svc/agent/app.py
@@ -182,7 +182,7 @@ def create_app() -> FastAPI:
         probe results with status, latency_ms, and detail.
         """
         result = await check_all(
-            valkey_url=app.state.redis_url,
+            valkey_url=app.state.valkey_url,
             searxng_url=app.state.searxng_url,
             scraper_url=app.state.scraper_url,
             browser_url="http://browser-svc:8012",


### PR DESCRIPTION
## Summary

One-line fix: the enhanced `/health` endpoint from PR #123 references `app.state.redis_url` but the state attribute is set as `app.state.valkey_url` in `create_app()`. Without this fix, every `/health` request crashes with `AttributeError: 'State' object has no attribute 'redis_url'`.

## Related Issue

Closes #124

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change
- [x] Manual verification done (described below)

### Manual Verification

Applied fix via `docker cp` to the running container on hal2000, restarted, and verified:

```
$ curl -s http://localhost:8080/health | python3 -m json.tool
{
    "status": "ok",
    "checks": {
        "valkey": {"status": "ok", "latency_ms": 4.4, "detail": "Valkey PING ok"},
        "searxng": {"status": "ok", "latency_ms": 429.9, ...},
        "scraper": {"status": "ok", "latency_ms": 38.6, ...},
        "browser": {"status": "ok", "latency_ms": 157.1, ...}
    }
}
```

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure (N/A)

## Notes for Reviewers

This was caught during post-merge validation on the production Docker stack. The existing `test_services_health` integration test checks that `/health` returns status 200 but didn't catch this because the test's `wait_for()` function checks connectivity, not response content — the endpoint was crashing with a 500 that the test didn't differentiate from a connection failure. The new `test_health_endpoint_returns_per_dependency_checks` test (added in PR #123) would catch this, but it hasn't been run against the docker stack yet.
