### PR TITLE
docs: promote ADR-0030 to accepted after deployment verification

### DIFF
--- a/docs/adr/0030-batch-vector-ingestion.md
+++ b/docs/adr/0030-batch-vector-ingestion.md
@@ -1,6 +1,6 @@
 # Batch Vector Ingestion via Qdrant gRPC
 
-* Status: proposed
+* Status: accepted
 * Deciders: magnus, jasper
 * Date: 2026-06-09
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0027 | [Smarter Index Retention — Domain TTLs, Frequency Weighting, Access Boosting](0027-smarter-index-retention.md) | proposed |
 | 0028 | [Embedding Model Migration Path for Index Rebuilds](0028-embedding-model-migration-path.md) | proposed |
 | 0029 | [Service-Level Metrics for semantic-svc](0029-service-level-metrics-for-semantic-svc.md) | accepted |
-| 0030 | [Batch Vector Ingestion via Qdrant gRPC](0030-batch-vector-ingestion.md) | proposed |
+| 0030 | [Batch Vector Ingestion via Qdrant gRPC](0030-batch-vector-ingestion.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
ADR-0030 (Batch Vector Ingestion via Qdrant gRPC) was merged in #163 and deployment-verified on hal2000. Promoting from `proposed` to `accepted`.

- `docs/adr/0030-batch-vector-ingestion.md`: `Status: proposed` → `accepted`
- `docs/adr/README.md`: index table updated