### PR TITLE
docs: proxy support ADR and README sections (refs #127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,32 @@ route through the agent API.
 See [SECURITY.md](SECURITY.md) for our disclosure policy and how to
 privately report security issues.
 
+## Proxy Configuration
+
+GroktoCrawl supports outbound proxy routing via the `SCRAPER_PROXY_URL` environment variable. When set, all scrape requests route through the specified proxy before reaching their target.
+
+```env
+SCRAPER_PROXY_URL=http://user:pass@residential-proxy:8080
+```
+
+**Supported schemes:** `http://`, `https://`, `socks5://`, `socks5h://`
+
+**Behavior:**
+- The proxy is applied at the transport layer across the full scrape pipeline — httpx clients (Tiers 1-2) and Playwright browser context (Tier 3)
+- If the proxy is unreachable, Groktocrawl **fails open**: it retries the request without a proxy and logs the fallback at WARN level
+- Every proxied scrape records `proxy_host=<host:port>` in its structured log for operational debugging
+
+**Guardrails:**
+- **Opt-in only** — users who don't set this variable see zero behavioral change
+- **Single static proxy** — one URL only. For proxy rotation or pool management, front Groktocrawl with a rotating proxy orchestrator (HAProxy, Scrapoxy, etc.)
+- **Credentials never logged** — only the host and port are recorded in scrape logs; the full URL (including auth) is redacted at the logging boundary
+
+**Notes:**
+- Proxy credentials embedded in the URL use standard HTTP Basic Auth encoding. Avoid special characters (@, #, %) in passwords — they can conflict with URL parsing.
+- The Playwright proxy uses **context-level assignment** (`browser.new_context(proxy=...)`) for per-job isolation, not launch-level args (`--proxy-server`).
+
+See [ADR-0020](docs/adr/0020-proxy-support-with-guardrails.md) for the full architecture decision.
+
 ## Adapters
 
 GroktoCrawl supports **site-specific content handlers** that extract richer content from JavaScript-heavy sites. When `scrape <url>` is called, the adapter registry checks if a handler matches the URL before running the generic pipeline. If it matches, the adapter handles extraction with its own fallback chain. If it fails, the generic pipeline runs as normal.
@@ -429,6 +455,8 @@ A token with `public_repo` scope is sufficient for public repositories. For priv
 5. Add `.env` variables to `.env.sample` and document them in this section
 
 See `docs/adr/` for the architecture decision records behind the adapter pattern, and `CONTRIBUTING.md` for the ADR convention.
+
+> **External anti-detection browser hook:** For sites that require advanced browser fingerprinting evasion (Turnstile challenges, DDoS-Guard), the adapter framework supports routing scrape requests to a self-hosted anti-detection browser service. The `AdapterContext.config` provides access to environment variables for configuring the external service endpoint. This is an **advanced operator pattern** — the external browser service is self-managed and outside the project's scope. Groktocrawl provides the dispatch interface; the external service's behavior, compatibility, and reliability are the operator's responsibility.
 
 ## Project Status
 

--- a/docs/adr/0020-proxy-support-with-guardrails.md
+++ b/docs/adr/0020-proxy-support-with-guardrails.md
@@ -1,0 +1,98 @@
+# Proxy Support for Egress Routing (SCRAPER_PROXY_URL)
+
+* Status: accepted
+* Deciders: magnus, jasper
+* Date: 2026-06-06
+
+Technical Story: Issue #127 requests a `SCRAPER_PROXY_URL` env var plumbed through the httpx clients (Tiers 1-2) and Playwright browser context (Tier 3), enabling Groktocrawl to route outbound scrape requests through a proxy. The author has a working implementation (~10 lines) and offered to PR.
+
+## Context and Problem Statement
+
+Groktocrawl's five-tier scrape pipeline (adapters → llms.txt → content negotiation → Playwright stealth → FlareSolverr) handles detection-method blocking — browser fingerprinting, JS challenges, CAPTCHAs — but has no mechanism for IP-origin blocking. A user behind a datacenter IP, corporate NAT, CGNAT, or geo-restricted network may have perfect browser fingerprinting evasion and still be blocked because the exit IP itself is on every blocklist.
+
+Firecrawl v2 supports proxy configuration natively. As a self-hosted alternative, Groktocrawl has a parity gap.
+
+Additionally, corporate environments often require all outbound HTTP traffic to route through an egress proxy. A self-hosted service deployed behind a corporate NAT that cannot be configured for outbound proxy routing is operationally unreachable for those users.
+
+## Decision Drivers
+
+* Must preserve existing behavior for users who do not set the proxy env var — zero behavioral change by default
+* Proxy failures must not silently degrade scrape quality — operators must be able to distinguish "proxy gave wrong content" from "site changed content"
+* Must be a single env var (one proxy URL), not a pool management system — rotation belongs in an orchestration layer above Groktocrawl
+* Proxy credentials must not leak into error logs or process listings
+* The change must be minimal in code surface area — the ~10 line estimate from the contributor is the right scale
+* Must work across all three transport tiers: llms.txt fetch (httpx), content negotiation fetch (httpx), and Playwright browser context
+
+## Considered Options
+
+* **A. Single SCRAPER_PROXY_URL env var** — One env var, plumbed through httpx clients (Tiers 1-2) and Playwright browser context (Tier 3). Fail open with WARN on proxy failure.
+* **B. Documented workaround** — No code change. Document that users can set `HTTP_PROXY`/`HTTPS_PROXY` env vars at the container level (which httpx respects natively) and that Playwright proxy is a manual configuration concern.
+* **C. Proxy pool / rotation system** — Built-in support for multiple proxies, rotation policies, health checking, and geo-targeting. Significantly larger scope.
+
+## Decision Outcome
+
+Chosen option: **A. Single SCRAPER_PROXY_URL env var**, because:
+
+1. It fills a genuine structural gap (IP-origin blocking is orthogonal to all five existing tiers)
+2. The implementation surface is bounded (~10-30 lines)
+3. A single env var is the gold standard for deployment topology flexibility — it works identically across Docker env_file, K8s secrets, Ansible vars, and systemd unit files
+4. It is trivially absent when unset — no behavioral change for users who don't need it
+5. The author has a working, production-tested implementation that validates the approach
+
+Option B was rejected because standard `HTTP_PROXY` env vars are not inherited by Playwright browser contexts consistently, and leaving Playwright without proxy support would leave the most important tier uncovered. Option C was rejected because proxy pool management is a separate concern that belongs above Groktocrawl (HAProxy, Scrapoxy, rotating pool frontend), not embedded in a scraping tool.
+
+### Guardrails
+
+The following guardrails are non-negotiable for merge:
+
+1. **Opt-in only via env var** — users who don't set `SCRAPER_PROXY_URL` see zero behavioral change
+2. **Per-scrape proxy identity logging** — every scrape log line emitted on a proxied request must record which proxy was used (host:port, without credentials) so operators can distinguish "proxy returned stale data" from "the site's content actually changed"
+3. **Fail open with WARN** — if the proxy is unreachable or returns an error, retry the request without proxy and log the fallback at WARN level. Never cascade silently into bad data.
+4. **Single static proxy** — exactly one proxy URL. No rotation, no pool management, no geo-targeting. Users who need multiple proxies should front Groktocrawl with a rotating proxy orchestrator.
+
+### Architectural Placement
+
+Proxy support is not a "sixth tier" in the scrape pipeline sequence. It is a **transport-layer modifier** that operates orthogonally to the existing five tiers:
+
+```
+Request → [SCRAPER_PROXY_URL check] → [Tier 1: Adapters] → [Tier 2: llms.txt] → [Tier 3: Content negotiation] → [Tier 4: Playwright stealth (via context proxy)] → [Tier 5: FlareSolverr] → Response
+```
+
+The proxy is applied at the transport layer before any tier executes. If a tier fails due to an IP-origin block, the proxy does not retry that tier — it is the transport for the tier's request. The fail-open behavior means a failed proxy connection falls through to a direct connection for that request.
+
+### Playwright Implementation Details
+
+The Playwright proxy must use **context-level assignment** (`browser.new_context(proxy={"server": "...", "username": "...", "password": "..."})`) rather than **launch-level args** (`browser.launch(args=["--proxy-server=..."])`). Context-level assignment provides:
+
+- Per-isolation — each scrape job gets its own proxy context, unrelated to others
+- No conflict with existing stealth browser launch args (`--disable-web-security`, `--no-sandbox`)
+- Clean teardown — proxy config is scoped to the context lifecycle
+
+### Security
+
+- Proxy credentials in the env var URL (`http://user:pass@host:port`) must be redacted from all log output. Log only `proxy_host=host:port`, never the full URL.
+- The env var must support standard URI schemes: `http://`, `https://`, `socks5://`, `socks5h://`.
+- No proxy auth secrets may appear in process listings or error telemetry.
+
+### Consequences
+
+*Good:*
+- Groktocrawl becomes deployable behind corporate NAT gateways, residential proxy pools, and geo-restricted networks
+- Parity with Firecrawl v2 proxy support
+- The change is opt-in and bounded — no regression for existing users
+- The single env var pattern matches standard deployment conventions (Docker, K8s, systemd)
+
+*Neutral:*
+- Proxy adds a new failure mode (silent data corruption through a bad proxy). This is mitigated by the per-scrape logging and fail-open guardrails.
+- Documentation needed: one paragraph in README covering env var name, tier effect, and guardrails
+
+*Risks:*
+- Proxy credentials may leak into error telemetry if not scrubbed at the logging boundary. Mitigated by the security requirement above.
+- Users may request proxy rotation, pool management, or geo-targeting follow-up features. Mitigated by explicitly documenting these as out of scope in the feature.
+- The fail-open default means users behind a corporate proxy that requires all egress to route through it may bypass that policy on proxy failure. A future enhancement could add a configurable `SCRAPER_PROXY_FAIL_CLOSED` flag.
+
+## Links
+
+- [Issue #127: feat: proxy support + external browser adapter for anti-bot sites](https://github.com/groktopus/groktocrawl/issues/127)
+- [PR #121: Reddit JSON API adapter](https://github.com/groktopus/groktocrawl/pull/121)
+- [ADR-0010: Five-Tier Scraper Pipeline with LLM-Assisted Recovery](0010-five-tier-scraper-with-llm-recovery.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,5 +38,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0017 | [Grounded Q&A Endpoint](0017-grounded-qa-endpoint.md) | accepted |
 | 0018 | [Observability Infrastructure](0018-observability-infrastructure.md) | accepted |
 | 0019 | [Intelligent Scrape Cache](0019-intelligent-scrape-cache.md) | accepted |
+| 0020 | [Proxy Support with Guardrails](0020-proxy-support-with-guardrails.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
## Summary

This PR documents the architecture decision and user-facing configuration for proxy support (Part 1 of issue #127) and adds a signpost for the external anti-detection browser hook pattern (Part 2).

## Changes

| File | Change |
|------|--------|
| `docs/adr/0020-proxy-support-with-guardrails.md` | **New ADR.** Documents the decision to accept `SCRAPER_PROXY_URL` as a single static proxy env var, with 4 guardrails (opt-in only, proxy identity per-scrape logging, fail-open with WARN, no rotation). Specifies Playwright context-level assignment rather than launch-level args. |
| `README.md` | **Proxy Configuration section** — env var, supported schemes, behavior, guardrails, notes on credential handling and Playwright isolation. **External browser hook signpost** — one paragraph in the Adapters section noting the adapter framework supports this pattern, with clear liability disclaimer. |
| `docs/adr/README.md` | Index entry for ADR-0020 |

## Relationship to Issue #127

- **Part 1 (SCRAPER_PROXY_URL)**: The ADR and README section establish the architectural contract. The actual code PR is expected from @Jackal991 per the issue discussion.
- **Part 2 (External browser hook)**: Documented as a signpost in the adapter-authoring section — no built-in code changes, the adapter framework already supports this pattern.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
