### PR TITLE
ci: publish Docker images to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,100 @@
+# Docker Build & Publish CI
+#
+# Builds and publishes Docker images for GroktoCrawl services to ghcr.io.
+# Uses a build matrix with capped parallelism to avoid runner resource exhaustion.
+#
+# Tags:
+#   - main branch → latest, unstable
+#   - vX.Y.Z tag  → stable, X, X.Y, X.Y.Z
+#   - PR to main  → build-only (no push)
+
+name: Docker Build & Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_OWNER: groktopus
+
+jobs:
+  build-and-push:
+    name: ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: agent-svc
+            context: ./agent-svc
+            dockerfile: agent-svc/Dockerfile
+            image: ghcr.io/groktopus/groktocrawl-agent
+          - service: scraper-svc
+            context: ./scraper-svc
+            dockerfile: scraper-svc/Dockerfile
+            image: ghcr.io/groktopus/groktocrawl-scraper
+          - service: browser-svc
+            context: ./browser-svc
+            dockerfile: browser-svc/Dockerfile
+            image: ghcr.io/groktopus/groktocrawl-browser
+          - service: semantic-svc
+            context: ./semantic-svc
+            dockerfile: semantic-svc/Dockerfile
+            image: ghcr.io/groktopus/groktocrawl-semantic
+          - service: portal-svc
+            context: ./portal-svc
+            dockerfile: portal-svc/Dockerfile
+            image: ghcr.io/groktopus/groktocrawl-portal
+      max-parallel: 2
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
+            type=raw,value=unstable,enable=${{ github.ref_name == 'main' }}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{raw}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to build and publish Docker images for GroktoCrawl's 5 production services to `ghcr.io/groktopus/`. Previously, no Docker images were published — the only CI workflow validated ADR structure and architecture diagrams.

### Files Changed

| File | Action |
|------|--------|
| `.github/workflows/docker.yml` | **Create** — Docker build-and-publish workflow |

### Trigger Strategy

| Trigger | Images Built? | Images Published? | Tags |
|---------|:---:|:---:|------|
| Push to `main` | ✅ | ✅ | `latest`, `unstable` |
| Tag push `v*` | ✅ | ✅ | `stable`, `:X`, `:X.Y`, `:X.Y.Z` |
| PR to `main` | ✅ | ❌ (build only) | — |

### Build Strategy

- Matrix across 5 services, `max-parallel: 2`
- Docker Buildx with QEMU setup
- GHA cache (`type=gha`, `mode=max`)
- Standard OCI labels (source, revision, version)
- `${{ secrets.GITHUB_TOKEN }}` for ghcr.io auth — no additional secrets needed

## Related Issue

Closes #198

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] YAML syntax validated: `python3 -c "import yaml; yaml.safe_load(...)"` — passes
- [ ] Manual verification: on merge to main, verify image appears at `ghcr.io/groktopus/groktocrawl-*`
- [ ] Manual verification: on tag push, verify semver tags are applied correctly
- [ ] No existing files modified — only 1 new file created

## Checklist

- [x] My code follows the project's coding conventions (YAML formatting consistent with `architecture.yml`)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — N/A: CI-only change, no user-facing impact
- [ ] I have added tests that prove my fix is effective or my feature works — N/A: workflow syntax is validated by CI on push
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — N/A: CI workflow, not an endpoint

## Notes for Reviewers

This is a standard docker build-and-publish workflow following the same conventions as `architecture.yml` (same checkout action version, same YAML style). The matrix is capped at `max-parallel: 2` to avoid GitHub Actions runner resource exhaustion with 5 concurrent Docker builds. Fixture services (search-svc, llm-svc) and parse-svc are excluded — they're development-only or rarely changed, as noted in the issue.
