### PR TITLE
feat: agent SSE streaming with CLI default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,15 @@ The agent service uses an OpenAI-compatible client. Swap the provider by changin
 
 **Search parameters:** `POST /v2/search` accepts Firecrawl v2 `sources` and `categories` dimensions alongside `query` and `limit`. These are translated to SearXNG categories — see `searxng_client.py` for the translation maps and `docs/adr/0013-search-architecture-with-vertical-categories.md` for the architecture. The CLI exposes `--sources` (web, news, images, video, social) and `--categories` (research, github, pdf, etc.) flags.
 
+### Agent Endpoint with SSE Streaming
+
+`POST /v2/agent` now supports SSE streaming via `stream: true`. Two-phase protocol:
+- **Discovery:** `sources_pending` (search results found), `source_scraped` (URL fetched) — shown as they happen
+- **Synthesis:** `token` events stream the LLM's output token by token
+- **Final:** `done` event with full `result`, `sources` list, and `latency_ms`
+
+When `stream` is omitted, the existing create→poll pattern is used. The CLI defaults to streaming with `--sync` to opt out.
+
 ### Grounded Q&A (`POST /v2/answer`)
 
 A synchronous single-turn Q&A endpoint that bridges `/v2/search` and `/v2/agent`: search → scrape top results → LLM synthesis with inline citations. Designed for 1-3s latency. Request fields: `query` (required), `num_sources` (1-20, default 5), `model` (per-request LLM override), `stream` (boolean, SSE streaming). Returns `answer` (markdown with `[N]` citation markers), `sources` (list of `{url, title, relevance}`), `citations` (index→URL mapping), `search_type`, and `latency_ms`. When `stream: true`, delivers SSE events: `sources`, `token` (individual tokens), `done` (final), and `error`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent SSE streaming — live progress and token streaming for deep research (ADR-0022)** — `POST /v2/agent` now accepts `stream: true` for Server-Sent Events. Two-phase streaming: discovery events (`sources_pending`, `source_scraped`) show sources as they're found and scraped, followed by token-by-token LLM output (`token` events). Falls back to create→poll pattern when `stream` is omitted. Reuses the SSE event protocol from `POST /v2/answer` (ADR-0017). CLI defaults to streaming with `--sync` to opt out. See `docs/adr/0022-agent-sse-streaming.md`.
