### PR TITLE
feat: add search volume controls to agent-svc

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -143,3 +143,13 @@
 # SCRAPER_POLITENESS_CRAWL_DELAY=1.0
 # TTL for cached robots.txt (seconds, default: 3600)
 # SCRAPER_POLITENESS_ROBOTS_TTL=3600
+
+# ── Search Volume Controls ──────────────────────────────────────
+# Maximum number of SearXNG search calls a single /answer or /agent
+# request is allowed to make. Prevents runaway Brave API consumption.
+# AGENT_MAX_SEARCHES_PER_REQUEST=5
+#
+# Per-client sliding-window rate limit in the format <count>/<window>s.
+# Limits how many search calls a single client IP can make within the
+# window. Uses Valkey-backed INCR/EXPIRE for atomic counting.
+# AGENT_SEARCH_RATE_LIMIT=10/60s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Search volume controls for agent-svc (ADR-0033)** — two independent mechanisms to prevent runaway Brave API consumption: (1) per-request max-searches cap (`AGENT_MAX_SEARCHES_PER_REQUEST`, default 5) enforced inside `SearXNGClient` before each search call, raises `RateLimitedError` (429) when exceeded; (2) per-client sliding-window rate limit (`AGENT_SEARCH_RATE_LIMIT`, default `10/60s`) using Valkey `INCR`/`EXPIRE`. New `X-Search-Budget` and `X-Search-Rate-Remaining` response headers. Search volume observable via new `search_calls_total` metrics counter. Backward compatible — existing callers see 429s only if they exceed limits. No new dependencies. See `docs/adr/0033-search-volume-controls.md`. (closes #213)
+
 - **Project Gutenberg adapter** — extracts books as chapter-structured markdown. Three-tier fallback chain: EPUB → plain text → generic pipeline. Zero new dependencies. Enriches metadata via Gutendex API (title, author, subjects, language). Registered at priority 200. See `scraper-svc/scraper/adapters/gutenberg.py`. (closes #181)
 
 - **Batch vector ingestion via Qdrant gRPC (ADR-0030)** — adds `POST /index/batch` to semantic-svc for batched embedding and Qdrant upsert. Batch scrape and crawl workers now accumulate pages and fire a single batch call instead of N per-page calls. Expected: 500-page crawl indexing drops from ~50s to ~250ms (200x). New tests: `test_batch_index_endpoint`, `test_batch_index_empty`. Legacy flat-vector Qdrant collections auto-migrate to named vectors on startup. See `docs/adr/0030-batch-vector-ingestion.md`. (closes #154)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import httpx
 from bs4 import BeautifulSoup
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Response
 from rq import Queue
 
 from common.url import extract_domain, is_same_origin
@@ -71,6 +71,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _get_client_ip(request: Request) -> str:
+    """Extract the client IP address from the request.
+
+    Respects the ``X-Forwarded-For`` header for reverse-proxy deployments.
+    Falls back to ``request.client.host`` when the header is absent.
+    """
+    xff = request.headers.get("X-Forwarded-For")
+    if xff:
+        return xff.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
 def _enqueue(queue: Queue, func: str, **kwargs: Any) -> None:
     queue.enqueue(func, **kwargs)
 
@@ -126,7 +140,31 @@ async def scrape(request: Request, body: ScrapeRequest):
 
 
 @router.post("/v2/agent", response_model=AgentCreateResponse)
-async def create_agent(request: Request, body: AgentRequest):
+async def create_agent(request: Request, body: AgentRequest, response: Response):
+    # ── Per-client rate limit check ────────────────────────────
+    client_ip = _get_client_ip(request)
+    rate_limiter = request.app.state.rate_limiter
+    allowed, rate_remaining = await rate_limiter.check(f"{client_ip}:search")
+    if not allowed:
+        from .exceptions import RateLimitedError
+        from .metrics import METRICS
+
+        METRICS.counter("search_calls_total", "Total search calls", ["status"]).inc(
+            {"status": "rate_limited"}
+        )
+        raise RateLimitedError(
+            detail=f"Per-client rate limit exceeded ({rate_limiter.limit}/{rate_limiter.window}s)"
+        )
+
+    max_searches = request.app.state.max_searches_per_request
+
+    # ── Metrics ──────────────────────────────────────────────────
+    from .metrics import METRICS
+
+    METRICS.counter("search_calls_total", "Total search calls", ["status"]).inc(
+        {"status": "allowed"}
+    )
+
     # Streaming path — run inline, return SSE
     if body.stream:
         from fastapi.responses import StreamingResponse
@@ -144,6 +182,7 @@ async def create_agent(request: Request, body: AgentRequest):
                 llm_api_key=request.app.state.llm_api_key,
                 llm_model=request.app.state.llm_model,
                 requested_model=body.model if body.model != "default" else None,
+                max_searches_per_request=max_searches,
             ):
                 import json
 
@@ -161,7 +200,13 @@ async def create_agent(request: Request, body: AgentRequest):
                     yield f"data: {json.dumps({'type': 'error', 'content': event['content']})}\n\n"
             yield "data: [DONE]\n\n"
 
-        return StreamingResponse(event_stream(), media_type="text/event-stream")
+        headers = {
+            "X-Search-Budget": f"{max_searches}/{max_searches}",
+            "X-Search-Rate-Remaining": f"{rate_remaining}/{rate_limiter.limit}",
+        }
+        return StreamingResponse(
+            event_stream(), media_type="text/event-stream", headers=headers
+        )
 
     # Sync path — create job, process in background
     store: JobStore = request.app.state.job_store
@@ -189,6 +234,11 @@ async def create_agent(request: Request, body: AgentRequest):
             webhook_config=body.webhook,
             requested_model=body.model,
         )
