### PR TITLE
fix: replace numpy with pure-Python dot product in semantic reranking

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -254,7 +254,6 @@ async def search(request: Request, body: SearchRequest):
         if body.retrieval_mode in ("semantic", "hybrid") and results:
             from .semantic_client import SemanticClient
             from .scraper_client import ScraperClient
-            import numpy as np
 
             semantic = SemanticClient(request.app.state.semantic_url)
             scraper = ScraperClient(request.app.state.scraper_url)
@@ -273,8 +272,8 @@ async def search(request: Request, body: SearchRequest):
                 # Embed query + document contents
                 texts = [body.query] + contents
                 embeddings = await semantic.embed(texts)
-                query_embedding = np.array(embeddings[0])
-                doc_embeddings = np.array(embeddings[1:])
+                query_embedding = embeddings[0]
+                doc_embeddings = embeddings[1:]
 
                 if body.retrieval_mode == "hybrid":
                     # Cross-encoder reranker for merged keyword+semantic scoring
@@ -287,9 +286,14 @@ async def search(request: Request, body: SearchRequest):
                     new_order = [item["index"] for item in reranked]
                     search_results = [search_results[i] for i in new_order if i < len(search_results)]
                 else:
-                    # Cosine similarity reranking
-                    similarities = np.dot(query_embedding, doc_embeddings.T)
-                    ranked_indices = np.argsort(similarities)[::-1]
+                    # Cosine similarity reranking (vectors are L2-normalized, so cosine = dot product)
+                    similarities = [
+                        sum(a * b for a, b in zip(query_embedding, doc_emb))
+                        for doc_emb in doc_embeddings
+                    ]
+                    ranked_indices = sorted(
+                        range(len(similarities)), key=lambda i: similarities[i], reverse=True
+                    )
                     search_results = [search_results[i] for i in ranked_indices if i < len(search_results)]
 
             finally:


### PR DESCRIPTION
## Summary

Agent-svc does not have `numpy` as a dependency. The semantic reranking code introduced in #142 used `np.dot()` and `np.argsort()`, causing a `ModuleNotFoundError` at runtime on the deployment target.

This fix replaces numpy with pure-Python operations:
- `np.dot(query, docs.T)` → `sum(a * b for a, b in zip(query, doc))` per document
- `np.argsort(similarities)[::-1]` → `sorted(range(len(sims)), key=lambda i: sims[i], reverse=True)`

Vectors from semantic-svc are L2-normalized, so cosine similarity = dot product. No precision loss.

## Related Issue

Fixes regression in #142

## Type of Change

- [x] 🐛 Bug fix

## Test Plan

- [x] Manual verification done — semantic search endpoint returns results on hal2000 (tested with `retrieval_mode=semantic`, limit=1)
- [ ] Integration tests pass — same gap as #142 (no local Docker)

## Checklist

- [x] My code follows the project's coding conventions
- [x] No new dependencies added

Filed by Jasper (AI agent on behalf of Magnus Hedemark)