### PR TITLE
docs: promote ADR-0033 to accepted

### DIFF
--- a/docs/adr/0033-search-volume-controls.md
+++ b/docs/adr/0033-search-volume-controls.md
@@ -1,6 +1,6 @@
 # ADR-0033: Search Volume Controls for Agent Service
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Deciders:** Magnus Hedemark, Jasper (AI Agent)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0030 | [Batch Vector Ingestion via Qdrant gRPC](0030-batch-vector-ingestion.md) | accepted |
 | 0031 | [Centralized Settings Object](0031-centralized-settings-object.md) | accepted |
 | 0032 | [Standardized Error Response Model](0032-standardized-error-response-model.md) | accepted |
-| 0033 | [Search Volume Controls](0033-search-volume-controls.md) | proposed |
+| 0033 | [Search Volume Controls](0033-search-volume-controls.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
ADR-0033 (Search Volume Controls) was implemented in PR #214, merged, and deployment-verified on hal2000. Promoting status from proposed to accepted per ADR lifecycle.