### PR TITLE
ci: run integration tests on self-hosted runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,3 +98,46 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  integration-tests:
+    name: Integration Tests
+    needs: build-and-push
+    runs-on: [self-hosted, groktocrawl, docker]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .env
+        run: cp .env.sample .env
+
+      - name: Start the Docker stack
+        run: docker compose up --build -d
+        timeout-minutes: 10
+
+      - name: Wait for services to be healthy
+        run: |
+          python3 -c "
+          import time, httpx
+          deadline = time.time() + 180
+          while time.time() < deadline:
+              try:
+                  r = httpx.get('http://localhost:8080/health', timeout=5)
+                  if r.status_code == 200:
+                      print('Stack healthy')
+                      break
+              except Exception:
+                  pass
+              time.sleep(3)
+          else:
+              raise RuntimeError('Timed out waiting for stack')
+          "
+
+      - name: Run integration tests
+        run: |
+          docker compose exec -T agent-svc mkdir -p /app/tests
+          docker cp tests/test_stack.py $(docker compose ps -q agent-svc):/app/tests/test_stack.py
+          docker compose exec -T agent-svc python3 /app/tests/test_stack.py
+        timeout-minutes: 10
+
+      - name: Collect logs on failure
+        if: failure()
+        run: docker compose logs --tail 50


### PR DESCRIPTION
## Summary

Adds an `integration-tests` job that runs on the self-hosted saru runner after the Docker build matrix completes. This ensures every PR's code is verified against a running Docker stack before merging.

## Changes

| File | Action | Details |
|------|--------|---------|
| `.github/workflows/docker.yml` | **Patch** | Added `integration-tests` job (5 steps) |

### Integration Test Flow

1. Checkout code on saru
2. `cp .env.sample .env`
3. `docker compose up --build -d` — starts the full stack from freshly-built images
4. Python health-check loop — waits up to 180s for all services
5. `docker cp` test file into agent-svc container, then `docker compose exec` to run `test_stack.py`
6. On failure: `docker compose logs --tail 50`

### Labels

The runner is configured with labels: `self-hosted`, `groktocrawl`, `docker` — targeting only this repo's workflows.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ⚠️ Breaking change
- [ ] 📚 Documentation
- [x] ⚡ CI/DevOps

## Test Plan

- [ ] ⏭️ CI-only change — will verify on this PR's CI run after merge

## Checklist

- [x] Workflow syntax validated — `python3 -c "import yaml; yaml.safe_load(open(...))"` passes
- [ ] Runner must be online at saru (verified: active)

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
