### PR TITLE
fix: use engine: braveapi instead of engine: brave

### DIFF
--- a/searxng/settings.yml
+++ b/searxng/settings.yml
@@ -43,9 +43,12 @@ engines:
   - name: bing
     disabled: true
 
-  # Our primary search engine — requires BRAVE_API_KEY env var
+  # Override default brave engine with API key
+  # (use_default_settings: true loads a brave scraper without auth)
+  # Using engine: braveapi hits the actual Brave Search API with
+  # X-Subscription-Token auth (not scraping search.brave.com)
   - name: brave-api
-    engine: brave
+    engine: braveapi
     api_key: "${BRAVE_API_KEY}"
     shortcut: bv
     disabled: false


### PR DESCRIPTION
## Summary

`engine: brave` scraps the public Brave search website (search.brave.com) — it does not use the Brave Search API. This means it hits rate limits and CAPTCHAs immediately from container networks.

`engine: braveapi` uses the actual Brave Search API at `api.search.brave.com` with `X-Subscription-Token` auth, which works with a paid API key.

## Test Plan

- [x] Verified: direct Brave API call returns 200 with 20 results
- [x] Verified: SearXNG with `engine: brave` returns "too many requests"
- [x] Verified: SearXNG with `engine: braveapi` returns real search results
- [x] Verified: `groktocrawl search` returns results through the full stack
- [x] Verified: answer endpoint completes in 5.6s (down from 26s)

## Files Changed

`searxng/settings.yml` — +5/-2: `engine: brave` → `engine: braveapi`, with comment explaining the difference