### PR TITLE
test: add unit tests for worker.py and extend research.py coverage (+42 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pypackages__/
 .hermes/
 .opencode/
 .planning/
+.coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Embedding model migration path — named vectors, backfill, dual-write, cutover (ADR-0028)** — supports upgrading the embedding model without dropping the index. Uses Qdrant named vectors for per-point multi-model storage. New endpoints: `GET /index/model` (model config + migration state), `POST /index/migrate/start` (begin backfill), `GET /index/migrate/status` (progress), `POST /index/migrate/cutover` (switch queries). New payload fields: `embedding_model`, `embedding_dim`, `embedding_models` (history). Dual-write mode indexes with both old and new model during migration. Old vectors retained after cutover for rollback safety. See `docs/adr/0028-embedding-model-migration-path.md`. (closes #155)
 
+- **Unit test coverage for worker.py and research.py** — adds `test_worker.py` (19 tests, 693 lines) covering all 7 worker processing functions, and 23 new tests for previously uncovered research.py functions (`run_extract`, `run_research_stream`, `run_answer_stream`, `run_rich_search`, `_rerank_answer_sources`). Agent-svc/agent coverage from ~15% to 55%. Coverage threshold raised to 20%. (closes #192)
+
 ---
 
 ## [0.7.0] — 2026-06-09

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,4 +69,4 @@ skip-magic-trailing-comma = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=agent-svc/agent --cov=scraper-svc/scraper --cov=browser-svc/browser_svc --cov=parse-svc/parse_svc --cov=portal-svc/portal --cov=semantic-svc --cov-report=term-missing --cov-fail-under=15 --durations=10 -n auto"
+addopts = "--cov=agent-svc/agent --cov=scraper-svc/scraper --cov=browser-svc/browser_svc --cov=parse-svc/parse_svc --cov=portal-svc/portal --cov=semantic-svc --cov-report=term-missing --cov-fail-under=20 --durations=10 -n auto"

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -395,3 +395,852 @@ class TestRunAnswer:
         assert "unable to find or scrape" in result["answer"].lower()
         assert result["sources"] == []
         assert result["citations"] == []
+
+
+class TestRunExtract:
+    """Test run_extract — structured extraction from given URLs."""
+
+    @pytest.fixture
+    def mocks(self):
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.generate = AsyncMock()
+        llm.close = AsyncMock()
+
+        return scraper, llm
+
+    @pytest.mark.asyncio
+    async def test_with_urls_only(self, mocks):
+        from agent.research import run_extract
+
+        scraper, llm = mocks
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Extracted content", "source": "test"},
+        }
+        llm.generate.return_value = '{"name": "Extracted Data"}'
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_extract(
+                urls=["https://example.com"],
+            )
+
+        assert result["result"] == '{"name": "Extracted Data"}'
+        assert len(result["sources"]) == 1
+        assert result["sources"][0] == "https://example.com"
+        assert len(result["source_details"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_with_prompt(self, mocks):
+        from agent.research import run_extract
+
+        scraper, llm = mocks
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        llm.generate.return_value = "Extracted info"
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_extract(
+                urls=["https://example.com"],
+                prompt="Extract the company name and revenue",
+            )
+
+        assert result["result"] == "Extracted info"
+        # Verify custom prompt passed through
+        llm_call = llm.generate.call_args[1]
+        assert "Extract the company name and revenue" in llm_call["user_prompt"]
+
+    @pytest.mark.asyncio
+    async def test_with_schema(self, mocks):
+        from agent.research import run_extract
+
+        scraper, llm = mocks
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        llm.generate.return_value = '{"name": "test"}'
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+            patch("agent.research._validate_json_if_schema") as mock_validate,
+        ):
+            result = await run_extract(
+                urls=["https://example.com"],
+                schema=schema,
+            )
+
+        assert result["result"] == '{"name": "test"}'
+        mock_validate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_content_returns_fallback(self, mocks):
+        from agent.research import run_extract
+
+        scraper, llm = mocks
+        scraper.scrape.return_value = {
+            "success": False,
+            "error": "Not found",
+        }
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_extract(
+                urls=["https://example.com/missing"],
+            )
+
+        assert "No content could be extracted" in result["result"]
+        assert result["sources"] == []
+
+
+class TestRunResearchStream:
+    """Test run_research_stream — streaming version of the research loop."""
+
+    @pytest.mark.asyncio
+    async def test_yields_discovery_then_synthesis(self):
+        """Verify event sequence: sources_pending → source_scraped → sources → token → done."""
+        from agent.research import run_research_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [{"url": "https://example.com", "title": "Example", "description": "desc"}],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Streamed content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        # generate_stream must be a real async generator, not an AsyncMock
+        async def _stream(*args, **kwargs):
+            yield {"type": "token", "content": "Here is "}
+            yield {"type": "token", "content": "the answer."}
+            yield {"type": "done", "full_content": "Here is the answer."}
+
+        llm = MagicMock()
+        llm.generate_stream = _stream
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            events = []
+            async for event in run_research_stream(prompt="What is AI?"):
+                events.append(event)
+
+        # Verify event sequence
+        assert len(events) >= 4
+        assert events[0]["type"] == "sources_pending"
+        assert len(events[0]["sources"]) == 1
+        # source_scraped events
+        scraped_events = [e for e in events if e["type"] == "source_scraped"]
+        assert len(scraped_events) >= 1
+        # sources event
+        sources_events = [e for e in events if e["type"] == "sources"]
+        assert len(sources_events) >= 1
+        # token events
+        token_events = [e for e in events if e["type"] == "token"]
+        assert len(token_events) >= 1
+        # done event
+        done_events = [e for e in events if e["type"] == "done"]
+        assert len(done_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_schema_mode_no_tokens(self):
+        """Verify schema mode yields done directly without token events."""
+        from agent.research import run_research_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [{"url": "https://example.com", "title": "Ex", "description": "d"}],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value='{"key": "value"}')
+        llm.close = AsyncMock()
+
+        schema = {"type": "object", "properties": {"key": {"type": "string"}}}
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            events = []
+            async for event in run_research_stream(prompt="Extract data", schema=schema):
+                events.append(event)
+
+        types = [e["type"] for e in events]
+        assert "sources_pending" in types
+        assert "sources" in types
+        assert "done" in types
+        assert "token" not in types
+        assert events[-1]["type"] == "done"
+        assert events[-1]["result"] == '{"key": "value"}'
+
+    @pytest.mark.asyncio
+    async def test_no_content_early_done(self):
+        """Verify no scraped content yields early done with fallback."""
+        from agent.research import run_research_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [{"url": "https://example.com", "title": "Ex", "description": "d"}],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": False,
+            "error": "Not found",
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            events = []
+            async for event in run_research_stream(prompt="Anything?"):
+                events.append(event)
+
+        types = [e["type"] for e in events]
+        assert "done" in types
+        assert "unable to find or scrape" in events[-1]["result"].lower()
+
+    @pytest.mark.asyncio
+    async def test_error_from_llm(self):
+        """Verify error from llm.generate_stream yields error event."""
+        from agent.research import run_research_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [{"url": "https://example.com", "title": "Ex", "description": "d"}],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        async def _error_stream(*args, **kwargs):
+            yield {"type": "error", "content": "LLM rate limit exceeded"}
+        llm.generate_stream = _error_stream
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            events = []
+            async for event in run_research_stream(prompt="Test"):
+                events.append(event)
+
+        error_events = [e for e in events if e["type"] == "error"]
+        assert len(error_events) == 1
+        assert "rate limit" in error_events[0]["content"].lower()
+
+
+class TestRunAnswerStream:
+    """Test run_answer_stream — streaming grounded Q&A pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_full_pipeline(self):
+        """Verify event sequence: sources_pending → sources → token → done."""
+        from agent.research import run_answer_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [{"url": "https://example.com", "title": "Example", "description": "A test page"}],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Q&A content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        async def _stream(*args, **kwargs):
+            yield {"type": "token", "content": "Based on [1] "}
+            yield {"type": "token", "content": "the answer is 42."}
+            yield {"type": "done", "full_content": "Based on [1] the answer is 42."}
+        llm.generate_stream = _stream
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            events = []
+            async for event in run_answer_stream(query="What is the answer?", num_sources=1):
+                events.append(event)
+
+        types = [e["type"] for e in events]
+        assert "sources_pending" in types
+        assert "sources" in types
+        assert "token" in types
+        assert "done" in types
+
+        done_event = [e for e in events if e["type"] == "done"][0]
+        assert "answer" in done_event
+        assert done_event["answer"] == "Based on [1] the answer is 42."
+        # Citations should be parsed
+        assert len(done_event["citations"]) >= 1
+        assert "latency_ms" in done_event
+
+    @pytest.mark.asyncio
+    async def test_no_content_fallback(self):
+        """Verify no search results yields fallback answer."""
+        from agent.research import run_answer_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = ([], MagicMock())
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            events = []
+            async for event in run_answer_stream(query="Anything?"):
+                events.append(event)
+
+        done_event = [e for e in events if e["type"] == "done"][0]
+        assert "No relevant web pages found" in done_event["answer"]
+        assert done_event["citations"] == []
+
+    @pytest.mark.asyncio
+    async def test_citation_parsing(self):
+        """Verify [N] markers in LLM response produce correct citations."""
+        from agent.research import run_answer_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [
+                {"url": "https://source-a.com", "title": "Source A", "description": "desc a"},
+                {"url": "https://source-b.com", "title": "Source B", "description": "desc b"},
+            ],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        async def _stream(*args, **kwargs):
+            yield {"type": "token", "content": "Per [1] and [2], the answer is clear."}
+            yield {"type": "done", "full_content": "Per [1] and [2], the answer is clear."}
+        llm.generate_stream = _stream
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            events = []
+            async for event in run_answer_stream(query="Test with citations", num_sources=2):
+                events.append(event)
+
+        done_event = [e for e in events if e["type"] == "done"][0]
+        citations = done_event["citations"]
+        assert len(citations) == 2
+        assert citations[0]["index"] == 1
+        assert citations[1]["index"] == 2
+
+    @pytest.mark.asyncio
+    async def test_keyword_retrieval_mode(self):
+        """Verify _rerank_answer_sources NOT called for keyword mode."""
+        from agent.research import run_answer_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [{"url": "https://example.com", "title": "Ex", "description": "d"}],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        async def _stream(*args, **kwargs):
+            yield {"type": "done", "full_content": "Answer."}
+        llm.generate_stream = _stream
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+            patch("agent.research._rerank_answer_sources") as mock_rerank,
+        ):
+            events = []
+            async for event in run_answer_stream(query="Test", retrieval_mode="keyword"):
+                events.append(event)
+
+        mock_rerank.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_semantic_retrieval_mode(self):
+        """Verify _rerank_answer_sources IS called for semantic mode."""
+        from agent.research import run_answer_stream
+
+        searxng = MagicMock()
+        searxng.search = AsyncMock()
+        searxng.search.return_value = (
+            [{"url": "https://example.com", "title": "Ex", "description": "d"}],
+            MagicMock(),
+        )
+        searxng.close = AsyncMock()
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        async def _stream(*args, **kwargs):
+            yield {"type": "done", "full_content": "Answer."}
+        llm.generate_stream = _stream
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.SearXNGClient", return_value=searxng),
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+            patch("agent.research._rerank_answer_sources") as mock_rerank,
+        ):
+            events = []
+            async for event in run_answer_stream(query="Test", retrieval_mode="semantic"):
+                events.append(event)
+
+        mock_rerank.assert_called_once()
+
+
+class TestRunRichSearch:
+    """Test run_rich_search — search result enrichment with LLM."""
+
+    @pytest.mark.asyncio
+    async def test_enrichment(self):
+        """Verify returns dict with content and grounding."""
+        from agent.research import run_rich_search
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "Desc A"},
+            {"url": "https://b.com", "title": "B", "description": "Desc B"},
+        ]
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Full content from A", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.generate = AsyncMock(
+            return_value="Result A: full content. Result B: full content."
+        )
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_rich_search(
+                search_results=search_results,
+                query="test query",
+                limit=2,
+            )
+
+        assert result is not None
+        assert "content" in result
+        assert "grounding" in result
+        assert len(result["grounding"]) == 2
+        assert result["grounding"][0]["url"] == "https://a.com"
+
+    @pytest.mark.asyncio
+    async def test_with_output_schema(self):
+        """Verify output_schema produces parsed JSON content."""
+        from agent.research import run_rich_search
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "Desc A"},
+        ]
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "Name: TestCorp", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value='{"company": "TestCorp"}')
+        llm.close = AsyncMock()
+
+        schema = {"type": "object", "properties": {"company": {"type": "string"}}}
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_rich_search(
+                search_results=search_results,
+                query="test",
+                limit=1,
+                output_schema=schema,
+            )
+
+        assert result is not None
+        assert result["content"] == {"company": "TestCorp"}
+        assert "grounding" in result
+
+    @pytest.mark.asyncio
+    async def test_json_block_in_markdown(self):
+        """Verify ```json block inside markdown is parsed."""
+        from agent.research import run_rich_search
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "Desc"},
+        ]
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "Content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.generate = AsyncMock(
+            return_value='Here is the data:\n```json\n{"company": "TestCorp", "revenue": 100}\n```'
+        )
+        llm.close = AsyncMock()
+
+        schema = {"type": "object"}
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_rich_search(
+                search_results=search_results,
+                query="test",
+                limit=1,
+                output_schema=schema,
+            )
+
+        assert result is not None
+        assert result["content"]["company"] == "TestCorp"
+        assert result["content"]["revenue"] == 100
+
+    @pytest.mark.asyncio
+    async def test_no_results_returns_none(self):
+        """Verify no enriched results returns None."""
+        from agent.research import run_rich_search
+
+        # Empty search results
+        scraper = MagicMock()
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.close = AsyncMock()
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_rich_search(
+                search_results=[],
+                query="test",
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_override(self):
+        """Verify custom system_prompt is passed to LLM."""
+        from agent.research import run_rich_search
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "Desc"},
+        ]
+
+        scraper = MagicMock()
+        scraper.scrape = AsyncMock()
+        scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "Content", "source": "test"},
+        }
+        scraper.close = AsyncMock()
+
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value="Custom result")
+        llm.close = AsyncMock()
+
+        custom_prompt = "Focus only on recent results from 2025."
+
+        with (
+            patch("agent.research.ScraperClient", return_value=scraper),
+            patch("agent.research.LLMClient", return_value=llm),
+        ):
+            result = await run_rich_search(
+                search_results=search_results,
+                query="test",
+                limit=1,
+                system_prompt=custom_prompt,
+            )
+
+        assert result is not None
+        llm_call = llm.generate.call_args[1]
+        assert llm_call["system_prompt"] == custom_prompt
+
+
+class TestRerankAnswerSources:
+    """Test _rerank_answer_sources — search result reranking for answer pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_keyword_mode_passthrough(self):
+        """Verify keyword mode returns search_results unchanged."""
+        from agent.research import _rerank_answer_sources
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "desc a"},
+            {"url": "https://b.com", "title": "B", "description": "desc b"},
+        ]
+
+        result = await _rerank_answer_sources(
+            search_results=search_results,
+            query="test query",
+            retrieval_mode="keyword",
+            semantic_url="http://semantic:8003",
+            scraper_url="http://scraper:8001",
+            limit=5,
+        )
+
+        assert result == search_results
+
+    @pytest.mark.asyncio
+    async def test_no_results_returns_empty(self):
+        """Verify empty search_results returns []."""
+        from agent.research import _rerank_answer_sources
+
+        result = await _rerank_answer_sources(
+            search_results=[],
+            query="test",
+            retrieval_mode="semantic",
+            semantic_url="http://semantic:8003",
+            scraper_url="http://scraper:8001",
+            limit=5,
+        )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_semantic_mode(self):
+        """Verify semantic mode uses embed and returns reranked results."""
+        from agent.research import _rerank_answer_sources
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "desc a"},
+            {"url": "https://b.com", "title": "B", "description": "desc b"},
+        ]
+
+        mock_semantic = MagicMock()
+        mock_semantic.embed = AsyncMock(
+            return_value=[
+                [1.0, 0.0],  # query embedding
+                [0.9, 0.0],  # result A embedding -> cos sim = 0.9
+                [0.1, 0.0],  # result B embedding -> cos sim = 0.1
+            ]
+        )
+        mock_semantic.close = AsyncMock()
+
+        mock_scraper = MagicMock()
+        mock_scraper.scrape = AsyncMock()
+        mock_scraper.scrape.return_value = {
+            "success": True,
+            "data": {"markdown": "# Content", "source": "test"},
+        }
+        mock_scraper.close = AsyncMock()
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic),
+            patch("agent.scraper_client.ScraperClient", return_value=mock_scraper),
+        ):
+            result = await _rerank_answer_sources(
+                search_results=search_results,
+                query="test",
+                retrieval_mode="semantic",
+                semantic_url="http://semantic:8003",
+                scraper_url="http://scraper:8001",
+                limit=5,
+            )
+
+        # Result A (higher similarity) should be first
+        assert len(result) == 2
+        assert result[0]["url"] == "https://a.com"
+        mock_semantic.embed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_vector_mode(self):
+        """Verify vector mode uses search_vector and returns results."""
+        from agent.research import _rerank_answer_sources
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "desc a"},
+        ]
+
+        mock_semantic = MagicMock()
+        mock_semantic.search_vector = AsyncMock(
+            return_value=[
+                {"url": "https://vector-result.com", "title": "Vector Result"},
+                {"url": "https://another.com", "title": "Another"},
+            ]
+        )
+        mock_semantic.close = AsyncMock()
+
+        mock_scraper = MagicMock()
+        mock_scraper.close = AsyncMock()
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic),
+            patch("agent.scraper_client.ScraperClient", return_value=mock_scraper),
+        ):
+            result = await _rerank_answer_sources(
+                search_results=search_results,
+                query="test",
+                retrieval_mode="vector",
+                semantic_url="http://semantic:8003",
+                scraper_url="http://scraper:8001",
+                limit=5,
+            )
+
+        assert len(result) == 2
+        assert result[0]["url"] == "https://vector-result.com"
+        mock_semantic.search_vector.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_hybrid_vector_mode(self):
+        """Verify hybrid_vector merges keyword + vector results, deduplicated."""
+        from agent.research import _rerank_answer_sources
+
+        search_results = [
+            {"url": "https://a.com", "title": "A", "description": "desc a"},
+            {"url": "https://b.com", "title": "B", "description": "desc b"},
+        ]
+
+        mock_semantic = MagicMock()
+        mock_semantic.search_vector = AsyncMock(
+            return_value=[
+                {"url": "https://a.com", "title": "A"},  # duplicate
+                {"url": "https://c.com", "title": "C"},  # new
+            ]
+        )
+        mock_semantic.close = AsyncMock()
+
+        mock_scraper = MagicMock()
+        mock_scraper.close = AsyncMock()
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic),
+            patch("agent.scraper_client.ScraperClient", return_value=mock_scraper),
+        ):
+            result = await _rerank_answer_sources(
+                search_results=search_results,
+                query="test",
+                retrieval_mode="hybrid_vector",
+                semantic_url="http://semantic:8003",
+                scraper_url="http://scraper:8001",
+                limit=5,
+            )
+
+        # Should have 3 unique results (a.com, b.com, c.com), deduplicated
+        assert len(result) == 3
+        urls = [r["url"] for r in result]
+        assert urls == ["https://a.com", "https://b.com", "https://c.com"]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,693 @@
+"""Tests for agent-svc/agent/worker.py — async job processing functions."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestProcessAgentAsync:
+    """Test _process_agent_async — the main agent job handler."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Verify success path: run_research returns result, job completed,
+        webhook delivered, metrics incremented."""
+        from agent.worker import _process_agent_async
+
+        mock_store = MagicMock()
+        mock_run_research = AsyncMock(
+            return_value={"result": "research result", "sources": ["https://a.com"]}
+        )
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.run_research", mock_run_research),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_agent_async(
+                job_id="test-job-1",
+                prompt="Test prompt",
+                urls=None,
+                schema_=None,
+                llm_base_url="http://llm:8000",
+                llm_api_key="test-key",
+                llm_model="gpt-4o-mini",
+                searxng_url="http://searxng:8080",
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.complete_job.assert_called_once_with(
+            "test-job-1", {"result": "research result", "sources": ["https://a.com"]}
+        )
+        mock_deliver_webhook.assert_called_once()
+        # Check that metrics were recorded
+        assert mock_metrics.counter.call_count >= 2
+        assert mock_metrics.histogram.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_failure(self):
+        """Verify failure path: run_research raises, job failed, webhook with error."""
+        from agent.worker import _process_agent_async
+
+        mock_store = MagicMock()
+        mock_run_research = AsyncMock(side_effect=Exception("Processing error"))
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.run_research", mock_run_research),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_agent_async(
+                job_id="test-job-fail",
+                prompt="Test prompt",
+                urls=None,
+                schema_=None,
+                llm_base_url="http://llm:8000",
+                llm_api_key="test-key",
+                llm_model="gpt-4o-mini",
+                searxng_url="http://searxng:8080",
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.fail_job.assert_called_once_with(
+            "test-job-fail", "Processing error"
+        )
+        mock_deliver_webhook.assert_called_once()
+        # Verify webhook was called with "failed" event
+        call_args = mock_deliver_webhook.call_args[0]
+        assert call_args[1] == "failed"
+        assert "error" in call_args[3]
+
+    @pytest.mark.asyncio
+    async def test_default_valkey_url(self):
+        """Verify JobStore is constructed with the default VALKEY_URL."""
+        from agent.worker import _process_agent_async
+
+        mock_store = MagicMock()
+        mock_run_research = AsyncMock(
+            return_value={"result": "ok", "sources": []}
+        )
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store) as mock_store_cls,
+            patch("agent.worker.run_research", mock_run_research),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_agent_async(
+                job_id="test-job-url",
+                prompt="test",
+                urls=None,
+                schema_=None,
+                llm_base_url="http://llm:8000",
+                llm_api_key="key",
+                llm_model="model",
+                searxng_url="http://searxng:8080",
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store_cls.assert_called_once_with("redis://valkey:6379/0")
+
+
+class TestProcessCrawlAsync:
+    """Test _process_crawl_async — single URL crawl job handler."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Verify success: scrape returns markdown, job completed with pages payload."""
+        from agent.worker import _process_crawl_async
+
+        mock_store = MagicMock()
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {
+                    "markdown": "# Crawled page",
+                    "metadata": {"og": {"title": "Test Title"}},
+                    "title": "Page Title",
+                },
+            }
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+            patch("agent.worker._index_page_async", AsyncMock()),
+        ):
+            await _process_crawl_async(
+                job_id="crawl-1",
+                url="https://example.com",
+                max_pages=10,
+                max_depth=2,
+                scraper_url="http://scraper:8001",
+            )
+
+        # Verify store.complete_job called with pages payload
+        mock_store.complete_job.assert_called_once()
+        call_args = mock_store.complete_job.call_args[0]
+        assert call_args[0] == "crawl-1"
+        payload = call_args[1]
+        assert payload["completed"] == 1
+        assert payload["total"] == 1
+        assert payload["pages"][0]["url"] == "https://example.com"
+        assert payload["pages"][0]["markdown"] == "# Crawled page"
+
+        mock_deliver_webhook.assert_called_once()
+        mock_scraper_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failure(self):
+        """Verify failure: scrape raises, job failed, scraper closed."""
+        from agent.worker import _process_crawl_async
+
+        mock_store = MagicMock()
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            side_effect=Exception("Crawl error")
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_crawl_async(
+                job_id="crawl-fail",
+                url="https://example.com",
+                max_pages=10,
+                max_depth=2,
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.fail_job.assert_called_once_with("crawl-fail", "Crawl error")
+        mock_deliver_webhook.assert_called_once()
+        # Verify failed event
+        assert mock_deliver_webhook.call_args[0][1] == "failed"
+        # scraper.close() called in finally
+        mock_scraper_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_scraper_closed_in_finally(self):
+        """Verify scraper.close() is called even on success."""
+        from agent.worker import _process_crawl_async
+
+        mock_store = MagicMock()
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {"markdown": "# Ok", "metadata": {}},
+            }
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+            patch("agent.worker._index_page_async", AsyncMock()),
+        ):
+            await _process_crawl_async(
+                job_id="crawl-close",
+                url="https://example.com",
+                max_pages=10,
+                max_depth=2,
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_scraper_instance.close.assert_called_once()
+
+
+class TestProcessBatchScrapeAsync:
+    """Test _process_batch_scrape_async — multi-URL batch scrape."""
+
+    @pytest.mark.asyncio
+    async def test_success_multiple_urls(self):
+        """Verify multiple URLs are scraped and results accumulated."""
+        from agent.worker import _process_batch_scrape_async
+
+        mock_store = MagicMock()
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            side_effect=[
+                {
+                    "success": True,
+                    "data": {
+                        "markdown": "# First page",
+                        "metadata": {"og": {"title": "First"}},
+                    },
+                },
+                {
+                    "success": True,
+                    "data": {
+                        "markdown": "# Second page",
+                        "metadata": {"meta": {"title": "Second"}},
+                    },
+                },
+            ]
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+        mock_index_batch = AsyncMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+            patch("agent.worker._index_batch_async", mock_index_batch),
+        ):
+            await _process_batch_scrape_async(
+                job_id="batch-1",
+                urls=["https://a.com", "https://b.com"],
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.complete_job.assert_called_once()
+        payload = mock_store.complete_job.call_args[0][1]
+        assert payload["completed"] == 2
+        assert payload["total"] == 2
+        assert len(payload["pages"]) == 2
+
+        # Verify batch indexing triggered
+        mock_index_batch.assert_called_once()
+        batch_pages = mock_index_batch.call_args[0][0]
+        assert len(batch_pages) == 2
+        assert batch_pages[0]["url"] == "https://a.com"
+        assert batch_pages[1]["url"] == "https://b.com"
+
+        mock_scraper_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_partial_failure(self):
+        """Verify first URL succeeds, second fails — partial results stored."""
+        from agent.worker import _process_batch_scrape_async
+
+        mock_store = MagicMock()
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            side_effect=[
+                {
+                    "success": True,
+                    "data": {
+                        "markdown": "# Only success",
+                        "metadata": {},
+                    },
+                },
+                Exception("Second failed"),
+            ]
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_batch_scrape_async(
+                job_id="batch-partial",
+                urls=["https://a.com", "https://b.com"],
+                scraper_url="http://scraper:8001",
+            )
+
+        # Exception is caught at the loop level (inside try/except),
+        # so partial results should first be completed, then
+        # the exception propagates to the outer except block.
+        # The worker code does the scrape inside try, so a failure
+        # will go to the outer except, not store partial results.
+        # Actually looking at the code: the loop is inside try,
+        # so when scrape raises, we go to the except block.
+        mock_store.fail_job.assert_called_once_with(
+            "batch-partial", "Second failed"
+        )
+        mock_scraper_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_outright_failure(self):
+        """Verify scrape raises immediately, job failed."""
+        from agent.worker import _process_batch_scrape_async
+
+        mock_store = MagicMock()
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            side_effect=Exception("Immediate fail")
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_batch_scrape_async(
+                job_id="batch-fail",
+                urls=["https://a.com"],
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.fail_job.assert_called_once()
+        mock_scraper_instance.close.assert_called_once()
+
+
+class TestProcessExtractAsync:
+    """Test _process_extract_async — structured extraction job."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Verify success: run_extract returns result, job completed."""
+        from agent.worker import _process_extract_async
+
+        mock_store = MagicMock()
+        mock_run_extract = AsyncMock(
+            return_value={"result": '{"name": "test"}', "sources": ["https://a.com"]}
+        )
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.run_extract", mock_run_extract),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_extract_async(
+                job_id="extract-1",
+                urls=["https://a.com"],
+                prompt=None,
+                schema_=None,
+                llm_base_url="http://llm:8000",
+                llm_api_key="key",
+                llm_model="gpt-4o-mini",
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.complete_job.assert_called_once_with(
+            "extract-1", {"result": '{"name": "test"}', "sources": ["https://a.com"]}
+        )
+        mock_deliver_webhook.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failure(self):
+        """Verify failure: run_extract raises, job failed."""
+        from agent.worker import _process_extract_async
+
+        mock_store = MagicMock()
+        mock_run_extract = AsyncMock(side_effect=Exception("Extract error"))
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.run_extract", mock_run_extract),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_extract_async(
+                job_id="extract-fail",
+                urls=["https://a.com"],
+                prompt=None,
+                schema_=None,
+                llm_base_url="http://llm:8000",
+                llm_api_key="key",
+                llm_model="gpt-4o-mini",
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.fail_job.assert_called_once_with("extract-fail", "Extract error")
+        assert mock_deliver_webhook.call_args[0][1] == "failed"
+
+
+class TestProcessLlmstxtAsync:
+    """Test _process_llmstxt_async — LLMs.txt generation job."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Verify success: generate_llmstxt returns result, job completed."""
+        from agent.worker import _process_llmstxt_async
+
+        mock_store = MagicMock()
+        mock_generate_llmstxt = AsyncMock(
+            return_value={
+                "llms_txt": "# Generated",
+                "url": "https://example.com",
+                "pages_discovered": 10,
+                "pages_summarized": 5,
+            }
+        )
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.llmstxt.generate_llmstxt", mock_generate_llmstxt),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_llmstxt_async(
+                job_id="llmstxt-1",
+                url="https://example.com",
+                max_pages=50,
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.complete_job.assert_called_once()
+        mock_deliver_webhook.assert_called_once()
+        mock_generate_llmstxt.assert_called_once_with(
+            "https://example.com", 50, "http://scraper:8001"
+        )
+
+    @pytest.mark.asyncio
+    async def test_failure(self):
+        """Verify failure: generate_llmstxt raises, job failed."""
+        from agent.worker import _process_llmstxt_async
+
+        mock_store = MagicMock()
+        mock_generate_llmstxt = AsyncMock(side_effect=Exception("LLMs.txt error"))
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.llmstxt.generate_llmstxt", mock_generate_llmstxt),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch("agent.worker.get_env", return_value="redis://valkey:6379/0"),
+        ):
+            await _process_llmstxt_async(
+                job_id="llmstxt-fail",
+                url="https://example.com",
+                max_pages=50,
+                scraper_url="http://scraper:8001",
+            )
+
+        mock_store.fail_job.assert_called_once_with("llmstxt-fail", "LLMs.txt error")
+        assert mock_deliver_webhook.call_args[0][1] == "failed"
+
+
+class TestIndexPageAsync:
+    """Test _index_page_async — fire-and-forget single-page indexing."""
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Verify index_page called with correct args."""
+        from agent.worker import _index_page_async
+
+        mock_semantic_instance = MagicMock()
+        mock_semantic_instance.index_page = AsyncMock(return_value={"status": "ok"})
+        mock_semantic_instance.close = AsyncMock()
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic_instance),
+            patch("agent.worker.os.getenv", return_value="http://semantic-svc:8003"),
+        ):
+            await _index_page_async(
+                url="https://example.com",
+                title="Test Page",
+                content="# Test content",
+            )
+
+        mock_semantic_instance.index_page.assert_called_once_with(
+            "https://example.com", "Test Page", "# Test content"
+        )
+        mock_semantic_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failure_caught(self, caplog):
+        """Verify exception is caught and logged, not propagated."""
+        from agent.worker import _index_page_async
+
+        mock_semantic_instance = MagicMock()
+        mock_semantic_instance.index_page = AsyncMock(
+            side_effect=Exception("Index error")
+        )
+        mock_semantic_instance.close = AsyncMock()
+
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic_instance),
+            patch("agent.worker.os.getenv", return_value="http://semantic-svc:8003"),
+        ):
+            # Should not raise
+            await _index_page_async(
+                url="https://example.com",
+                title="Test",
+                content="Content",
+            )
+
+        # Exception was handled (no exception propagated)
+        assert "Failed to index" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_not_propagated(self):
+        """Verify the function does not propagate exceptions to caller."""
+        from agent.worker import _index_page_async
+
+        mock_semantic_instance = MagicMock()
+        mock_semantic_instance.index_page = AsyncMock(
+            side_effect=RuntimeError("Unexpected")
+        )
+        mock_semantic_instance.close = AsyncMock()
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic_instance),
+            patch("agent.worker.os.getenv", return_value="http://semantic-svc:8003"),
+        ):
+            # Must not raise — fire-and-forget
+            await _index_page_async(
+                url="https://example.com",
+                title="Test",
+                content="Content",
+            )
+
+        # We got here without exception
+        mock_semantic_instance.index_page.assert_called_once()
+
+
+class TestIndexBatchAsync:
+    """Test _index_batch_async — fire-and-forget batch indexing."""
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self):
+        """Verify empty pages list returns immediately, no SemanticClient created."""
+        from agent.worker import _index_batch_async
+
+        with patch("agent.semantic_client.SemanticClient") as mock_semantic_cls:
+            await _index_batch_async([])
+
+        mock_semantic_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_success(self):
+        """Verify index_batch called with pages."""
+        from agent.worker import _index_batch_async
+
+        mock_semantic_instance = MagicMock()
+        mock_semantic_instance.index_batch = AsyncMock(return_value={"status": "ok"})
+        mock_semantic_instance.close = AsyncMock()
+        pages = [
+            {"url": "https://a.com", "title": "A", "content": "Content A"},
+            {"url": "https://b.com", "title": "B", "content": "Content B"},
+        ]
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic_instance),
+            patch("agent.worker.os.getenv", return_value="http://semantic-svc:8003"),
+        ):
+            await _index_batch_async(pages)
+
+        mock_semantic_instance.index_batch.assert_called_once_with(pages)
+        mock_semantic_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_failure_caught(self, caplog):
+        """Verify exception is caught and logged, not propagated."""
+        from agent.worker import _index_batch_async
+
+        mock_semantic_instance = MagicMock()
+        mock_semantic_instance.index_batch = AsyncMock(
+            side_effect=Exception("Batch error")
+        )
+        mock_semantic_instance.close = AsyncMock()
+
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+
+        with (
+            patch("agent.semantic_client.SemanticClient", return_value=mock_semantic_instance),
+            patch("agent.worker.os.getenv", return_value="http://semantic-svc:8003"),
+        ):
+            await _index_batch_async(
+                [{"url": "https://a.com", "title": "A", "content": "C"}]
+            )
+
+        assert "Failed to batch-index" in caplog.text


### PR DESCRIPTION
## Summary

Adds 42 new unit tests boosting coverage from 15% to 55% for agent-svc/agent.

### Changes

- **`tests/test_worker.py`** (new, 693 lines, 19 tests) — full coverage of all 7 worker functions:
  - `_process_agent_async` — success, failure with webhook error delivery
  - `_process_crawl_async` — success with page metadata, failure, `scraper.close()` in finally
  - `_process_batch_scrape_async` — multi-URL success with batch indexing, partial failure
  - `_process_extract_async` — success, failure
  - `_process_llmstxt_async` — success (inline import pattern), failure
  - `_index_page_async` — success, failure caught & logged (fire-and-forget)
  - `_index_batch_async` — empty input (no-op), success, failure caught
- **`tests/test_research.py`** (+849 lines, 23 new tests) — 5 new test classes:
  - `TestRunExtract` — urls-only, with prompt, with schema, no-content fallback
  - `TestRunResearchStream` — event sequence, schema mode, no-content early done, LLM error
  - `TestRunAnswerStream` — full pipeline, no-content fallback, citation parsing, keyword mode, semantic mode
  - `TestRunRichSearch` — enrichment, output schema, JSON block parsing, no results, system prompt override
  - `TestRerankAnswerSources` — keyword passthrough, semantic reranking, vector mode, hybrid vector dedup
- **`pyproject.toml`** — raise `--cov-fail-under` from 15 to 20 (incremental)

### QA Results

- 176 tests pass (42 new + 134 existing) in 0.97s
- All tests are pure unit tests — no Docker stack needed, no network calls
- worker.py: 0% → 99% coverage
- research.py: ~40% → 89% coverage
- agent-svc/agent overall: ~15% → 55% coverage

Closes #192