+
 - **Web portal — single-search-bar UI for human users (ADR-0021)** — new `portal-svc` container in the Docker Compose stack. A lightweight FastAPI + Jinja2 web interface with a Google-inspired search bar. Routes queries to `POST /v2/answer` with SSE streaming, displaying real-time token output with source citations and a recent queries sidebar in localStorage. One-button v0.1 (answer endpoint); deep research button placeholder reserved for v0.2 (agent SSE, issue #130). Port 8081. See `docs/adr/0021-web-portal.md`.
 
 - **Intelligent scrape cache — freshness-aware revalidation with ETag/Last-Modified support (ADR-0019)** — the existing Valkey-backed scrape cache now stores HTTP ETag and Last-Modified headers from Tier 1-2 (llms.txt, content-negotiation) responses and uses conditional GETs (If-None-Match / If-Modified-Since) for blocking revalidation of cached content from slow tiers (playwright, flare-solverr, browser-svc). On 304 Not Modified, extends the cached entry's TTL without re-downloading. On 200, replaces the cache entry with fresh content.

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -85,6 +85,41 @@ async def scrape(request: Request, body: ScrapeRequest):
 
 @router.post("/v2/agent", response_model=AgentCreateResponse)
 async def create_agent(request: Request, body: AgentRequest):
+    # Streaming path — run inline, return SSE
+    if body.stream:
+        from fastapi.responses import StreamingResponse
+
+        async def event_stream():
+            from .research import run_research_stream
+            async for event in run_research_stream(
+                prompt=body.prompt,
+                urls=body.urls,
+                schema=body.schema_,
+                searxng_url=request.app.state.searxng_url,
+                scraper_url=request.app.state.scraper_url,
+                llm_base_url=request.app.state.llm_base_url,
+                llm_api_key=request.app.state.llm_api_key,
+                llm_model=request.app.state.llm_model,
+                requested_model=body.model if body.model != "default" else None,
+            ):
+                import json
+                if event["type"] == "sources_pending":
+                    yield f"data: {json.dumps({'type': 'sources_pending', 'sources': event['sources']})}\n\n"
+                elif event["type"] == "source_scraped":
+                    yield f"data: {json.dumps({'type': 'source_scraped', 'url': event['url'], 'source': event.get('source', ''), 'chars': event.get('chars', 0)})}\n\n"
+                elif event["type"] == "sources":
+                    yield f"data: {json.dumps({'type': 'sources', 'sources': event['sources']})}\n\n"
+                elif event["type"] == "token":
+                    yield f"data: {json.dumps({'type': 'token', 'content': event['content']})}\n\n"
+                elif event["type"] == "done":
+                    yield f"data: {json.dumps({'type': 'done', 'result': event['result'], 'sources': event['sources'], 'latency_ms': event['latency_ms']})}\n\n"
+                elif event["type"] == "error":
+                    yield f"data: {json.dumps({'type': 'error', 'content': event['content']})}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    # Sync path — create job, process in background
     store: JobStore = request.app.state.job_store
     job_id = store.create_job(kind="agent", payload=body.model_dump(exclude_none=True, by_alias=True))
 

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -41,6 +41,7 @@ class AgentRequest(BaseModel):
     max_credits: int | None = None
     webhook: dict[str, Any] | None = None
     strict_constrain_to_urls: bool = False
+    stream: bool = Field(default=False, description="SSE streaming response")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -122,6 +122,156 @@ async def run_research(
         await llm.close()
 
 
+async def run_research_stream(
+    prompt: str,
+    urls: list[str] | None = None,
+    schema: dict | None = None,
+    searxng_url: str = "http://searxng:8080",
+    scraper_url: str = "http://scraper-svc:8001",
+    llm_base_url: str = "https://api.openai.com/v1",
+    llm_api_key: str = "",
+    llm_model: str = "gpt-4o-mini",
+    requested_model: str | None = None,
+):
+    """Streaming version of run_research. Yields SSE-suitable dicts.
+
+    Phase 1 - Discovery: search + scrape, yielding progress events.
+    Phase 2 - Synthesis: LLM token stream (or full response for schema-based output).
+
+    Yields:
+      {"type": "sources_pending", "sources": [...]} — search results (before scrape)
+      {"type": "source_scraped", "url": "...", "title": "...", "chars": N} — each scraped page
+      {"type": "token", "content": "..."} — individual tokens from the LLM (no schema)
+      {"type": "done", "result": "...", "sources": [...], "latency_ms": N} — final
+      {"type": "error", "content": "..."} — error
+    """
+    import time
+    start = time.monotonic()
+
+    searxng = SearXNGClient(searxng_url)
+    scraper = ScraperClient(scraper_url)
+    effective_model = requested_model if requested_model and requested_model != "default" else llm_model
+    llm = LLMClient(llm_base_url, llm_api_key, effective_model)
+
+    try:
+        target_urls = list(urls) if urls else []
+        search_results = []
+        if not target_urls:
+            logger.info("Research stream: searching for: %s", prompt)
+            search_results, _health = await searxng.search(prompt, limit=10)
+            target_urls = [r["url"] for r in search_results if r.get("url")]
+
+        # Yield pending sources for progress visibility
+        pending_sources = [
+            {"url": r["url"], "title": r.get("title", ""), "relevance": r.get("description", "")}
+            for r in search_results if r.get("url")
+        ] if not urls else [{"url": u, "title": "", "relevance": ""} for u in urls]
+        yield {"type": "sources_pending", "sources": pending_sources}
+
+        # Phase 1: Scrape with progress events
+        logger.info("Research stream: scraping URLs")
+        documents: list[str] = []
+        source_details: list[dict] = []
+        import asyncio
+        semaphore = asyncio.Semaphore(2)
+        url_timeout = 20
+
+        async def _scrape_one(url: str) -> tuple[str | None, dict | None]:
+            async with semaphore:
+                try:
+                    result = await asyncio.wait_for(scraper.scrape(url), timeout=url_timeout)
+                    if result.get("success") and result.get("data", {}).get("markdown"):
+                        md = result["data"]["markdown"]
+                        domain = urlparse(url).netloc
+                        doc = f"Source: {url} (domain: {domain})\n\n{md[:8000]}"
+                        src = {"url": url, "source": result["data"].get("source", "unknown"), "char_count": len(md)}
+                        return doc, src
+                    else:
+                        logger.warning("Failed to scrape %s: %s", url, result.get("error"))
+                        return None, None
+                except asyncio.TimeoutError:
+                    logger.warning("Timeout scraping %s after %ss", url, url_timeout)
+                    return None, None
+                except Exception as e:
+                    logger.warning("Error scraping %s: %s", url, e)
+                    return None, None
+
+        pending = list(target_urls)
+        tasks: set[asyncio.Task] = set()
+        task_to_url: dict[asyncio.Task, str] = {}
+
+        while pending or tasks:
+            while len(tasks) < 2 and pending:
+                url = pending.pop(0)
+                task = asyncio.create_task(_scrape_one(url))
+                task_to_url[task] = url
+                tasks.add(task)
+
+            if not tasks:
+                break
+
+            done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+            for task in done:
+                doc, src = task.result()
+                url = task_to_url.pop(task, "")
+                if doc and src:
+                    documents.append(doc)
+                    source_details.append(src)
+                    yield {"type": "source_scraped", "url": src["url"], "source": src["source"], "chars": src["char_count"]}
+
+        context = "\n\n---\n\n".join(documents) if documents else ""
+
+        if not context:
+            elapsed = int((time.monotonic() - start) * 1000)
+            yield {"type": "sources", "sources": []}
+            yield {"type": "done", "result": "I was unable to find or scrape any relevant web pages.", "sources": [], "latency_ms": elapsed}
+            return
+
+        # Phase 2: Synthesis
+        # If schema is provided, use synchronous generation (structured JSON output)
+        if schema:
+            answer = await llm.generate(
+                system_prompt=SYSTEM_PROMPT,
+                user_prompt=prompt,
+                context=context,
+                schema=schema,
+            )
+            _validate_json_if_schema(answer, schema)
+            source_list = [s["url"] for s in source_details]
+            elapsed = int((time.monotonic() - start) * 1000)
+            yield {"type": "sources", "sources": source_list}
+            yield {"type": "done", "result": answer, "sources": source_list, "latency_ms": elapsed}
+            return
+
+        # No schema — stream tokens from the LLM
+        yield {"type": "sources", "sources": [s["url"] for s in source_details]}
+
+        full_answer = ""
+        async for event in llm.generate_stream(
+            system_prompt=SYSTEM_PROMPT,
+            user_prompt=prompt,
+            context=context,
+        ):
+            if event["type"] == "token":
+                full_answer += event["content"]
+                yield {"type": "token", "content": event["content"]}
+            elif event["type"] == "error":
+                yield {"type": "error", "content": event["content"]}
+                return
+            elif event["type"] == "done":
+                full_answer = event["full_content"]
+
+        source_list = [s["url"] for s in source_details]
+        elapsed = int((time.monotonic() - start) * 1000)
+        yield {"type": "done", "result": full_answer, "sources": source_list, "latency_ms": elapsed}
+
+    finally:
+        await searxng.close()
+        await scraper.close()
+        await llm.close()
+
+
 async def run_extract(
     urls: list[str],
     prompt: str | None = None,

--- a/docs/adr/0022-agent-sse-streaming.md
+++ b/docs/adr/0022-agent-sse-streaming.md
@@ -1,0 +1,153 @@
+# Agent SSE Streaming — Real-Time Research for Interactive Clients
+
+* Status: proposed
+* Deciders: magnus, jasper
+* Date: 2026-06-08
+
+Technical Story: The agent endpoint (`POST /v2/agent`) currently uses an async create-job→poll pattern. Interactive clients (web portal, CLI) need real-time progress visibility and token streaming during deep research.
+
+## Context and Problem Statement
+
+GroktoCrawl has two research-oriented endpoints:
+
+| Endpoint | Pattern | Latency | Use Case |
+|---|---|---|---|
+| `POST /v2/answer` | Sync inline + SSE streaming | 1-5s | Single-turn Q&A, fast path |
+| `POST /v2/agent` | Async create→poll | 5-30s+ | Multi-source deep research |
+
+The agent endpoint returns a job ID, processes research in a background task (`asyncio.create_task`), and writes results to Valkey. The client polls `GET /v2/agent/{job_id}` until completion.
+
+This works for programmatic clients (curl, agent tools) but creates a poor experience for:
+
+- **Web portal users** who see a blank screen while the agent researches for 15-30 seconds
+- **CLI users** who see only a spinner with no visibility into what sources are being consulted
+- **Chat UI integrations** that want to stream the answer token by token as it's generated
+
+The `answer` endpoint already solves the same problem with SSE streaming (see ADR-0017). The agent endpoint needs the same capability.
+
+## Decision Drivers
+
+- Must provide **real-time progress visibility** during the discovery phase (what URLs are being scraped)
+- Must **stream tokens** during the synthesis phase (LLM generation)
+- Must **reuse the SSE event protocol** established by the `answer` endpoint — no new streaming mechanism
+- Must **preserve backward compatibility** — existing clients that don't set `stream: true` get the current create→poll behavior unchanged
+- Must support all existing agent features: seed URLs, schema-based structured output, model override
+- Must not require new infrastructure dependencies
+
+## Considered Options
+
+### A. Inline SSE streaming — chosen
+
+Run the research loop inline in the route handler when `stream: true`, wrapping the generator in FastAPI's `StreamingResponse`. Reuse the two-phase event schema from the `answer` endpoint with one addition: intermediate `source_scraped` events during discovery.
+
+**Architecture:**
+```
+POST /v2/agent { stream: true }
+  → create_agent() checks body.stream
+  → run_research_stream() inline (no background task)
+    → Phase 1: search → scrape, yielding source_scraped events
+    → Phase 2: llm.generate_stream(), yielding token events
+    → Final: done event with result + sources + latency
+  → StreamingResponse(event_stream(), media_type="text/event-stream")
+```
+
+**Positive:**
+
+- Matches the proven `answer` endpoint pattern (ADR-0017) exactly
+- No new infrastructure (no pub/sub, no Valkey channels, no WebSocket manager)
+- Client sees progress in real time — sources appearing, then tokens streaming
+- Simple implementation: `run_research_stream()` parallels `run_answer_stream()`
+- Backward compatible: `stream` defaults to `false`
+- Same LLM client — `generate_stream()` already exists and is tested
+
+**Negative:**
+
+- Ties up the HTTP connection for the duration of the research loop (5-30s+)
+- No retry mechanism — if the connection drops mid-stream, progress is lost
+- Not suitable for very long-running research (minutes); the current create→poll pattern remains available for those cases via `--sync`
+
+### B. Valkey pub/sub bridge
+
+The background task publishes events to a Valkey channel. The SSE handler subscribes to the channel and relays events to the client.
+
+**Positive:**
+
+- Decouples processing from HTTP delivery
+- Survives connection drops with reconnection logic
+- Scales to multiple listeners per job
+
+**Negative:**
+
+- Adds significant infrastructure complexity (pub/sub channels, message serialization, reconnect logic)
+- Valkey bridge itself can fail, adding a new failure mode
+- No immediate benefit — the research loop already runs inside the API process (no separate worker)
+- Over-engineering for the current deployment scale
+
+### C. WebSocket endpoint
+
+Add a WebSocket endpoint `/v2/agent/ws/{job_id}` that streams events.
+
+**Positive:**
+
+- Native bidirectional streaming
+- Standard reconnection semantics
+- Well-suited for long-lived connections
+
+**Negative:**
+
+- Breaks from the REST-only API surface (all other endpoints are HTTP)
+- Requires WebSocket connection management and lifecycle handling
+- Not compatible with simple curl/httpx consumption
+- Web portal would need a separate WebSocket client library
+
+## Decision Outcome
+
+Chose option A (inline SSE streaming) because it:
+1. Reuses an established and tested pattern (the `answer` endpoint's SSE implementation)
+2. Requires no new infrastructure dependencies
+3. Preserves full backward compatibility
+4. Is simpler to implement, review, and maintain
+
+The create→poll pattern remains available for clients that prefer it, via the `--sync` CLI flag or by omitting `stream: true` in the API call.
+
+### Event Schema
+
+```
+Phase 1 — Discovery (search → scrape):
+  sources_pending  →  {sources: [{url, title, relevance}]}  — search results found
+  source_scraped   →  {url, source, chars}                   — each URL scraped
+
+Phase 2 — Synthesis (LLM):
+  sources          →  {sources: [url, ...]}                   — final source list
+  token            →  {content: "..."}                        — individual LLM token
+  done             →  {result, sources, latency_ms}           — final answer
+
+  error            →  {content: "..."}                        — any phase
+```
+
+When `schema` is provided (structured JSON output), Phase 2 delivers the full response in a single `done` event rather than streaming tokens — structured JSON output does not benefit from token-level streaming.
+
+### CLI Default
+
+The `groktocrawl agent` command uses streaming by default, with `--sync` to opt out of streaming and fall back to the create→poll pattern. This mirrors the existing `groktocrawl answer` default (ADR-0017, v1.5.1).
+
+### Consequences
+
+**Positive:**
+
+- Web portal users see sources appear as they're discovered, then the answer streaming in real time
+- CLI users see the same live progress — URL scraping and answer generation visible immediately
+- The `answer` and `agent` endpoints now have parallel streaming interfaces
+- Integration test surface grows by one test case (modeled on `test_answer_streaming_returns_sse_events`)
+
+**Negative:**
+
+- The agent's `SYSTEM_PROMPT` (68 lines) is much richer than `ANSWER_SYSTEM_PROMPT` (10 lines) — the streaming LLM call uses the same prompt unchanged, but the token stream is longer
+- HTTP connection held for the full research duration — long-running research (60s+) should use `--sync` instead
+- Schema-based (structured JSON) requests don't get token-level streaming — the full JSON arrives in a single `done` event
+
+## Links
+
+- [ADR-0017: Grounded Q&A Endpoint](0017-grounded-qa-endpoint.md) — establishes the SSE streaming pattern and event schema
+- [ADR-0012: Webhook Delivery for Async Endpoints](0012-webhook-delivery-for-async-endpoints.md) — the background-task pattern this complements
+- Issue [#130: feat: add SSE streaming support to the agent endpoint](https://github.com/groktopus/groktocrawl/issues/130)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,5 +40,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0019 | [Intelligent Scrape Cache](0019-intelligent-scrape-cache.md) | accepted |
 | 0020 | [Proxy Support with Guardrails](0020-proxy-support-with-guardrails.md) | accepted |
 | 0021 | [Web Portal](0021-web-portal.md) | accepted |
+| 0022 | [Agent SSE Streaming](0022-agent-sse-streaming.md) | proposed |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/groktocrawl
+++ b/groktocrawl
@@ -29,7 +29,8 @@ Examples:
   groktocrawl search "raspberry pi 5" --limit 5 --json
   groktocrawl map https://docs.example.com --limit 50
   groktocrawl crawl https://docs.example.com --max-depth 2 --limit 20
-  groktocrawl agent "What are the key announcements from Google I/O 2025?"
+  groktocrawl agent "What are the key announcements from Google I/O 2025?"  (streaming, default)
+  groktocrawl agent "Research multimodal models" --sync  (non-streaming, poll for results)
   groktocrawl answer "What is the current Fed interest rate?"  (streaming, default)
   groktocrawl answer "How many moons does Jupiter have?" --sync  (wait for full answer)
 """
@@ -275,6 +276,25 @@ class Client:
         if schema:
             data["schema"] = schema
         return self._request("POST", "/agent", json_data=data)
+
+    def create_agent_stream(
+        self,
+        prompt: str,
+        urls: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Create an agent research job with SSE streaming.
+
+        Returns a dict with ``_stream`` key containing the raw streaming response.
+        """
+        data: Dict[str, Any] = {"prompt": prompt, "stream": True}
+        if urls:
+            data["urls"] = urls
+        import requests
+        url = self._url("/agent")
+        resp = requests.post(url, json=data, timeout=300, stream=True)
+        if resp.status_code >= 400:
+            raise ApiError(f"API error ({resp.status_code}): {resp.text[:500]}")
+        return {"_stream": resp}
 
     def agent_status(self, job_id: str) -> Dict[str, Any]:
         return self._request("GET", f"/agent/{job_id}")
@@ -526,48 +546,95 @@ def cmd_agent(client: Client, args: argparse.Namespace) -> None:
         return
 
     try:
-        result = client.create_agent(prompt=args.prompt, urls=args.urls, schema=None)
+        if args.sync:
+            # Non-streaming path: create job and poll
+            result = client.create_agent(prompt=args.prompt, urls=args.urls, schema=None)
+        else:
+            # Streaming path (default)
+            result = client.create_agent_stream(prompt=args.prompt, urls=args.urls)
     except ApiError as e:
         die(str(e))
 
-    job_id = result.get("id", "")
-    if not job_id:
-        die("No job ID returned")
+    if args.sync:
+        # Poll loop (non-streaming)
+        job_id = result.get("id", "")
+        if not job_id:
+            die("No job ID returned")
 
-    if args.no_poll:
-        if JSON_OUTPUT:
-            emit(f"Agent job: {job_id}", {"job_id": job_id, "status": "started"})
-        else:
-            log(f"Agent job ID: {job_id}")
-        return
-
-    log(f"Agent job {job_id} — researching...")
-    while True:
-        time.sleep(POLL_INTERVAL)
-        try:
-            status = client.agent_status(job_id)
-        except ApiError as e:
-            warn(f"Status check failed: {e}")
-            continue
-
-        s = status.get("status", "unknown")
-        if s == "completed":
-            data = status.get("data", {})
+        if args.no_poll:
             if JSON_OUTPUT:
-                emit("", {"job_id": job_id, "status": "completed", "result": data})
+                emit(f"Agent job: {job_id}", {"job_id": job_id, "status": "started"})
             else:
-                result_text = data.get("result", "(no result)")
-                sources = data.get("sources", [])
-                print(f"\n{result_text}\n")
-                if sources:
-                    print("Sources:")
-                    for src in sources:
-                        print(f"  {src}")
+                log(f"Agent job ID: {job_id}")
             return
-        elif s == "failed":
-            die(f"Agent failed: {status.get('error', 'unknown')}")
-        else:
-            info(f"  Status: {s}")
+
+        log(f"Agent job {job_id} — researching...")
+        while True:
+            time.sleep(POLL_INTERVAL)
+            try:
+                status = client.agent_status(job_id)
+            except ApiError as e:
+                warn(f"Status check failed: {e}")
+                continue
+
+            s = status.get("status", "unknown")
+            if s == "completed":
+                data = status.get("data", {})
+                if JSON_OUTPUT:
+                    emit("", {"job_id": job_id, "status": "completed", "result": data})
+                else:
+                    result_text = data.get("result", "(no result)")
+                    sources = data.get("sources", [])
+                    print(f"\n{result_text}\n")
+                    if sources:
+                        print("Sources:")
+                        for src in sources:
+                            print(f"  {src}")
+                return
+            elif s == "failed":
+                die(f"Agent failed: {status.get('error', 'unknown')}")
+            else:
+                info(f"  Status: {s}")
+    else:
+        # Streaming path: read SSE events from the stream
+        resp = result["_stream"]
+        sources_shown = False
+        full_result = ""
+        for line in resp.iter_lines(decode_unicode=True):
+            if not line or not line.startswith("data: "):
+                continue
+            data_str = line[6:].strip()
+            if data_str == "[DONE]":
+                break
+            try:
+                event = json.loads(data_str)
+                if event["type"] == "sources_pending" and not sources_shown:
+                    if event.get("sources"):
+                        log(f"Found {len(event['sources'])} sources...")
+                elif event["type"] == "source_scraped":
+                    url = event.get("url", "")
+                    chars = event.get("chars", 0)
+                    info(f"  Scraped: {url} ({chars} chars)")
+                elif event["type"] == "sources" and not sources_shown:
+                    if event.get("sources"):
+                        log("Sources:")
+                        for s in event["sources"]:
+                            log("  " + s)
+                    sources_shown = True
+                elif event["type"] == "token":
+                    full_result += event["content"]
+                    print(event["content"], end="", flush=True)
+                elif event["type"] == "done":
+                    full_result = event.get("result", full_result)
+                    print()
+                elif event["type"] == "error":
+                    die("Error: " + event["content"])
+            except json.JSONDecodeError:
+                continue
+        if JSON_OUTPUT:
+            emit("", {"result": full_result})
+        elif not sources_shown and full_result:
+            print(full_result)
 
 
 
@@ -1112,7 +1179,8 @@ def make_parser() -> argparse.ArgumentParser:
     p_agent = subparsers.add_parser("agent", help="Start an autonomous research agent")
     p_agent.add_argument("prompt", help="Research prompt/question")
     p_agent.add_argument("--urls", nargs="+", help="Seed URLs to focus research")
-    p_agent.add_argument("--no-poll", action="store_true", help="Don't poll for results")
+    p_agent.add_argument("--no-poll", action="store_true", help="Don't poll for results (sync mode only)")
+    p_agent.add_argument("--sync", action="store_true", help="Non-streaming mode (poll for results)")
 
     p_download = subparsers.add_parser("download", help="Download binary content (PDF, EPUB, image, etc.) to disk")
     p_download.add_argument("url", help="URL to download")

--- a/skills/groktocrawl/SKILL.md
+++ b/skills/groktocrawl/SKILL.md
@@ -9,8 +9,9 @@ description: >-
 license: MIT
 metadata:
   author: groktopus
-  version: "1.5.1"
+  version: "1.6.0"
   changelog:
+    "1.6.0": "Agent endpoint SSE streaming; CLI --sync flag; streaming default for agent command"
     "1.5.1": "CLI answer default changed from sync to streaming; --stream flag replaced with --sync (opt-out)"
     "1.4.0": "Add CLI subcommands for monitor (create/list/get/update/delete), parse (file to markdown), and generate-llmstxt (with async polling)"
     "1.3.3": "Add change monitoring section with active job tracking and monitor lifecycle guidance"
@@ -33,7 +34,8 @@ The canonical CLI is on PATH (`groktocrawl`).
 ```bash
 groktocrawl scrape https://example.com
 groktocrawl search "raspberry pi 5" --limit 3 --json
-groktocrawl agent "What were the key Google I/O 2025 announcements?"
+groktocrawl agent "What were the key Google I/O 2025 announcements?"  (streaming, default)
+groktocrawl agent "Research multimodal models" --sync  (non-streaming, poll for results)
 groktocrawl answer "What is the Fed rate?"
 groktocrawl answer "How tall is the Burj Khalifa?" --sync  (non-streaming, wait for full answer)
 ```
@@ -48,7 +50,7 @@ groktocrawl answer "How tall is the Burj Khalifa?" --sync  (non-streaming, wait 
 | extract | Structured data | `groktocrawl extract <url> --prompt "..."` |
 | map | URL discovery | `groktocrawl map <url> --limit 50` |
 | crawl | Site crawling | `groktocrawl crawl <url> --max-depth 3` |
-| agent | Autonomous research | `groktocrawl agent "<prompt>"` |
+| agent | Autonomous research (streaming) | `groktocrawl agent "<prompt>"` |
 | answer | Grounded Q&A (streaming) | `groktocrawl answer "<question>"` |
 | browser | Headless browser | `groktocrawl browser create --ttl 300` |
 | active | List crawl jobs | `groktocrawl active --json` |

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -410,3 +410,36 @@ def test_answer_streaming_returns_sse_events():
     assert isinstance(done_event.get("answer"), str)
     assert done_event["latency_ms"] > 0
 
+
+def test_agent_streaming_returns_sse_events():
+    """POST /v2/agent with stream:true returns SSE events."""
+    r = httpx.post(AGENT + "/v2/agent", json={
+        "prompt": "What is the pricing on the fixture site?",
+        "stream": True,
+    }, timeout=180)
+    assert r.status_code == 200
+    assert r.headers.get("content-type", "").startswith("text/event-stream")
+    body = r.text
+
+    # Should have at least a done event
+    assert "data:" in body
+    assert "[DONE]" in body
+
+    # Parse events and verify structure
+    events = []
+    for line in body.split("\n"):
+        if line.startswith("data: ") and line[6:] != "[DONE]":
+            import json
+            events.append(json.loads(line[6:]))
+
+    event_types = {e.get("type") for e in events}
+
+    # Should have: sources_pending (maybe), source_scraped events (maybe),
+    # token events (maybe), and done
+    assert "done" in event_types, f"Missing 'done' event. Types found: {event_types}"
+
+    done_event = next(e for e in events if e.get("type") == "done")
+    assert "result" in done_event
+    assert isinstance(done_event.get("result"), str)
+    assert done_event["latency_ms"] > 0
+


### PR DESCRIPTION
## Summary

Adds SSE streaming support to the agent endpoint (`POST /v2/agent`), making the agent research loop stream progress events and token output in real time. The CLI defaults to streaming with `--sync` to opt out of streaming. Includes ADR-0022 documenting the architecture decision.

## Related Issue

Closes #130

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [X] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Changes

### Server-side (agent-svc)
- **models.py** — added `stream: bool = False` field to `AgentRequest`
- **research.py** — new `run_research_stream()` generator, mirroring `run_answer_stream()`. Two-phase SSE: discovery events (`sources_pending`, `source_scraped`) then synthesis tokens. Schema-based output (structured JSON) delivers full response in the `done` event
- **api.py** — `create_agent()` route checks `body.stream`; when true, runs `run_research_stream()` inline and wraps in `StreamingResponse`. Sync path unchanged

### CLI (groktocrawl)
- **Client class** — new `create_agent_stream()` method (POSTs with `{"stream": true}`), returns raw SSE response
- **argparse** — `--sync` flag on agent subparser (opt-out of streaming)
- **cmd_agent()** — default path reads SSE events: shows source progress via `info()`, streams tokens via `print(..., flush=True)`. `--sync` path keeps existing poll loop
- **Help banner** — streaming agent example added alongside answer examples

### Artifacts
- **ADR-0022** — documents inline-vs-pubsub-vs-websocket decision, event schema, backward-compatibility contract
- **Integration test** — `test_agent_streaming_returns_sse_events()` verifies SSE event types with `stream: true`
- **AGENTS.md** — streaming section added for agent endpoint
- **CHANGELOG** — unreleased entry for agent SSE streaming

## Test Plan

- [X] Integration tests pass: `test_agent_streaming_returns_sse_events` — PASSED (35s)
- [X] Existing agent test (`test_agent_endpoints_return_job_and_status`) — PASSED
- [X] Existing answer streaming test (`test_answer_streaming_returns_sse_events`) — PASSED
- [ ] Pre-existing failures in scraper/GitHub adapter tests (unrelated to this change)
- [X] Manual verification done: SSE endpoint returns `200` with `text/event-stream`, event types include `sources_pending`, `source_scraped`, `token`, `done` (307 events)

## Checklist

- [X] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [X] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [X] I have added tests that prove my fix is effective or my feature works
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — streaming path runs inline (not async); sync path already supports webhooks

## Notes for Reviewers

- The streaming path does NOT use the background-task pattern — it runs inline in the route handler, matching `run_answer_stream()`. The existing create→poll pattern is preserved for backwards compatibility
- Schema-based (structured JSON) requests deliver the full response in the `done` event rather than streaming tokens, since JSON structured output doesn't benefit from token-level streaming
- The ADR is marked `proposed` in this PR — update to `accepted` on merge

## Demo

```bash
# Streaming (default)
groktocrawl agent "What is the pricing on the test fixture site?"

# Non-streaming (poll style)
groktocrawl agent "What is the pricing on the test fixture site?" --sync

# API-level streaming
curl -s -N -X POST http://localhost:8080/v2/agent \
  -H "Content-Type: application/json" \
  -d '{"prompt": "What is the pricing?", "stream": true}'
```

Filed by Jasper (AI agent on behalf of Magnus Hedemark)