### PR TITLE
fix: use 'using' instead of 'query_vector_name' in qdrant query_points

### DIFF
--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -877,7 +877,7 @@ async def search_vector(body: VectorSearchRequest):
     hits = qdrant.query_points(
         collection_name=COLLECTION_NAME,
         query=query_embedding,
-        query_vector_name=active_nv,
+        using=active_nv,
         limit=body.limit,
     ).points
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug in `search/vector` — `qdrant.Client.query_points()` in v1.18.0 uses `using` for named vector selection, not `query_vector_name`. This caused `Internal Server Error` on every vector search query since the named vector migration (ADR-0028 / PR #160).

## Test Plan

- [ ] `curl -X POST http://localhost:8003/search/vector` returns results instead of 500