+    )
+
+    response.headers["X-Search-Budget"] = f"{max_searches}/{max_searches}"
+    response.headers["X-Search-Rate-Remaining"] = (
+        f"{rate_remaining}/{rate_limiter.limit}"
     )
     return AgentCreateResponse(id=job_id)
 
@@ -495,12 +545,36 @@ async def search(request: Request, body: SearchRequest):
 
 
 @router.post("/v2/answer", response_model=AnswerResponse)
-async def answer(request: Request, body: AnswerRequest):
+async def answer(request: Request, body: AnswerRequest, response: Response):
     """Grounded Q&A: search → scrape → LLM → citations.
 
     Synchronous single-turn endpoint. For streaming, set ``stream: true``
     to receive Server-Sent Events.
     """
+    # ── Per-client rate limit check ────────────────────────────
+    client_ip = _get_client_ip(request)
+    rate_limiter = request.app.state.rate_limiter
+    allowed, rate_remaining = await rate_limiter.check(f"{client_ip}:search")
+    if not allowed:
+        from .exceptions import RateLimitedError
+        from .metrics import METRICS
+
+        METRICS.counter("search_calls_total", "Total search calls", ["status"]).inc(
+            {"status": "rate_limited"}
+        )
+        raise RateLimitedError(
+            detail=f"Per-client rate limit exceeded ({rate_limiter.limit}/{rate_limiter.window}s)"
+        )
+
+    max_searches = request.app.state.max_searches_per_request
+
+    # ── Metrics ──────────────────────────────────────────────────
+    from .metrics import METRICS
+
+    METRICS.counter("search_calls_total", "Total search calls", ["status"]).inc(
+        {"status": "allowed"}
+    )
+
     if body.stream:
         from fastapi.responses import StreamingResponse
 
@@ -519,6 +593,7 @@ async def answer(request: Request, body: AnswerRequest):
                 llm_api_key=request.app.state.llm_api_key,
                 llm_model=request.app.state.llm_model,
                 requested_model=body.model if body.model != "default" else None,
+                max_searches_per_request=max_searches,
             ):
                 if event["type"] == "sources_pending":
                     import json
@@ -542,7 +617,13 @@ async def answer(request: Request, body: AnswerRequest):
                     yield f"data: {json.dumps({'type': 'error', 'content': event['content']})}\n\n"
             yield "data: [DONE]\n\n"
 
-        return StreamingResponse(event_stream(), media_type="text/event-stream")
+        headers = {
+            "X-Search-Budget": f"{max_searches}/{max_searches}",
+            "X-Search-Rate-Remaining": f"{rate_remaining}/{rate_limiter.limit}",
+        }
+        return StreamingResponse(
+            event_stream(), media_type="text/event-stream", headers=headers
+        )
 
     # Sync path
     from .research import run_answer
