### PR TITLE
docs: promote ADR-0029 to accepted

### DIFF
--- a/docs/adr/0029-service-level-metrics-for-semantic-svc.md
+++ b/docs/adr/0029-service-level-metrics-for-semantic-svc.md
@@ -1,6 +1,6 @@
 # ADR-0029: Service-Level Metrics for semantic-svc
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Deciders:** Magnus Hedemark, Jasper (AI Agent)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,6 +47,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0026 | [Phase 2 Semantic Search — Persistent Vector Index](0026-phase2-vector-index.md) | accepted |
 | 0027 | [Smarter Index Retention — Domain TTLs, Frequency Weighting, Access Boosting](0027-smarter-index-retention.md) | proposed |
 | 0028 | [Embedding Model Migration Path for Index Rebuilds](0028-embedding-model-migration-path.md) | proposed |
-| 0029 | [Service-Level Metrics for semantic-svc](0029-service-level-metrics-for-semantic-svc.md) | proposed |
+| 0029 | [Service-Level Metrics for semantic-svc](0029-service-level-metrics-for-semantic-svc.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
Promotes ADR-0029 (Service-Level Metrics for semantic-svc) from `proposed` to `accepted` after PR #161 was merged and deployment-verified on hal2000.

**Changes:**
- `docs/adr/0029-service-level-metrics-for-semantic-svc.md`: Status → Accepted
- `docs/adr/README.md`: ADR index table update

## Type of Change

- [x] 📚 Documentation