### PR TITLE
docs: update architecture.md for Phase 1 & 2 semantic search

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,27 +7,40 @@ flowchart LR
     user("User / CLI")
     agent_api("GroktoCrawl Agent API\n[FastAPI] Port 8080")
     scraper_svc("Scraper Service\n[Python] Port 8001")
-    browser_svc("Browser Service\n[Playwright] Port 8012")
+    browser_svc("Browser Service\n[Playwright]")
+    semantic_svc("Semantic Service\n[BGE-M3 / Reranker]\nPort 8003 (internal)")
+    qdrant("Qdrant\n[Vector DB]")
     valkey("Valkey\n[Key-Value Store]")
     searxng("SearXNG\n[Search Engine]")
     llm_svc("LLM Service\n[OpenAI Compatible]")
     flare_solverr("FlareSolverr\n[Cloudflare Solver]")
+    portal_svc("Portal Service\n[Web UI] Port 8082")
+    parse_svc("Parse Service\n[Markdown Parser]")
 
     user -->|"CLI / curl / SDK"| agent_api
+    user -->|"Browser"| portal_svc
     agent_api -->|"/v2/scrape"| scraper_svc
     agent_api -->|"/v2/search"| searxng
+    agent_api -->|"embed / rerank / index"| semantic_svc
     agent_api -->|"/v2/agent"| llm_svc
     agent_api <-->|"Job status"| valkey
+    portal_svc -->|"Proxy to"| agent_api
+    semantic_svc --> qdrant
     scraper_svc --> browser_svc
     scraper_svc --> flare_solverr
     scraper_svc --> llm_svc
+    parse_svc --> llm_svc
 
     style user fill:#084,color:#fff
     style agent_api fill:#06c,color:#fff
     style scraper_svc fill:#06c,color:#fff
     style browser_svc fill:#06c,color:#fff
+    style semantic_svc fill:#06c,color:#fff
+    style portal_svc fill:#06c,color:#fff
+    style parse_svc fill:#06c,color:#fff
     style valkey fill:#963,color:#fff
     style searxng fill:#963,color:#fff
+    style qdrant fill:#963,color:#fff
     style llm_svc fill:#639,color:#fff
     style flare_solverr fill:#639,color:#fff
 ```
@@ -42,6 +55,7 @@ flowchart LR
         research["Research Agent\nresearch.py"]
         scraper_client["Scraper Client\nscraper_client.py"]
         searxng_client["SearXNG Client\nsearxng_client.py"]
+        semantic_client["Semantic Client\nsemantic_client.py"]
         webhook["Webhook Deliverer\nwebhook.py"]
     end
 
@@ -57,6 +71,14 @@ flowchart LR
         bluesky_ad["Bluesky Adapter"]
     end
 
+    subgraph semantic_svc["Semantic Service (FastAPI)"]
+        embed["POST /embed\nBGE-M3"]
+        rerank["POST /rerank\nCross-Encoder"]
+        index["POST /index\nStore in Qdrant"]
+        search_vector["POST /search/vector\nQuery Qdrant"]
+        stats["GET /index/stats"]
+    end
+
     smart_scrape --> tier1
     tier1 --> tier2
     tier2 --> tier3
@@ -67,7 +89,60 @@ flowchart LR
     adapters --> bluesky_ad
 
     agent_svc --> scraper_svc
+    agent_svc --> semantic_svc
+    semantic_svc --> qdrant[(Qdrant\nVector DB)]
 ```