@@ -559,6 +640,11 @@ async def answer(request: Request, body: AnswerRequest):
         llm_api_key=request.app.state.llm_api_key,
         llm_model=request.app.state.llm_model,
         requested_model=body.model if body.model != "default" else None,
+        max_searches_per_request=max_searches,
+    )
+    response.headers["X-Search-Budget"] = f"{max_searches}/{max_searches}"
+    response.headers["X-Search-Rate-Remaining"] = (
+        f"{rate_remaining}/{rate_limiter.limit}"
     )
     return AnswerResponse(
         success=True,

--- a/agent-svc/agent/app.py
+++ b/agent-svc/agent/app.py
@@ -23,6 +23,7 @@ from .health import check_all
 from .llm import LLMClient
 from .metrics import METRICS
 from .models import ErrorDetail, ErrorResponse
+from .rate_limiter import SlidingWindowRateLimiter
 from .scraper_client import ScraperClient
 from .searxng_client import SearXNGClient
 from .settings import load_settings
@@ -111,6 +112,15 @@ def create_app() -> FastAPI:
         model=settings.llm_model,
     )
 
+    # ── Rate limiter ──────────────────────────────────────────────
+    rate_limit_count, rate_limit_window = SlidingWindowRateLimiter.parse_limit(
+        settings.search_rate_limit
+    )
+    rate_limiter = SlidingWindowRateLimiter(conn, rate_limit_count, rate_limit_window)
+
+    # ── Metrics initialization ────────────────────────────────────
+    METRICS.counter("search_calls_total", "Total search calls", ["status"])
+
     # ── App state ───────────────────────────────────────────────
     app.state.redis = conn
     app.state.queue = queue
@@ -125,6 +135,8 @@ def create_app() -> FastAPI:
     app.state.llm_api_key = settings.llm_api_key
     app.state.llm_model = settings.llm_model
     app.state.semantic_url = settings.semantic_url
+    app.state.rate_limiter = rate_limiter
+    app.state.max_searches_per_request = settings.max_searches_per_request
 
     # ── Middleware: request_id ───────────────────────────────────
     @app.middleware("http")

--- a/agent-svc/agent/exceptions.py
+++ b/agent-svc/agent/exceptions.py
@@ -56,3 +56,9 @@ class SearchError(GroktoCrawlError):
     status_code = 502
     error_code = "SEARCH_ERROR"
     detail = "Search failed"
+
+
+class RateLimitedError(GroktoCrawlError):
+    status_code = 429
+    error_code = "RATE_LIMITED"
+    detail = "Rate limit exceeded"

--- a/agent-svc/agent/rate_limiter.py
+++ b/agent-svc/agent/rate_limiter.py
@@ -1,0 +1,80 @@
+"""Sliding-window rate limiter using Valkey/Redis.
+
+Usage::
+
+    limiter = SlidingWindowRateLimiter(redis, limit=10, window_seconds=60)
+    allowed, remaining = await limiter.check("client_ip:search")
+"""
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class SlidingWindowRateLimiter:
+    """Sliding-window rate limiter backed by Valkey INCR/EXPIRE.
+
+    Tracks request counts per key within a fixed time window. Counts
+    for the current window slot are maintained atomically via Redis
+    INCR. The key expires after ``window * 2`` seconds to avoid
+    lingering keys.
+
+    The limiter **fails open** — if Redis is unreachable, ``check()``
+    returns ``(True, self.limit)`` so that transient infrastructure
+    issues do not block legitimate traffic.
+    """
+
+    def __init__(self, redis, limit: int, window_seconds: int):
+        self.redis = redis
+        self.limit = limit
+        self.window = window_seconds
+
+    async def check(self, key: str) -> tuple[bool, int]:
+        """Check whether *key* is within the rate limit.
+
+        Args:
+            key: Unique identifier for the client (e.g. ``client_ip:search``).
+
+        Returns:
+            Tuple of ``(allowed, remaining)`` where *allowed* is
+            ``True`` if the request is within the limit, and *remaining*
+            is the number of requests still available in the current
+            window.
+        """
+        now = int(time.time())
+        window_key = f"rate_limit:search:{key}:{now // self.window}"
+        try:
+            count = self.redis.incr(window_key)
+            if count == 1:
+                self.redis.expire(window_key, self.window * 2)
+            remaining = max(0, self.limit - count)
+            return count <= self.limit, remaining
+        except Exception as e:
+            logger.warning("Rate limiter check failed: %s", e)
+            return True, self.limit  # Fail open
+
+    @staticmethod
+    def parse_limit(limit_str: str) -> tuple[int, int]:
+        """Parse a limit string like ``"10/60s"`` into ``(limit, window_seconds)``.
+
+        Supports suffixes ``s`` (seconds). If no suffix is present,
+        the value is treated as seconds.
+
+        Raises:
+            ValueError: If the string cannot be parsed.
+        """
+        parts = limit_str.split("/")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid rate limit format: {limit_str!r} — expected 'count/window' (e.g. '10/60s')"
+            )
+        limit = int(parts[0])
+        window_str = parts[1].strip()
+        window_str = window_str.removesuffix("s")
+        window = int(window_str)
+        if limit <= 0 or window <= 0:
+            raise ValueError(
+                f"Rate limit values must be positive: limit={limit}, window={window}"
+            )
+        return limit, window

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -94,9 +94,10 @@ async def run_research(
     llm_api_key: str = "",
     llm_model: str = "gpt-4o-mini",
     requested_model: str | None = None,
+    max_searches_per_request: int = 5,
 ) -> dict:
     """Execute the research loop: search → scrape → think → answer."""
