### PR TITLE
fix: correct SlopSearX image tag — CI strips v prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       retries: 20
 
   slopsearx:
-    image: ghcr.io/magnus919/slopsearx:v0.1.1
+    image: ghcr.io/magnus919/slopsearx:0.1.1
     restart: unless-stopped
     ports:
       - "8081:8080"


### PR DESCRIPTION
CI strips the `v` prefix from tag names when generating Docker image tags (`v0.1.1` → `0.1.1`). The docker-compose.yml used `:v0.1.1` which doesn't exist on ghcr.io.