+
+## Search Retrieval Pipeline
+
+GroktoCrawl supports five retrieval modes, controlled by the `retrieval_mode` field on `POST /v2/search`:
+
+| Mode | Pipeline | Latency | Phase |
+|---|---|---|---|
+| `keyword` | SearXNG only | <1s | — |
+| `semantic` | SearXNG → scrape → BGE-M3 embed → cosine rerank | 1–30s | Phase 1 |
+| `hybrid` | SearXNG → scrape → cross-encoder merge | 2–40s | Phase 1 |
+| `vector` | Qdrant only → embed query → vector search | <1s | Phase 2 |
+| `hybrid_vector` | SearXNG + Qdrant parallel → merge → dedup by URL | 1–30s | Phase 2 |
+
+```mermaid
+flowchart TD
+    Q[User Query]
+    Q --> M{retrieval_mode}
+    M -->|keyword| SRX[SearXNG]
+    M -->|semantic| SRX2[SearXNG] --> SCR2[Scrape] --> EMB2[BGE-M3 Embed] --> COS[Cosine Rerank]
+    M -->|hybrid| SRX3[SearXNG] --> SCR3[Scrape] --> XENC[Cross-Encoder Merge]
+    M -->|vector| EMB4[BGE-M3 Embed Query] --> QDR4[(Qdrant Search)]
+    M -->|hybrid_vector| PAR{Parallel}
+    PAR --> SRX5[SearXNG]
+    PAR --> EMB5[BGE-M3 Embed] --> QDR5[(Qdrant)]
+    SRX5 --> MERGE[Merge + URL Dedup]
+    QDR5 --> MERGE
+    
+    SRX --> RESP[Results]
+    COS --> RESP
+    XENC --> RESP
+    QDR4 --> RESP
+    MERGE --> RESP
+```
+
+## Indexing Pipeline
+
+Every scrape, crawl, and map operation indexes the page in Qdrant via a fire-and-forget hook:
+
+```mermaid
+flowchart TD
+    SCRAPE[Scrape / Crawl / Map<br/>complete] --> HOOK[agent-svc<br/>indexing hook]
+    HOOK --> SVC[semantic-svc<br/>POST /index]
+    SVC --> EMBED[BGE-M3 embed<br/>content[:2000]]
+    EMBED --> UPSERT[Qdrant upsert<br/>uint64 point ID from URL hash]
+    UPSERT --> CHECK{docs > 250K?}
+    CHECK -->|yes| EVICT[LRU eviction]
+    CHECK -->|no| DONE[✓ indexed]
+    EVICT --> DONE
+```
+
+Indexing is best-effort — failure never blocks the scrape/crawl job. The same URL re-indexed updates the existing vector rather than creating a duplicate.
 
 ## Available Adapters
 
@@ -75,3 +150,15 @@ flowchart LR
 |---------|--------|----------------|------|
 | YouTube | `adapters/youtube.py` | youtube_transcript_api → browser render | ADR-0001–0009 |
 | Bluesky | `adapters/bluesky.py` | AT Protocol API → browser render | ADR-0001–0009 |
+
+## Architecture Decision Records
+
+All significant architectural decisions are documented as ADRs in `docs/adr/`. See the [ADR index](adr/README.md) for the full list. Key ADRs for this architecture:
+
+| ADR | Decision |
+|-----|----------|
+| [ADR-0013](adr/0013-search-architecture-with-vertical-categories.md) | Search architecture with vertical categories |
+| [ADR-0017](adr/0017-grounded-qa-endpoint.md) | Grounded Q&A endpoint |
+| [ADR-0023](adr/0023-search-type-spectrum-fast-and-rich.md) | Search type spectrum (fast/rich) |
+| [ADR-0025](adr/0025-semantic-search-pipeline.md) | Phase 1 semantic reranking |
+| [ADR-0026](adr/0026-phase2-vector-index.md) | Phase 2 persistent vector index |

