### PR TITLE
fix: run synchronous model.encode() in thread executor to unblock event loop

### DIFF
--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -675,13 +675,18 @@ async def embed(body: EmbedRequest):
     """Embed one or more texts into normalized vectors."""
     model = _get_embed_model()
     embed_start = time.time()
-    embeddings = model.encode(body.input, normalize_embeddings=True)
+    loop = asyncio.get_event_loop()
+    embeddings = await loop.run_in_executor(
+        None,
+        lambda: model.encode(body.input, normalize_embeddings=True),
+    )
+    embeddings_list = embeddings.tolist()
     embed_duration = time.time() - embed_start
     METRICS.histogram(
         "groktocrawl_index_embeddings_duration_seconds",
         "Embedding model inference latency",
     ).observe({}, embed_duration)
-    return EmbedResponse(embeddings=embeddings.tolist())
+    return EmbedResponse(embeddings=embeddings_list)
 
 
 @app.post("/rerank", response_model=RerankResponse)
@@ -725,9 +730,11 @@ async def index_page(body: IndexRequest):
         pass
 
     # Embed the content
-    embedding = model.encode(
-        body.content[:2000], normalize_embeddings=True
-    ).tolist()
+    loop = asyncio.get_event_loop()
+    embedding = await loop.run_in_executor(
+        None,
+        lambda: model.encode(body.content[:2000], normalize_embeddings=True).tolist(),
+    )
 
     # Build enriched payload
     payload = _build_index_payload(body.url, body.title, existing_payload)
@@ -791,7 +798,11 @@ async def index_batch(body: IndexBatchRequest):
     # Batch embed all content texts in one call
     contents = [p.content[:2000] for p in body.pages]
     embed_start = time.time()
-    embeddings = model.encode(contents, normalize_embeddings=True).tolist()
+    loop = asyncio.get_event_loop()
+    embeddings = await loop.run_in_executor(
+        None,
+        lambda: model.encode(contents, normalize_embeddings=True).tolist(),
+    )
     embed_duration = time.time() - embed_start
     METRICS.histogram(
         "groktocrawl_index_batch_embed_duration_seconds",
@@ -824,10 +835,13 @@ async def index_batch(body: IndexBatchRequest):
             target_name = _migration["target_model"]
             if target_name:
                 try:
-                    target_model = SentenceTransformer(target_name)
-                    target_embedding = target_model.encode(
-                        page.content[:2000], normalize_embeddings=True
-                    ).tolist()
+                    loop = asyncio.get_event_loop()
+                    target_embedding = await loop.run_in_executor(
+                        None,
+                        lambda: SentenceTransformer(target_name).encode(
+                            page.content[:2000], normalize_embeddings=True
+                        ).tolist(),
+                    )
                     target_nv = _named_vector_name(target_name)
                     vectors[target_nv] = target_embedding
                     existing_models = json.loads(payload.get("embedding_models", "[]"))
@@ -868,9 +882,11 @@ async def search_vector(body: VectorSearchRequest):
     qdrant = await _ensure_qdrant()
     model = _get_embed_model()
 
-    query_embedding = model.encode(
-        body.query, normalize_embeddings=True
-    ).tolist()
+    loop = asyncio.get_event_loop()
+    query_embedding = await loop.run_in_executor(
+        None,
+        lambda: model.encode(body.query, normalize_embeddings=True).tolist(),
+    )
 
     active_nv = _get_active_model()
 


### PR DESCRIPTION
## Summary

All five `model.encode()` calls in semantic-svc were running synchronously in async handlers, blocking uvicorn's single worker thread. During batch indexing (`POST /index/batch` with 84 pages), the entire service was unresponsive to health checks, stats queries, and any concurrent requests for the duration of the embedding (\~200-500ms).

This is the root cause of the `ReadTimeout` behavior observed when querying semantic-svc during active batch ingestion.

## Fix

Wrap each `model.encode()` call in `loop.run_in_executor()` to offload CPU-bound SentenceTransformer inference to a thread pool without blocking the asyncio event loop.

**Affected endpoints:**

| Endpoint | Change |
|---|---|
| `POST /embed` | `model.encode()` → `await loop.run_in_executor(None, lambda: model.encode())` |
| `POST /index` | Same pattern — per-page indexing |
| `POST /index/batch` | Same pattern — **primary fix target** (84-page batch) |
| `POST /index/batch` dual-write | Same pattern — target model embedding during migration |
| `POST /search/vector` | Same pattern — query embedding |

## Test Plan

- Verified on hal2000: raw TCP connects instantly while httpx timed out before fix
- Batch endpoint functional: `POST /index/batch` with 1 page returns 201
- Index stats: 117 docs across both groktop.us and magnus919.com

## Files Changed

`semantic-svc/app.py` — +29/-13 across 5 endpoints

## Related

Pre-existing bug surfaced during post-merge verification of #163. The service was working but unresponsive during batch processing.