### PR TITLE
docs: promote ADR-0032 from proposed to accepted

### DIFF
--- a/docs/adr/0032-standardized-error-response-model.md
+++ b/docs/adr/0032-standardized-error-response-model.md
@@ -1,6 +1,6 @@
 # Standardized Error Response Model
 
-* Status: proposed
+* Status: accepted
 * Deciders: magnus, jasper
 * Date: 2026-06-14
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,6 +50,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0029 | [Service-Level Metrics for semantic-svc](0029-service-level-metrics-for-semantic-svc.md) | accepted |
 | 0030 | [Batch Vector Ingestion via Qdrant gRPC](0030-batch-vector-ingestion.md) | accepted |
 | 0031 | [Centralized Settings Object](0031-centralized-settings-object.md) | accepted |
-| 0032 | [Standardized Error Response Model](0032-standardized-error-response-model.md) | proposed |
+| 0032 | [Standardized Error Response Model](0032-standardized-error-response-model.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
## Summary

Promotes ADR-0032 (Standardized Error Response Model) from **proposed** to **accepted** — the implementation was merged in PR #208 and verified on the hal2000 deployment.

## Related

ADR-0032: Standardized Error Response Model
PR #208: Implementation

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ⚠️ Breaking change
- [x] 📚 Documentation

## Test Plan

- ⏭️ N/A: documentation-only change (status field update)

## Checklist

- [x] ADR status reflects actual merged state
- [x] ADR index table updated to match

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
