### PR TITLE
chore: pin Qdrant image and client versions, fix comment conventions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -37,13 +37,9 @@
 # VECTOR_INDEX_MAX_DOCS=250000
 
 # ── Content-Based Near-Duplicate Detection (Phase 3) ─────────────
-# Cosine similarity threshold for near-duplicate detection at index time.
-# Pages above this threshold are treated as near-duplicates (default: 0.95).
+# Cosine similarity threshold for near-duplicate detection (default: 0.95)
 # NEAR_DUP_THRESHOLD=0.95
-
-# Behavior when a near-duplicate is detected:
-#   "skip"   — don't index, return "duplicate" status (default)
-#   "update" — proceed with upsert, return "updated_duplicate" status
+# Behavior on near-duplicate: "skip" (default) | "update"
 # NEAR_DUP_MODE=skip
 
 # ── Adapters ─────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - VECTOR_INDEX_MAX_DOCS=${VECTOR_INDEX_MAX_DOCS:-250000}
 
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.18.2
     restart: unless-stopped
     volumes:
       - qdrant_data:/qdrant/storage

--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -141,8 +141,8 @@ class IndexRequest(BaseModel):
     url: str
     title: str = ""
     content: str
-    near_dup_threshold: float | None = None  # overrides env default per-request
-    near_dup_mode: str | None = None  # "skip" | "update", overrides env default
+    near_dup_threshold: float | None = None  # overrides NEAR_DUP_THRESHOLD per-request
+    near_dup_mode: str | None = None  # "skip" | "update" — overrides NEAR_DUP_MODE per-request
 
 
 class IndexResponse(BaseModel):

--- a/semantic-svc/pyproject.toml
+++ b/semantic-svc/pyproject.toml
@@ -8,5 +8,5 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
     "sentence-transformers>=3.0.0",
     "numpy>=1.26.0",
-    "qdrant-client>=1.13.0",
+    "qdrant-client>=1.13.0,<1.19.0",
 ]


### PR DESCRIPTION
## Summary

Four post-merge fixes rolled up into one PR:

1. **Pin Qdrant server** — `qdrant/qdrant:v1.18.2` instead of `:latest`. Prevents silent image drift causing the server/client version mismatch warning we saw in #157 deployment verification.

2. **Pin qdrant-client upper bound** — `qdrant-client>=1.13.0,<1.19.0`. Client 1.18.x is the latest compatible with server 1.18.x. Without the upper bound, pip could resolve to 1.19.x on rebuild and fail.

3. **Fix `.env.sample` comment convention** — Compact pipe-separated format matching project style (like `retrieval_mode`).

4. **Fix inline comments** — Reference env var names instead of vague "env default".

## Related Issue

Cleanup from PR #157 (deployment verification revealed the version mismatch).

## Type of Change

- [x] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)

## Files Changed

| File | Change |
|---|---|
| `docker-compose.yml` | `qdrant/qdrant:latest` → `qdrant/qdrant:v1.18.2` |
| `semantic-svc/pyproject.toml` | `qdrant-client>=1.13.0` → `qdrant-client>=1.13.0,<1.19.0` |
| `.env.sample` | Compact NEAR_DUP_THRESHOLD/MODE comments |
| `semantic-svc/app.py` | Inline comments reference env var names |

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