-    searxng = SearXNGClient(searxng_url)
+    searxng = SearXNGClient(searxng_url, max_searches=max_searches_per_request)
     scraper = ScraperClient(scraper_url)
     effective_model = (
         requested_model
@@ -176,6 +177,7 @@ async def run_research_stream(
     llm_api_key: str = "",
     llm_model: str = "gpt-4o-mini",
     requested_model: str | None = None,
+    max_searches_per_request: int = 5,
 ):
     """Streaming version of run_research. Yields SSE-suitable dicts.
 
@@ -193,7 +195,7 @@ async def run_research_stream(
 
     start = time.monotonic()
 
-    searxng = SearXNGClient(searxng_url)
+    searxng = SearXNGClient(searxng_url, max_searches=max_searches_per_request)
     scraper = ScraperClient(scraper_url)
     effective_model = (
         requested_model
@@ -667,6 +669,7 @@ async def run_answer(
     llm_api_key: str = "",
     llm_model: str = "gpt-4o-mini",
     requested_model: str | None = None,
+    max_searches_per_request: int = 5,
 ) -> dict:
     """Run a grounded Q&A pipeline: search → scrape → LLM → citations.
 
@@ -677,7 +680,7 @@ async def run_answer(
 
     start = time.monotonic()
 
-    searxng = SearXNGClient(searxng_url)
+    searxng = SearXNGClient(searxng_url, max_searches=max_searches_per_request)
     scraper = ScraperClient(scraper_url)
     effective_model = (
         requested_model
@@ -820,6 +823,7 @@ async def run_answer_stream(
     llm_api_key: str = "",
     llm_model: str = "gpt-4o-mini",
     requested_model: str | None = None,
+    max_searches_per_request: int = 5,
 ):
     """Streaming version of run_answer. Yields SSE-suitable dicts.
 
@@ -833,7 +837,7 @@ async def run_answer_stream(
 
     start = time.monotonic()
 
-    searxng = SearXNGClient(searxng_url)
+    searxng = SearXNGClient(searxng_url, max_searches=max_searches_per_request)
     scraper = ScraperClient(scraper_url)
     effective_model = (
         requested_model

--- a/agent-svc/agent/searxng_client.py
+++ b/agent-svc/agent/searxng_client.py
@@ -27,6 +27,7 @@ class SearchHealth:
     degraded: bool = False
     detail: str = ""
 
+
 # ── Firecrawl v2 → SearXNG category translation ────────────────
 # Maps Firecrawl v2 search dimensions (sources, categories) to
 # SearXNG-native category names. Unknown values pass through for
@@ -54,12 +55,18 @@ _CATEGORIES_MAP = {
 class SearXNGClient:
     """Client for the SearXNG search engine JSON API."""
 
-    def __init__(self, base_url: str = "http://searxng:8080"):
+    def __init__(self, base_url: str = "http://searxng:8080", max_searches: int = 5):
         self.base_url = base_url.rstrip("/")
         self._client = httpx.AsyncClient(
             timeout=15,
-            headers={"User-Agent": "GroktoCrawl/0.1", "Accept": "text/html,application/json", "X-Forwarded-For": "127.0.0.1"},
+            headers={
+                "User-Agent": "GroktoCrawl/0.1",
+                "Accept": "text/html,application/json",
+                "X-Forwarded-For": "127.0.0.1",
+            },
         )
+        self._search_count = 0
+        self._max_searches = max_searches
 
     @staticmethod
     def _translate(
@@ -83,7 +90,7 @@ class SearXNGClient:
                 mapped = _CATEGORIES_MAP.get(c, c)
                 if mapped and mapped not in result:
                     result.append(mapped)
-        return result if result else ["general"]
+        return result or ["general"]
 
     @staticmethod
     def _parse_engine_health(data: dict, results: list[dict]) -> SearchHealth:
@@ -95,18 +102,12 @@ class SearXNGClient:
         """
         engines = data.get("engines", [])
         engines_total = len(engines)
-        engines_responding = sum(
-            1 for e in engines if e.get("results", 0) > 0
-        )
+        engines_responding = sum(1 for e in engines if e.get("results", 0) > 0)
 
         empty_result = bool(
-            engines_responding > 0
-            and not any(r.get("url") for r in results)
+            engines_responding > 0 and not any(r.get("url") for r in results)
         )
-        degraded = bool(
-            engines_total > 0
-            and engines_responding < engines_total / 2
-        )
+        degraded = bool(engines_total > 0 and engines_responding < engines_total / 2)
 
         # Build a human-readable detail string
         if engines_total == 0:
@@ -117,10 +118,7 @@ class SearXNGClient:
                 f"returned results"
             )
         elif empty_result:
-            detail = (
-                f"All {engines_total} engines responded but returned "
-                f"no results"
-            )
+            detail = f"All {engines_total} engines responded but returned no results"
         else:
             detail = (
                 f"Healthy: {engines_responding}/{engines_total} engines "
@@ -148,10 +146,28 @@ class SearXNGClient:
         ``sources`` and ``categories`` are merged via ``_translate()`` before
         being passed to SearXNG.
 
+        Enforces a per-request search budget. Raises ``RateLimitedError``
+        when the budget is exhausted.
+
         Returns a tuple of (results, health) where:
         - results: list of dicts with keys: url, title, description, engine.
         - health: SearchHealth dataclass with engine status information.
         """
+        # ── Per-request search budget check ────────────────────
+        if self._search_count >= self._max_searches:
+            from .exceptions import RateLimitedError
+
+            raise RateLimitedError(
+                detail=(
+                    f"Search budget exceeded: {self._search_count}/{self._max_searches}"
+                ),
+                details={
+                    "budget_used": self._search_count,
+                    "budget_max": self._max_searches,
+                },
+            )
+        self._search_count += 1
+
         effective_categories = self._translate(sources, categories)
         params = {
             "q": query,
@@ -167,18 +183,24 @@ class SearXNGClient:
                 params=params,
             )
             if resp.status_code != 200:
-                logger.warning("SearXNG returned %d: %s", resp.status_code, resp.text[:200])
-                return [], SearchHealth(detail=f"SearXNG returned HTTP {resp.status_code}")
+                logger.warning(
+                    "SearXNG returned %d: %s", resp.status_code, resp.text[:200]
+                )
+                return [], SearchHealth(
+                    detail=f"SearXNG returned HTTP {resp.status_code}"
+                )
 
             data = resp.json()
             results = []
             for item in data.get("results", []):
-                results.append({
-                    "url": item.get("url", ""),
-                    "title": item.get("title", ""),
-                    "description": item.get("content", ""),
-                    "engine": item.get("engine", ""),
-                })
+                results.append(
+                    {
+                        "url": item.get("url", ""),
+                        "title": item.get("title", ""),
+                        "description": item.get("content", ""),
+                        "engine": item.get("engine", ""),
+                    }
+                )
 
             results = results[:limit]
 

--- a/agent-svc/agent/settings.py
+++ b/agent-svc/agent/settings.py
@@ -22,6 +22,10 @@ class AgentSettings(BaseModel):
     llm_enable_thinking: bool = Field(default=False, alias="LLM_ENABLE_THINKING")
     api_key: str = Field(default="", alias="API_KEY")
     webhook_secret: str = Field(default="", alias="WEBHOOK_SECRET")
+    max_searches_per_request: int = Field(
+        default=5, alias="AGENT_MAX_SEARCHES_PER_REQUEST"
+    )
+    search_rate_limit: str = Field(default="10/60s", alias="AGENT_SEARCH_RATE_LIMIT")
 
 
 @functools.cache

--- a/docs/adr/0033-search-volume-controls.md
+++ b/docs/adr/0033-search-volume-controls.md
@@ -1,0 +1,194 @@
+# ADR-0033: Search Volume Controls for Agent Service
+
+**Status:** Proposed
+
+**Deciders:** Magnus Hedemark, Jasper (AI Agent)
+
+**Date:** 2026-06-14
+
+## Context
+
+GroktoCrawl agents can reflexively call search 5+ times per user turn via the `answer` and `agent` endpoints. Each search call burns a Brave API query (paid, $5/1K). During heavy research sessions, a single conversation can consume 50+ Brave queries in minutes — the June 9-10 spike burned 3,927 queries in 48 hours, eating 78% of the monthly $25 budget.
+
+The SlopSearX downstream cache alone cannot solve this because most agent queries are long-tail unique. The fix needs to live at the agent-svc level where search volume is initiated.
+
+Currently:
+- `/v2/answer` → `run_answer()` creates a `SearXNGClient` and calls `.search()` once per HTTP request
+- `/v2/agent` (streaming) → `run_research_stream()` creates a `SearXNGClient` and calls `.search()` once
+- `/v2/agent` (async job) → `_process_agent_async()` → `run_research()` → `.search()` once
+- `/v2/search` → creates a `SearXNGClient` and calls `.search()` once
+- `/v1/search` → creates a `SearXNGClient` and calls `.search()` once
+
+Each user-facing HTTP request currently produces exactly one search call per endpoint function. However, future research loops or recursive agent behavior could multiply this. The controls need to be in place before those patterns arrive.
+
+## Decision Drivers
+
+1. **Zero new infrastructure** — Valkey (redis-py) is already available; no new databases or services.
+2. **Zero new dependencies** — All mechanisms use existing imports (redis, contextvars, threading).
+3. **Backward-compatible** — Existing callers see 429s only if they exceed caps.
+4. **Configurable without code change** — Caps and limits driven by env vars.
+5. **Observable** — Every search call is countable in metrics; callers see remaining budget in response headers.
+6. **Decoupled per-request and per-client controls** — Two independent mechanisms with different enforcement points.
+
+## Considered Options
+
+| Option | Approach | Decision | Rationale |
+|--------|----------|----------|-----------|
+| **A: Valkey sliding window + contextvar per-request counter** | ContextVar tracks search count per request; Valkey tracks sliding window per client IP | ✅ Chosen | No new dependencies; uses existing Redis/Valkey; contextvar is request-scoped without middleware changes |
+| **B: Third-party rate limiter (slowapi, pyrate-limiter)** | Library-provided decorators and middleware | ❌ Rejected | Adds dependency; decorator approach doesn't integrate with internal `SearXNGClient` calls; less control over budget tracking |
+| **C: Proxy-level rate limiting (nginx, Traefik)** | Rate limit at reverse proxy before requests reach agent-svc | ❌ Rejected | Can't distinguish search vs scrape requests; can't track per-search budget within a request |
+| **D: In-memory only** | Use process-local dicts for rate tracking | ❌ Rejected | Doesn't survive restart; doesn't share across multiple agent-svc workers |
+
+## Decision Outcome
+
+Chosen option: **A — Valkey sliding window + contextvar per-request counter**, for the following architecture:
+
+### Two independent mechanisms
+
+**1. Per-request search cap** — Counts searches within a single HTTP request. Enforced inside `SearXNGClient.search()` via a `contextvars.ContextVar`. A `max_searches` limit is set at the client level (or via settings). When a single request tries to make more than `AGENT_MAX_SEARCHES_PER_REQUEST` search calls, a `RateLimitedError` is raised.
+
+**2. Per-client sliding-window rate limit** — Counts search calls from a client IP over a 60-second sliding window. Enforced as a FastAPI dependency on search/answer/agent endpoints, using Valkey `INCR` + `EXPIRE` for the window tracking. Returns 429 when exceeded.
+
+### New Components
+
+1. **`agent-svc/agent/rate_limiter.py`** — Sliding window rate limiter using Valkey
+2. **`RateLimitedError`** in `exceptions.py` — New exception class (429, code=RATE_LIMITED)
+3. **New settings** in `settings.py`:
+   - `AGENT_MAX_SEARCHES_PER_REQUEST: int = 5`
+   - `AGENT_SEARCH_RATE_LIMIT: str = "10/60s"`
+
+### Integration Points
+
+| Component | What changes | How |
+|-----------|-------------|-----|
+| `SearXNGClient.search()` | Check per-request cap via contextvar | Before HTTP call, check contextvar search count < max; raise `RateLimitedError` if exceeded |
+| `api.py` (answer, agent endpoints) | Initialize contextvar + check per-client rate | Set contextvar to 0; check Valkey sliding window before dispatching |
+| `worker.py` `_process_agent_async()` | Initialize contextvar for background jobs | Set contextvar to 0; no per-client rate check (background jobs have no client IP) |
+| `metrics.py` | Add search call counters | `search_calls_total{status="allowed\|rate_limited"}`, per-endpoint counts |
+| `api.py` response handlers | Add budget response headers | `X-Search-Budget: remaining/max`, `X-Search-Rate-Remaining: remaining/window` |
+
+### Per-Request Max-Searches: ContextVar Pattern
+
+```python
+import contextvars
+
+_search_count: contextvars.ContextVar[int] = contextvars.ContextVar("search_count", default=0)
+
+def reset_search_count(count: int = 0):
+    _search_count.set(count)
+
+async def check_search_budget(max_searches: int):
+    current = _search_count.get()
+    if current >= max_searches:
+        raise RateLimitedError(
+            detail=f"Search budget exceeded: {current}/{max_searches} searches used",
+            details={"budget_used": current, "budget_max": max_searches},
+        )
+    _search_count.set(current + 1)
+```
+
+### Per-Client Rate Limit: Valkey Sliding Window
+
+```python
+import time
+from redis import Redis
+
+class SlidingWindowRateLimiter:
+    def __init__(self, redis: Redis, limit: int, window_seconds: int):
+        self.redis = redis
+        self.limit = limit
+        self.window = window_seconds
+
+    async def check(self, key: str) -> tuple[bool, int]:
+        """Returns (allowed, remaining) where remaining is count left in window."""
+        now = int(time.monotonic())
+        window_key = f"rate_limit:{key}:{now // self.window}"
+        count = self.redis.incr(window_key)
+        if count == 1:
+            self.redis.expire(window_key, self.window * 2)
+        remaining = max(0, self.limit - count)
+        return count <= self.limit, remaining
+```
+
+### Response Headers
+
+| Header | Example | Source |
+|--------|---------|--------|
+| `X-Search-Budget` | `3/5` | Per-request counter: remaining/max |
+| `X-Search-Rate-Remaining` | `8/10` | Per-client window: remaining/limit |
+
+### Metrics
+
+```python
+# New counters
+METRICS.counter("search_calls_total", "Total search calls", ["status"]).inc({"status": "allowed"})
+METRICS.counter("search_calls_total", "Total search calls", ["status"]).inc({"status": "rate_limited"})
+```
+
+### Env Vars
+
+```bash
+# ── Search Volume Controls ────────────────────────────────────
+# Maximum search calls a single /answer or /agent request can make.
+# AGENT_MAX_SEARCHES_PER_REQUEST=5
+
+# Per-client sliding-window rate limit (searches / window_seconds).
+# AGENT_SEARCH_RATE_LIMIT=10/60s
+```
+
+## Consequences
+
+### Positive
+- Default caps prevent any single request from burning >5 Brave calls
+- Burst protection prevents 50+ search calls in 60s from a single client
+- All search volume observable via logs and metrics
+- Caps configurable without code changes
+- Backward compatible — existing callers see 429s only if they exceed limits
+- No new dependencies
+
+### Negative
+- Valkey key churn from sliding window (mitigated by 2x window TTL: each window key auto-expires)
+- ContextVar must be explicitly reset in each entry point (easy to forget for new code paths)
+- Per-client rate limit uses client IP which may be a NAT gateway (acceptable for current deployment)
+
+### Risks
+- False 429s if agent-svc runs behind a reverse proxy that doesn't forward `X-Forwarded-For` — mitigated by using `request.client.host` as fallback
+- Background agent jobs don't have client IPs — they use a shared pool budget (configured separately, or use the per-request cap only)
+
+## Links
+
+- Issue #213: Search volume caps
+- ADR-0031: Centralized Settings Object pattern (followed for new env vars)
+- ADR-0032: Standardized Error Response Model (extends exception hierarchy)
+- ADR-0018: Observability Infrastructure (extends metrics)
+
+## Diagrams
+
+```mermaid
+flowchart TD
+    subgraph "Per-Request Flow"
+        A[HTTP Request] --> B{Endpoint Handler}
+        B --> C[Reset search_count\ncontextvar to 0]
+        C --> D{Check Valkey\nsliding window}
+        D -->|429 exceeded| E[Return 429\nRateLimitedError]
+        D -->|OK| F[Call research function]
+        F --> G[SearXNGClient.search]
+        G --> H{Check contextvar\nsearch_count < max?}
+        H -->|No| I[Raise\nRateLimitedError]
+        H -->|Yes| J[Increment contextvar\nDo HTTP search call]
+        J --> K[Return results]
+    end
+
+    subgraph "Background Job Flow"
+        L[Worker\n_process_agent_async] --> M[Reset search_count\ncontextvar to 0]
+        M --> N[Call run_research]
+        N --> G
+    end
+
+    subgraph "Valkey Sliding Window"
+        O[Check key:\nrate_limit:{ip}:{window}] --> P[INCR key]
+        P --> Q{Count <= limit?}
+        Q -->|Yes| R[ALLOW\nset remaining header]
+        Q -->|No| S[429 DENY\nRetry-After header]
+    end
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,5 +51,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0030 | [Batch Vector Ingestion via Qdrant gRPC](0030-batch-vector-ingestion.md) | accepted |
 | 0031 | [Centralized Settings Object](0031-centralized-settings-object.md) | accepted |
 | 0032 | [Standardized Error Response Model](0032-standardized-error-response-model.md) | accepted |
+| 0033 | [Search Volume Controls](0033-search-volume-controls.md) | proposed |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
## Summary

Adds search volume controls to prevent runaway Brave API consumption. Two independent mechanisms:

1. **Per-request max-searches cap** — limits search calls within a single HTTP request (`AGENT_MAX_SEARCHES_PER_REQUEST`, default 5). Enforced inside `SearXNGClient.search()` before dispatch.
2. **Per-client sliding-window rate limit** — limits search calls from a client IP (`AGENT_SEARCH_RATE_LIMIT`, default `10/60s`). Valkey `INCR`/`EXPIRE`-based, checked at endpoint level before research dispatch.

### Files Changed

- `agent-svc/agent/exceptions.py` — Added `RateLimitedError` (status 429, code `RATE_LIMITED`)
- `agent-svc/agent/rate_limiter.py` — **NEW** `SlidingWindowRateLimiter` with `check()` and `parse_limit()`
- `agent-svc/agent/settings.py` — Added `max_searches_per_request` and `search_rate_limit` fields
- `agent-svc/agent/searxng_client.py` — Per-request budget check before each search call
- `agent-svc/agent/research.py` — Pass `max_searches_per_request` to all 4 research functions
- `agent-svc/agent/api.py` — Per-client rate check in `/v2/agent` and `/v2/answer`; response headers `X-Search-Budget` and `X-Search-Rate-Remaining`
- `agent-svc/agent/app.py` — Wires rate limiter into `app.state`, initializes metrics
- `.env.sample` — Documents both new env vars
- `docs/adr/0033-search-volume-controls.md` — ADR-0033 with architecture diagram

### Design Decisions

- **Fail-open**: Rate limiter allows request through if Valkey is unreachable
- **No new dependencies**: Uses existing `redis`, `httpx`, and stdlib only
- **No worker.py changes**: Background jobs use default `max_searches_per_request` (5) from settings
- **Per-instance counter**: Each request creates a fresh `SearXNGClient`, making budget tracking naturally per-request

### Testing

- All 62 existing unit tests pass (18 searxng_client, 44 research)
- New `RateLimitedError` exception (429) follows ADR-0032 error model
- `SlidingWindowRateLimiter.parse_limit()` handles `"10/60s"` format with validation
- Full integration tests require Docker fixture stack (not available on dev machine)

Closes #213
