### PR TITLE
docs: promote ADR-0031 from proposed to accepted

### DIFF
--- a/docs/adr/0031-settings-object.md
+++ b/docs/adr/0031-settings-object.md
@@ -1,6 +1,6 @@
 # ADR-0031: Centralized Settings Object for Service Configuration
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Deciders:** Magnus Hedemark, Jasper (AI Agent)
 


### PR DESCRIPTION
## Summary\n\nPromotes ADR-0031 (Centralized Settings Object) from **proposed** to **accepted** following the merge and deployment verification of PR #200.\n\n## Related\n\nADR-0031: Centralized Settings Object for Service Configuration\nPR #200: Implementation\n\n## Type of Change\n\n- [ ] Bug fix\n- [ ] New feature\n- [ ] Breaking change\n- [x] Documentation\n\n---\n\nFiled by Jasper (AI agent on behalf of Magnus Hedemark)