### PR TITLE
ci: add ghcr.io image references to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
   scraper-svc:
     build:
       context: ./scraper-svc
+    image: ghcr.io/groktopus/groktocrawl-scraper
     restart: unless-stopped
     ports:
       - "8001:8001"
@@ -78,6 +79,7 @@ services:
   browser-svc:
     build:
       context: ./browser-svc
+    image: ghcr.io/groktopus/groktocrawl-browser
     restart: unless-stopped
 
   flare-solverr:
@@ -94,6 +96,7 @@ services:
   semantic-svc:
     build:
       context: ./semantic-svc
+    image: ghcr.io/groktopus/groktocrawl-semantic
     restart: unless-stopped
     ports:
       - "8003:8003"
@@ -116,6 +119,7 @@ services:
   agent-svc:
     build:
       context: ./agent-svc
+    image: ghcr.io/groktopus/groktocrawl-agent
     restart: unless-stopped
     ports:
       - "${AGENT_PORT:-8080}:8080"
@@ -150,6 +154,7 @@ services:
   portal-svc:
     build:
       context: ./portal-svc
+    image: ghcr.io/groktopus/groktocrawl-portal
     restart: unless-stopped
     ports:
       - "8082:8081"


### PR DESCRIPTION
## Summary

Adds `image:` references to ghcr.io alongside the existing `build:` directives for all 5 production services in the CI workflow. Now that the Docker Build & Publish workflow is publishing images to `ghcr.io/groktopus/groktocrawl-*`, new users can `docker compose up` and pull pre-built images instead of building everything from scratch.

### Files Changed

| File | Action |
|------|--------|
| `docker-compose.yml` | **Patch** — 5 `image:` lines added |

### Per-Service

| Service | Image |
|---------|-------|
| scraper-svc | `ghcr.io/groktopus/groktocrawl-scraper` |
| browser-svc | `ghcr.io/groktopus/groktocrawl-browser` |
| semantic-svc | `ghcr.io/groktopus/groktocrawl-semantic` |
| agent-svc | `ghcr.io/groktopus/groktocrawl-agent` |
| portal-svc | `ghcr.io/groktopus/groktocrawl-portal` |

Fixture services (search-svc, llm-svc, test-site) and parse-svc are left `build:` only — they aren't published by CI.

## Test Plan

- [x] YAML syntax validated: `docker compose config` — passes
- [x] Images must exist at ghcr.io before `docker compose up` without `--build` can pull them (workflow #203 still running on main)

## Checklist

- [x] My code follows the project's coding conventions
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — ⏭️ N/A: CI-only change, no user-facing behavior change
- [ ] I have added tests — ⏭️ N/A: docker-compose.yml patch only
- [ ] If adding a new async endpoint, it accepts a webhook field — N/A