--- a/tests/test_phase2_semantic.py
+++ b/tests/test_phase2_semantic.py
@@ -1,0 +1,312 @@
+"""Integration tests for Phase 1 & 2 semantic search features.
+
+Run inside the Docker network with:
+    docker compose exec agent-svc python3 /app/tests/test_phase2_semantic.py
+
+Requires the full stack: agent-svc, semantic-svc, searxng, scraper-svc, qdrant.
+"""
+
+import os
+import time
+
+import httpx
+
+AGENT = os.getenv("AGENT_BASE_URL", "http://agent-svc:8080")
+SEMANTIC = os.getenv("SEMANTIC_BASE_URL", "http://semantic-svc:8003")
+
+
+def wait_for(url: str, path: str = "/health", timeout_s: int = 120):
+    deadline = time.time() + timeout_s
+    last_err = None
+    while time.time() < deadline:
+        try:
+            r = httpx.get(url + path, timeout=2)
+            if r.status_code == 200:
+                return r
+        except Exception as e:
+            last_err = e
+        time.sleep(2)
+    raise RuntimeError(f"Timed out waiting for {url}{path}: {last_err}")
+
+
+# ── Phase 1: Embedding & Reranking ───────────────────────────────
+
+def test_embed_endpoint_returns_1024_dim_vectors():
+    """POST /embed returns L2-normalized 1024-dim BGE-M3 vectors."""
+    resp = httpx.post(
+        SEMANTIC + "/embed",
+        json={"input": ["hello world", "test sentence"]},
+        timeout=120,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    embeddings = data["embeddings"]
+    assert len(embeddings) == 2
+    for emb in embeddings:
+        assert len(emb) == 1024
+        # L2-normalized → magnitude ≈ 1.0
+        mag = sum(x * x for x in emb) ** 0.5
+        assert 0.99 < mag < 1.01, f"Expected unit vector, got magnitude {mag}"
+
+
+def test_rerank_endpoint_ranks_relevant_higher():
+    """POST /rerank puts relevant documents before irrelevant ones."""
+    resp = httpx.post(
+        SEMANTIC + "/rerank",
+        json={
+            "query": "machine learning algorithms",
+            "documents": [
+                "how to bake a chocolate cake",
+                "supervised and unsupervised learning methods",
+                "the history of ancient Rome",
+                "neural networks and deep learning explained",
+            ],
+            "top_k": 3,
+        },
+        timeout=120,
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 3
+    # The two ML-related docs should rank above the cake and Rome docs
+    ml_indices = {1, 3}  # indices of ML docs
+    for r in results[:2]:
+        assert r["index"] in ml_indices, (
+            f"Expected ML doc in top 2, got index {r['index']}"
+        )
+
+
+# ── Phase 1: Search Retrieval Modes ──────────────────────────────
+
+def test_keyword_mode_is_default_and_backward_compatible():
+    """Keyword mode (default) returns results without semantic-svc dependency."""
+    resp = httpx.post(
+        AGENT + "/v2/search",
+        json={"query": "fixture pricing", "limit": 3},
+        timeout=120,
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert len(payload["data"]["web"]) >= 1
+    for result in payload["data"]["web"]:
+        assert "url" in result
+        assert "title" in result
+
+
+def test_semantic_retrieval_mode_returns_results():
+    """Semantic mode reranks by cosine similarity and returns results."""
+    resp = httpx.post(
+        AGENT + "/v2/search",
+        json={
+            "query": "fixture pricing information",
+            "limit": 2,
+            "retrieval_mode": "semantic",
+        },
+        timeout=300,
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert len(payload["data"]["web"]) >= 1
+    # Each result must have url and title
+    for r in payload["data"]["web"]:
+        assert r["url"], "Result missing URL"
+        assert r["title"], "Result missing title"
+
+
+def test_hybrid_retrieval_mode_returns_results():
+    """Hybrid mode cross-encodes and returns results."""
+    resp = httpx.post(
+        AGENT + "/v2/search",
+        json={
+            "query": "fixture pricing options",
+            "limit": 2,
+            "retrieval_mode": "hybrid",
+        },
+        timeout=300,
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert len(payload["data"]["web"]) >= 1
+
+
+# ── Phase 2: Vector Index ────────────────────────────────────────
+
+def test_index_endpoint_stores_and_retrieves():
+    """Index a page, then search for it by semantic similarity."""
+    # Index a distinctive test page
+    idx_resp = httpx.post(
+        SEMANTIC + "/index",
+        json={
+            "url": "https://fixture.test/unique-page-9944",
+            "title": "Quantum Computing for Distributed Systems",
+            "content": (
+                "This page discusses quantum computing algorithms applied to "
+                "distributed systems, including Shor's algorithm and Grover's "
+                "search in the context of consensus protocols and leader election."
+            ),
+        },
+        timeout=120,
+    )
+    assert idx_resp.status_code == 201
+    idx_data = idx_resp.json()
+    assert idx_data["status"] == "indexed"
+    assert "url_hash" in idx_data
+
+    # Search for it with a semantically related query
+    search_resp = httpx.post(
+        SEMANTIC + "/search/vector",
+        json={"query": "quantum algorithms for consensus", "limit": 3},
+        timeout=120,
+    )
+    assert search_resp.status_code == 200
+    results = search_resp.json()["results"]
+    assert len(results) >= 1
+    # Our indexed page should be in the results
+    urls = [r["url"] for r in results]
+    assert "https://fixture.test/unique-page-9944" in urls, (
+        f"Indexed page not found in search results: {urls}"
+    )
+
+
+def test_index_stats_reports_counts():
+    """GET /index/stats returns total_docs and max_docs."""
+    resp = httpx.get(SEMANTIC + "/index/stats", timeout=30)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_docs"] >= 1  # at least our test page
+    assert data["max_docs"] == 250000
+
+
+def test_delete_index_removes_page():
+    """DELETE /index/{url_hash} removes a page from the index."""
+    # Index a page
+    idx_resp = httpx.post(
+        SEMANTIC + "/index",
+        json={
+            "url": "https://fixture.test/delete-me-7721",
+            "title": "Temporary Page",
+            "content": "This page will be deleted.",
+        },
+        timeout=120,
+    )
+    url_hash = idx_resp.json()["url_hash"]
+
+    # Delete it
+    del_resp = httpx.delete(
+        SEMANTIC + f"/index/{url_hash}", timeout=30
+    )
+    assert del_resp.status_code == 200
+    assert del_resp.json()["status"] == "deleted"
+
+    # Verify it's gone
+    search_resp = httpx.post(
+        SEMANTIC + "/search/vector",
+        json={"query": "temporary page", "limit": 5},
+        timeout=120,
+    )
+    results = search_resp.json()["results"]
+    urls = [r["url"] for r in results]
+    assert "https://fixture.test/delete-me-7721" not in urls
+
+
+# ── Phase 2: Vector Search Modes ─────────────────────────────────
+
+def test_vector_retrieval_mode_queries_qdrant():
+    """Vector mode queries Qdrant without SearXNG."""
+    # First, index content via semantic-svc so there's something to find
+    httpx.post(
+        SEMANTIC + "/index",
+        json={
+            "url": "https://fixture.test/vector-test-3321",
+            "title": "Advanced Fixture Testing",
+            "content": (
+                "Comprehensive guide to fixture-based testing with pytest, "
+                "including parametrization, conftest.py patterns, and mock strategies."
+            ),
+        },
+        timeout=120,
+    )
+
+    resp = httpx.post(
+        AGENT + "/v2/search",
+        json={
+            "query": "pytest fixture patterns",
+            "limit": 2,
+            "retrieval_mode": "vector",
+        },
+        timeout=120,
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert len(payload["data"]["web"]) >= 1
+    # Should find our indexed fixture page
+    urls = [r["url"] for r in payload["data"]["web"]]
+    assert "https://fixture.test/vector-test-3321" in urls
+
+
+def test_hybrid_vector_mode_merges_sources():
+    """Hybrid vector mode queries SearXNG + Qdrant and merges results."""
+    resp = httpx.post(
+        AGENT + "/v2/search",
+        json={
+            "query": "pytest fixtures and testing",
+            "limit": 5,
+            "retrieval_mode": "hybrid_vector",
+        },
+        timeout=300,
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert len(payload["data"]["web"]) >= 1
+    # Results should have no duplicate URLs (dedup working)
+    urls = [r["url"] for r in payload["data"]["web"]]
+    assert len(urls) == len(set(urls)), f"Duplicate URLs found: {urls}"
+
+
+def test_reindex_same_url_updates_not_duplicates():
+    """Indexing the same URL twice updates the vector, doesn't create a duplicate."""
+    url = "https://fixture.test/reindex-test-5588"
+
+    # Index twice with different content
+    httpx.post(SEMANTIC + "/index", json={
+        "url": url, "title": "First", "content": "original content about databases",
+    }, timeout=120)
+
+    httpx.post(SEMANTIC + "/index", json={
+        "url": url, "title": "Second", "content": "updated content about graph theory",
+    }, timeout=120)
+
+    # Search — should find the page but not twice
+    resp = httpx.post(SEMANTIC + "/search/vector", json={
+        "query": "graph theory and networks", "limit": 10,
+    }, timeout=120)
+
+    results = resp.json()["results"]
+    matches = [r for r in results if r["url"] == url]
+    assert len(matches) <= 1, f"Duplicate indexed: found {len(matches)} entries for {url}"
+
+
+if __name__ == "__main__":
+    import sys
+
+    tests = [
+        fn for name, fn in sorted(globals().items())
+        if name.startswith("test_") and callable(fn)
+    ]
+    passed = 0
+    failed = 0
+    for fn in tests:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+            passed += 1
+        except Exception as e:
+            print(f"FAIL {fn.__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed, {len(tests)} total")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

Updates `docs/architecture.md` to reflect Phase 1 & 2 additions. The doc was from before semantic-svc, Qdrant, portal-svc, parse-svc, and all 5 retrieval modes existed.

### What changed

**System Context diagram:**
- Added `semantic-svc` (BGE-M3 / reranker, internal port 8003)
- Added `qdrant` (vector DB)
- Added `portal-svc` (web UI, port 8082) — existed but wasn't documented
- Added `parse-svc` (markdown parser) — existed but wasn't documented
- Added edges: agent → semantic-svc, semantic-svc → Qdrant, portal-svc → agent-svc

**Container Diagram:**
- New `semantic-svc` subgraph showing all 5 endpoints
- Added `semantic_client.py` to agent-svc

**New sections:**
- **Search Retrieval Pipeline** — table of all 5 retrieval modes with latency and phase
- **Retrieval Flow Diagram** — Mermaid flowchart showing mode routing
- **Indexing Pipeline Diagram** — fire-and-forget indexing flow
- **ADR Cross-Reference** — links to ADR-0013, 0017, 0023, 0025, 0026

## Type of Change

- [x] 📚 Documentation

Filed by Jasper (AI agent on behalf of Magnus Hedemark)