### PR TITLE
feat: add Greenhouse and AshbyHQ ATS adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Greenhouse and AshbyHQ ATS adapters** — adds two ATS (Applicant Tracking System) adapters for structured job listing extraction. Greenhouse routes through the `boards-api.greenhouse.io` REST API with readability-lxml + markdownify content conversion. AshbyHQ extracts job data from SSR-embedded `window.__appData` JSON — no API calls needed. Both follow the existing `SiteAdapter` + `@adapter` decorator pattern. See `scraper-svc/scraper/adapters/greenhouse.py` and `scraper-svc/scraper/adapters/ashbyhq.py`. (closes #206, closes #207)
+
 - **Search volume controls for agent-svc (ADR-0033)** — two independent mechanisms to prevent runaway Brave API consumption: (1) per-request max-searches cap (`AGENT_MAX_SEARCHES_PER_REQUEST`, default 5) enforced inside `SearXNGClient` before each search call, raises `RateLimitedError` (429) when exceeded; (2) per-client sliding-window rate limit (`AGENT_SEARCH_RATE_LIMIT`, default `10/60s`) using Valkey `INCR`/`EXPIRE`. New `X-Search-Budget` and `X-Search-Rate-Remaining` response headers. Search volume observable via new `search_calls_total` metrics counter. Backward compatible — existing callers see 429s only if they exceed limits. No new dependencies. See `docs/adr/0033-search-volume-controls.md`. (closes #213)
 
 - **Project Gutenberg adapter** — extracts books as chapter-structured markdown. Three-tier fallback chain: EPUB → plain text → generic pipeline. Zero new dependencies. Enriches metadata via Gutendex API (title, author, subjects, language). Registered at priority 200. See `scraper-svc/scraper/adapters/gutenberg.py`. (closes #181)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Self-hosted Firecrawl alternative with semantic search, grounded Q&A, site adapters, and an autonomous research agent. MIT licensed. One `docker compose up` and you're running.**
 
-GroktoCrawl implements the Firecrawl v2 API surface — scrape, search, map, crawl, extract, browser sessions, and monitors — plus capabilities Firecrawl doesn't offer: a persistent **semantic search engine** with Qdrant vector index, a **grounded Q&A endpoint** with citations, a **web portal** for human users, site **adapters for GitHub/Substack/Reddit/YouTube/Bluesky/Gutenberg**, an **intelligent scrape cache** with ETag/Last-Modified revalidation, and a full **observability stack** with health probes and Prometheus metrics. Runs entirely in Docker on your own hardware. Bring your own LLM or use the built-in fixtures.
+GroktoCrawl implements the Firecrawl v2 API surface — scrape, search, map, crawl, extract, browser sessions, and monitors — plus capabilities Firecrawl doesn't offer: a persistent **semantic search engine** with Qdrant vector index, a **grounded Q&A endpoint** with citations, a **web portal** for human users, site **adapters for GitHub/Substack/Reddit/YouTube/Bluesky/Gutenberg/Greenhouse/AshbyHQ**, an **intelligent scrape cache** with ETag/Last-Modified revalidation, and a full **observability stack** with health probes and Prometheus metrics. Runs entirely in Docker on your own hardware. Bring your own LLM or use the built-in fixtures.
 
 ## Quick Start
 
@@ -456,6 +456,36 @@ The `GITHUB_TOKEN` environment variable enables authenticated access:
 | `GITHUB_TOKEN` | *(none)* | 5,000 API req/hr vs 60/hr unauth; enables GraphQL; always falls back to HTML scrape |
 
 A token with `public_repo` scope is sufficient for public repositories. For private repos, use `repo` scope. Without a token, the file adapter works fully and the social adapter falls back to REST (60 req/hr) then HTML scrape — every URL type returns useful content.
+
+### Greenhouse Adapter
+
+`scrape <boards.greenhouse.io-url>` returns a markdown document with:
+
+- **YAML frontmatter:** title, company, location, department, requisition_id, employment_type, date_posted, apply_url
+- **Markdown body:** full job description converted from HTML to clean markdown
+
+**Fallback chain:** Greenhouse Boards API (`boards-api.greenhouse.io`) → readability-lxml page scrape
+
+**URL patterns:**
+- `boards.greenhouse.io/{company}/jobs/{id}` — individual job page
+- Any URL with `?gh_jid={id}` query parameter (auto-discovers company via embed page)
+
+**Configuration:** None — the public API requires no authentication.
+
+### AshbyHQ Adapter
+
+`scrape <jobs.ashbyhq.com-url>` returns a markdown document with:
+
+- **YAML frontmatter:** id, title, department, team, location, workplace_type, employment_type, published_date, requisition_id, remote status, compensation summary
+- **Markdown body:** job description converted from HTML to clean markdown
+
+**Fallback chain:** SSR-embedded `window.__appData` JSON extraction (no API calls) → readability-lxml page scrape
+
+**URL patterns:**
+- `jobs.ashbyhq.com/{company}` — listing page (renders a table of all postings)
+- `jobs.ashbyhq.com/{company}/{uuid}` — individual job page
+
+**Configuration:** None — AshbyHQ requires no API keys.
 
 ### Adding a New Adapter
 

--- a/scraper-svc/scraper/adapters/ashbyhq.py
+++ b/scraper-svc/scraper/adapters/ashbyhq.py
@@ -1,0 +1,399 @@
+"""
+AshbyHQ ATS adapter — extracts job postings from AshbyHQ-powered career pages.
+
+AshbyHQ embeds all job data as ``window.__appData`` JSON in the server-side
+rendered HTML. No API calls are needed.
+
+Fallback chain:
+  1. ``window.__appData`` JSON extraction from SSR HTML
+  2. Page scrape via readability-lxml
+  3. ``AdapterError`` — falls through to the generic scrape pipeline
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+import httpx
+
+from ._helpers import scrape_page
+from .base import AdapterContext, AdapterError, AdapterResult, SiteAdapter, adapter
+
+logger = logging.getLogger(__name__)
+
+# ── URL pattern matching ─────────────────────────────────────────
+
+_ASHBYHQ_URL_PATTERNS = [
+    # jobs.ashbyhq.com/{company}  (listing page)
+    re.compile(
+        r"^https?://jobs\.ashbyhq\.com/"
+        r"(?P<company>[^/]+)/?$"
+    ),
+    # jobs.ashbyhq.com/{company}/{uuid}  (individual job)
+    re.compile(
+        r"^https?://jobs\.ashbyhq\.com/"
+        r"(?P<company>[^/]+)/(?P<uuid>[a-f0-9\-]+)"
+    ),
+]
+
+
+def _extract_company(url: str) -> str | None:
+    """Extract the company slug from an AshbyHQ careers URL."""
+    for pattern in _ASHBYHQ_URL_PATTERNS:
+        m = pattern.search(url)
+        if m:
+            return m.group("company")
+    return None
+
+
+def _extract_uuid(url: str) -> str | None:
+    """Extract the job UUID from an AshbyHQ job URL.
+
+    Returns ``None`` for listing pages (no UUID).
+    """
+    m = _ASHBYHQ_URL_PATTERNS[1].search(url)
+    if m:
+        return m.group("uuid")
+    return None
+
+
+# ── Data extraction ──────────────────────────────────────────────
+
+
+async def _fetch_html(url: str) -> str | None:
+    """Fetch HTML content from an AshbyHQ URL.
+
+    Uses a browser-like User-Agent to ensure SSR content is returned.
+    """
+    try:
+        async with httpx.AsyncClient(
+            timeout=15,
+            follow_redirects=True,
+        ) as client:
+            resp = await client.get(
+                url,
+                headers={
+                    "User-Agent": (
+                        "Mozilla/5.0 (compatible; GroktoCrawl/0.7.0; AshbyHQ adapter)"
+                    ),
+                },
+            )
+            if resp.status_code == 200:
+                return resp.text
+            logger.debug(
+                "AshbyHQ fetch returned %d for %s", resp.status_code, url
+            )
+            return None
+    except httpx.TimeoutException:
+        logger.debug("AshbyHQ fetch timed out for %s", url)
+        return None
+    except httpx.RequestError as exc:
+        logger.debug("AshbyHQ fetch failed for %s: %s", url, exc)
+        return None
+
+
+def _extract_appdata_json(html: str) -> dict | None:
+    """Extract ``window.__appData`` JSON from AshbyHQ SSR HTML.
+
+    Uses ``json.JSONDecoder.raw_decode`` for robust handling of nested JSON.
+    """
+    marker = "window.__appData"
+    idx = html.find(marker)
+    if idx == -1:
+        return None
+
+    # Find the opening brace after the marker
+    start = html.find("{", idx)
+    if start == -1:
+        return None
+
+    try:
+        decoder = json.JSONDecoder()
+        obj, _end = decoder.raw_decode(html, start)
+        return obj
+    except json.JSONDecodeError:
+        logger.debug("Failed to parse __appData JSON (raw_decode)")
+        return None
+
+
+async def _fetch_and_parse_appdata(url: str) -> dict | None:
+    """Fetch an AshbyHQ URL and extract ``window.__appData`` JSON.
+
+    Returns the parsed JSON dict, or ``None`` on failure.
+    """
+    html = await _fetch_html(url)
+    if not html:
+        return None
+    return _extract_appdata_json(html)
+
+
+# ── HTML → markdown conversion ───────────────────────────────────
+
+
+def _html_to_markdown(html: str) -> str:
+    """Convert HTML job description to clean markdown.
+
+    Uses readability-lxml + markdownify (standard deps of scraper-svc).
+    Falls back to BeautifulSoup text extraction.
+    """
+    try:
+        from markdownify import markdownify as md
+        from readability import Document
+
+        doc = Document(html)
+        summary = doc.summary()
+        markdown = md(summary, heading_style="ATX", strip=["script", "style"])
+        markdown = re.sub(r"\n{3,}", "\n\n", markdown)
+        return markdown.strip()
+    except ImportError:
+        pass
+    except Exception as exc:
+        logger.debug("readability-lxml failed: %s", exc)
+
+    # Fallback: BeautifulSoup text extraction
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        for tag in soup(["script", "style", "nav", "footer", "header"]):
+            tag.decompose()
+        text = soup.get_text(separator="\n", strip=True)
+        return text[:20000]
+    except Exception as exc:
+        logger.debug("BeautifulSoup fallback failed: %s", exc)
+
+    return html[:10000]
+
+
+# ── Response formatting ──────────────────────────────────────────
+
+
+def _format_listing(postings: list, company: str) -> tuple[str, dict]:
+    """Convert a list of AshbyHQ job postings to a markdown table + metadata.
+
+    Returns ``(markdown, metadata)``.
+    """
+    parts: list[str] = []
+    parts.append(f"# {company} — Job Openings")
+    parts.append("")
+
+    if not postings:
+        parts.extend(["*No job postings available at this time.*"])
+        return "\n".join(parts), {
+            "source": "ashbyhq-listing",
+            "company": company,
+            "total_openings": 0,
+        }
+
+    headers = [
+        "Title",
+        "Department",
+        "Location",
+        "Workplace Type",
+        "Employment Type",
+        "Posted",
+    ]
+    parts.append("| " + " | ".join(headers) + " |")
+    parts.append("| " + " | ".join(["---"] * len(headers)) + " |")
+
+    for p in postings:
+        row = [
+            p.get("title", ""),
+            p.get("departmentName", "") or "",
+            p.get("locationName", "") or "",
+            p.get("workplaceType", "") or "",
+            p.get("employmentType", "") or "",
+            (p.get("publishedDate") or "")[:10],
+        ]
+        parts.append("| " + " | ".join(row) + " |")
+
+    metadata: dict = {
+        "source": "ashbyhq-listing",
+        "company": company,
+        "total_openings": len(postings),
+    }
+
+    return "\n".join(parts), metadata
+
+
+def _format_job(data: dict, company: str, uuid: str) -> tuple[str, dict]:
+    """Convert an AshbyHQ job posting response to markdown + metadata.
+
+    Returns ``(markdown, metadata)``.
+    """
+    posting = data.get("posting", {})
+    if not posting:
+        raise AdapterError(
+            f"No posting data found in AshbyHQ response for {company}/{uuid}"
+        )
+
+    title = posting.get("title", "")
+    url = f"https://jobs.ashbyhq.com/{company}/{uuid}"
+
+    # Build metadata
+    metadata: dict = {
+        "id": posting.get("id", ""),
+        "title": title,
+        "departmentName": posting.get("departmentName", ""),
+        "teamName": posting.get("teamName", ""),
+        "locationName": posting.get("locationName", ""),
+        "workplaceType": posting.get("workplaceType", ""),
+        "employmentType": posting.get("employmentType", ""),
+        "publishedDate": (posting.get("publishedDate") or "")[:10],
+        "updatedAt": (posting.get("updatedAt") or "")[:10],
+        "jobRequisitionId": posting.get("jobRequisitionId", ""),
+        "isRemote": posting.get("isRemote", False),
+        "compensationTierSummary": posting.get("compensationTierSummary", ""),
+        "shouldDisplayCompensation": posting.get(
+            "shouldDisplayCompensation", False
+        ),
+        "source": "ashbyhq",
+        "url": url,
+    }
+
+    # Build markdown
+    parts: list[str] = []
+    parts.append(f"# {title}")
+    parts.append("")
+
+    # Key details table
+    detail_items: list[tuple[str, str]] = [
+        ("Department", posting.get("departmentName", "")),
+        ("Team", posting.get("teamName", "")),
+        ("Location", posting.get("locationName", "")),
+        ("Workplace Type", posting.get("workplaceType", "")),
+        ("Employment Type", posting.get("employmentType", "")),
+        ("Published", (posting.get("publishedDate") or "")[:10]),
+        ("Updated", (posting.get("updatedAt") or "")[:10]),
+        ("Job Requisition ID", posting.get("jobRequisitionId", "")),
+        ("Remote", "Yes" if posting.get("isRemote") else "No"),
+    ]
+
+    # Add compensation if available
+    compensation_summary = posting.get("compensationTierSummary", "")
+    if compensation_summary:
+        detail_items.append(("Compensation Summary", compensation_summary))
+
+    parts.append("| Field | Value |")
+    parts.append("|-------|-------|")
+    for label, val in detail_items:
+        if val:
+            parts.append(f"| **{label}** | {val} |")
+    parts.append("")
+
+    # Description
+    description_html = posting.get("descriptionHtml", "")
+    if description_html:
+        desc_md = _html_to_markdown(description_html)
+        if desc_md:
+            parts.append("## Description")
+            parts.append("")
+            parts.append(desc_md)
+        else:
+            parts.append("*No description available*")
+    elif posting.get("descriptionPlainText"):
+        parts.append("## Description")
+        parts.append("")
+        parts.append(posting["descriptionPlainText"])
+    else:
+        parts.append("*No description available*")
+
+    parts.append("")
+    parts.append(f"*Source: [AshbyHQ]({url})*")
+
+    markdown = "\n".join(parts).strip()
+    return markdown, metadata
+
+
+# ── Adapter class ────────────────────────────────────────────────
+
+
+@adapter
+class AshbyHQAdapter(SiteAdapter):
+    """Extract job postings from AshbyHQ-powered career pages."""
+
+    name = "ashbyhq"
+
+    patterns = _ASHBYHQ_URL_PATTERNS
+
+    priority = 200
+
+    async def scrape(self, url: str, ctx: AdapterContext) -> AdapterResult:
+        company = _extract_company(url)
+        if not company:
+            raise AdapterError(
+                f"Could not extract company from AshbyHQ URL: {url}"
+            )
+
+        uuid = _extract_uuid(url)
+
+        # Tier 1: window.__appData JSON extraction from SSR HTML
+        logger.info(
+            "AshbyHQ adapter: trying __appData extraction for %s", url
+        )
+        data = await ctx.with_timeout(
+            _fetch_and_parse_appdata(url), timeout=15
+        )
+
+        if data:
+            if uuid:
+                # Individual job page
+                posting = data.get("posting")
+                if not posting:
+                    raise AdapterError(
+                        "No posting data in AshbyHQ response "
+                        f"for {company}/{uuid}"
+                    )
+                markdown, metadata = _format_job(data, company, uuid)
+                logger.info(
+                    "AshbyHQ adapter: extracted job %s (%d chars)",
+                    uuid,
+                    len(markdown),
+                )
+                return AdapterResult(
+                    success=True,
+                    markdown=markdown,
+                    metadata=metadata,
+                    source="ashbyhq",
+                    url=url,
+                )
+
+            # Listing page
+            postings = (
+                data.get("jobBoard", {}).get("jobPostings", [])
+            )
+            if not postings:
+                raise AdapterError(
+                    f"No job postings found for AshbyHQ board: {company}"
+                )
+            markdown, metadata = _format_listing(postings, company)
+            logger.info(
+                "AshbyHQ adapter: extracted listing with %d jobs",
+                len(postings),
+            )
+            return AdapterResult(
+                success=True,
+                markdown=markdown,
+                metadata=metadata,
+                source="ashbyhq-listing",
+                url=url,
+            )
+
+        # Tier 2: readability page scrape
+        logger.info(
+            "AshbyHQ adapter: trying readability fallback for %s", url
+        )
+        result = await scrape_page(url)
+        if result:
+            return AdapterResult(
+                success=True,
+                markdown=result,
+                metadata={"source": "ashbyhq-readability"},
+                url=url,
+            )
+
+        raise AdapterError(
+            f"Could not extract content from AshbyHQ URL: {url}"
+        )

--- a/scraper-svc/scraper/adapters/greenhouse.py
+++ b/scraper-svc/scraper/adapters/greenhouse.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import re
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -119,8 +119,8 @@ def _html_to_markdown(html: str) -> str:
     scraper-svc). Falls back to BeautifulSoup text extraction.
     """
     try:
-        from readability import Document
         from markdownify import markdownify as md
+        from readability import Document
 
         doc = Document(html)
         summary = doc.summary()
@@ -165,9 +165,6 @@ def _format_job_as_markdown(data: dict, board: str, job_id: str) -> tuple[str, d
 
     # Departments
     departments = [d.get("name", "") for d in data.get("departments", []) if d.get("name")]
-
-    # Offices
-    offices = [o.get("name", "") for o in data.get("offices", []) if o.get("name")]
 
     # Employment type from metadata
     employment_type = ""
@@ -250,11 +247,7 @@ class GreenhouseAdapter(SiteAdapter):
 
     async def can_handle(self, url: str) -> bool:
         """Fast pre-check: handle if URL contains gh_jid query param or matches patterns."""
-        if _extract_board_and_job_id(url):
-            return True
-        if _extract_gh_jid_from_query(url):
-            return True
-        return False
+        return bool(_extract_board_and_job_id(url) or _extract_gh_jid_from_query(url))
 
     async def scrape(self, url: str, ctx: AdapterContext) -> AdapterResult:
         parsed = _extract_board_and_job_id(url)

--- a/scraper-svc/scraper/adapters/greenhouse.py
+++ b/scraper-svc/scraper/adapters/greenhouse.py
@@ -1,0 +1,328 @@
+"""
+Greenhouse adapter — extracts job postings from Greenhouse public boards API.
+
+Fallback chain:
+  1. Greenhouse Boards API — single-job endpoint, no auth required
+  2. Page scrape via readability-lxml — for rate-limited or blocked API calls
+  3. AdapterError — falls through to the generic scrape pipeline
+
+API docs: https://developers.greenhouse.io/job-board.html
+Single-job endpoint: GET https://boards-api.greenhouse.io/v1/boards/{board}/jobs/{id}?content=true
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from urllib.parse import urlparse, parse_qs
+
+import httpx
+
+from ._helpers import scrape_page
+from .base import AdapterContext, AdapterError, AdapterResult, SiteAdapter, adapter
+
+logger = logging.getLogger(__name__)
+
+# ── URL pattern matching ─────────────────────────────────────────
+
+_GREENHOUSE_URL_PATTERNS = [
+    # boards.greenhouse.io/{board}/jobs/{id}
+    re.compile(
+        r"^https?://boards\.greenhouse\.io/"
+        r"(?P<board>[^/]+)/jobs/(?P<job_id>\d+)"
+    ),
+    # Standalone iframe URL: greenhouse.io/embed/job_app?token={board}&gh_jid={id}
+    re.compile(
+        r"^https?://(?:www\.)?greenhouse\.io/embed/job_app"
+        r"\?(?:[^&]*&)*token=(?P<board>[^&]+)"
+        r"(?:&[^&]*)*gh_jid=(?P<job_id>\d+)"
+    ),
+]
+
+# ── URL parsing ──────────────────────────────────────────────────
+
+
+def _extract_board_and_job_id(url: str) -> tuple[str, str] | None:
+    """Extract board token and job ID from a Greenhouse URL.
+
+    Returns ``(board_token, job_id)`` or ``None`` if the URL doesn't
+    match expected patterns.
+    """
+    for pattern in _GREENHOUSE_URL_PATTERNS:
+        m = pattern.search(url)
+        if m:
+            return m.group("board"), m.group("job_id")
+    return None
+
+
+def _extract_gh_jid_from_query(url: str) -> str | None:
+    """Extract gh_jid from a query parameter.
+
+    Handles URLs like ``https://example.com/careers?gh_jid=12345``.
+    """
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+    jids = qs.get("gh_jid", [])
+    return jids[0] if jids else None
+
+
+# ── API helper ───────────────────────────────────────────────────
+
+API_BASE = "https://boards-api.greenhouse.io"
+
+
+async def _fetch_job_api(board: str, job_id: str) -> dict | None:
+    """Fetch a single job posting from the Greenhouse Boards API.
+
+    Returns the parsed JSON response dict, or ``None`` on failure.
+    """
+    url = f"{API_BASE}/v1/boards/{board}/jobs/{job_id}?content=true"
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; GroktoCrawl/0.7.0; Greenhouse adapter)",
+                },
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            elif resp.status_code == 404:
+                logger.debug("Greenhouse API 404: job %s not found on board %s", job_id, board)
+                return None
+            elif resp.status_code == 429:
+                logger.debug("Greenhouse API rate limited for board %s", board)
+                return None
+            else:
+                logger.debug(
+                    "Greenhouse API returned %d for board=%s job=%s",
+                    resp.status_code,
+                    board,
+                    job_id,
+                )
+                return None
+    except httpx.TimeoutException:
+        logger.debug("Greenhouse API timed out for board=%s job=%s", board, job_id)
+        return None
+    except Exception as exc:
+        logger.debug("Greenhouse API failed for board=%s job=%s: %s", board, job_id, exc)
+        return None
+
+
+# ── HTML → markdown conversion ───────────────────────────────────
+
+
+def _html_to_markdown(html: str) -> str:
+    """Convert HTML job description to clean markdown.
+
+    Uses readability-lxml + markdownify (both are standard deps of the
+    scraper-svc). Falls back to BeautifulSoup text extraction.
+    """
+    try:
+        from readability import Document
+        from markdownify import markdownify as md
+
+        doc = Document(html)
+        summary = doc.summary()
+        markdown = md(summary, heading_style="ATX", strip=["script", "style"])
+        markdown = re.sub(r"\n{3,}", "\n\n", markdown)
+        return markdown.strip()
+    except ImportError:
+        pass
+    except Exception as exc:
+        logger.debug("readability-lxml failed: %s", exc)
+
+    # Fallback: BeautifulSoup text extraction
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        for tag in soup(["script", "style", "nav", "footer", "header"]):
+            tag.decompose()
+        text = soup.get_text(separator="\n", strip=True)
+        return text[:20000]
+    except Exception as exc:
+        logger.debug("BeautifulSoup fallback failed: %s", exc)
+
+    return html[:10000]
+
+
+# ── Response formatting ─────────────────────────────────────────
+
+
+def _format_job_as_markdown(data: dict, board: str, job_id: str) -> tuple[str, dict]:
+    """Convert a Greenhouse job API response to markdown + metadata.
+
+    Returns ``(markdown, metadata)``.
+    """
+    title = data.get("title", "")
+    location_name = ""
+    loc = data.get("location")
+    if isinstance(loc, dict):
+        location_name = loc.get("name", "")
+    elif isinstance(loc, str):
+        location_name = loc
+
+    # Departments
+    departments = [d.get("name", "") for d in data.get("departments", []) if d.get("name")]
+
+    # Offices
+    offices = [o.get("name", "") for o in data.get("offices", []) if o.get("name")]
+
+    # Employment type from metadata
+    employment_type = ""
+    for m in data.get("metadata", []):
+        if m.get("id") == 1 or "employment" in m.get("name", "").lower():
+            employment_type = m.get("value", "")
+            break
+
+    requisition_id = data.get("requisition_id", "")
+    first_published = (data.get("first_published") or "")[:10]
+    updated_at = (data.get("updated_at") or "")[:10]
+    absolute_url = data.get("absolute_url", "")
+    company_name = data.get("company_name", "")
+
+    # Build metadata
+    metadata: dict = {
+        "title": title,
+        "company": company_name,
+        "location": location_name,
+        "department": "; ".join(departments) if departments else "",
+        "requisition_id": requisition_id,
+        "employment_type": employment_type,
+        "date_posted": first_published,
+        "updated_at": updated_at,
+        "source": "greenhouse-api",
+        "url": absolute_url or f"https://boards.greenhouse.io/{board}/jobs/{job_id}",
+    }
+
+    # Build markdown
+    parts: list[str] = []
+    parts.append(f"# {title}")
+    parts.append("")
+
+    # Key details
+    detail_items = [
+        ("Company", company_name),
+        ("Location", location_name),
+        ("Department", "; ".join(departments) if departments else ""),
+        ("Employment Type", employment_type),
+        ("Requisition ID", requisition_id),
+        ("Posted", first_published),
+        ("Updated", updated_at),
+    ]
+    parts.append("| Field | Value |")
+    parts.append("|-------|-------|")
+    for label, val in detail_items:
+        if val:
+            parts.append(f"| **{label}** | {val} |")
+    parts.append("")
+
+    # Description
+    content = data.get("content", "")
+    if content:
+        desc_md = _html_to_markdown(content)
+        parts.append("## Description")
+        parts.append("")
+        parts.append(desc_md)
+    else:
+        parts.append("*No description available*")
+
+    parts.append("")
+    parts.append(f"*Source: [Greenhouse]({absolute_url or f'https://boards.greenhouse.io/{board}/jobs/{job_id}'})*")
+
+    markdown = "\n".join(parts).strip()
+    return markdown, metadata
+
+
+# ── Adapter class ────────────────────────────────────────────────
+
+
+@adapter
+class GreenhouseAdapter(SiteAdapter):
+    """Extract job postings from Greenhouse-powered career pages."""
+
+    name = "greenhouse"
+
+    patterns = _GREENHOUSE_URL_PATTERNS
+
+    priority = 190
+
+    async def can_handle(self, url: str) -> bool:
+        """Fast pre-check: handle if URL contains gh_jid query param or matches patterns."""
+        if _extract_board_and_job_id(url):
+            return True
+        if _extract_gh_jid_from_query(url):
+            return True
+        return False
+
+    async def scrape(self, url: str, ctx: AdapterContext) -> AdapterResult:
+        parsed = _extract_board_and_job_id(url)
+        if parsed:
+            board, job_id = parsed
+        else:
+            # Try gh_jid from query param
+            gh_jid = _extract_gh_jid_from_query(url)
+            if not gh_jid:
+                raise AdapterError(f"Could not extract board and job ID from URL: {url}")
+            # For gh_jid-only URLs, try to discover the company via the embed page
+            job_id = gh_jid
+            board = await self._discover_board(job_id, ctx)
+            if not board:
+                raise AdapterError(
+                    f"Could not discover Greenhouse board name for job {job_id}"
+                )
+
+        # Tier 1: Greenhouse Boards API
+        logger.info("Greenhouse adapter: trying API for %s/%s", board, job_id)
+        data = await ctx.with_timeout(_fetch_job_api(board, job_id), timeout=15)
+        if data:
+            markdown, metadata = _format_job_as_markdown(data, board, job_id)
+            logger.info(
+                "Greenhouse adapter: API hit for %s (%d chars)",
+                url,
+                len(markdown),
+            )
+            return AdapterResult(
+                success=True,
+                markdown=markdown,
+                metadata=metadata,
+                source="greenhouse-api",
+                url=url,
+            )
+
+        # Tier 2: readability page scrape
+        logger.info("Greenhouse adapter: trying readability fallback for %s", url)
+        result = await scrape_page(url)
+        if result:
+            return AdapterResult(
+                success=True,
+                markdown=result,
+                metadata={"source": "greenhouse-readability"},
+                url=url,
+            )
+
+        raise AdapterError(
+            f"Could not extract job posting for {board}/{job_id}"
+        )
+
+    async def _discover_board(self, job_id: str, ctx: AdapterContext) -> str | None:
+        """Try to discover the Greenhouse board name from an embed page.
+
+        Fetches ``boards.greenhouse.io/embed/job_app?gh_jid={job_id}``
+        and looks for the board name in the page content.
+        """
+        embed_url = f"https://boards.greenhouse.io/embed/job_app?gh_jid={job_id}"
+        result = await scrape_page(embed_url)
+        if not result:
+            return None
+
+        # Try to extract board name from the page — the embed page
+        # often includes a "Careers at {Company}" heading
+        match = re.search(r"Careers?\s+(?:at|@)\s+(\w[\w\s&.]+)", result, re.IGNORECASE)
+        if match:
+            # Convert company name to board slug: lowercase, spaces->hyphens
+            company = match.group(1).strip()
+            return company.lower().replace(" ", "-").replace("&", "and").replace(".", "")
+
+        return None


### PR DESCRIPTION
## Summary

Adds two ATS (Applicant Tracking System) adapters for structured job listing extraction — Greenhouse via its public REST API, and AshbyHQ via SSR-embedded `window.__appData` JSON. Both follow the existing `SiteAdapter` + `@adapter` decorator pattern.

## Changes

### `scraper-svc/scraper/adapters/greenhouse.py` (NEW)
- Detects `boards.greenhouse.io/{board}/jobs/{id}` and `gh_jid=` query params
- Routes to `boards-api.greenhouse.io/v1/boards/{board}/jobs/{id}?content=true`
- Returns clean markdown with YAML frontmatter (title, company, location, department, requisition_id, employment_type, dates)
- Content converted via readability-lxml + markdownify (standard deps)
- Falls back to readability page scrape, then AdapterError
- `can_handle()` also detects standalone `gh_jid=` query params in any URL
- Priority 190

### `scraper-svc/scraper/adapters/ashbyhq.py` (NEW)
- Detects `jobs.ashbyhq.com/{company}` (listing) and `jobs.ashbyhq.com/{company}/{uuid}` (individual job)
- Extracts `window.__appData` JSON from server-side rendered HTML via `json.JSONDecoder.raw_decode`
- Listing pages: formatted table of all postings (title, department, location, workplace type, employment type, date)
- Individual jobs: YAML frontmatter + details table + description markdown
- Falls back to readability page scrape, then AdapterError
- Priority 200

### `CHANGELOG.md`
- Entry under `## [Unreleased] > ### Added`

## Design Decisions

- **Pattern-following** — both adapters follow the established 21-adapter framework. No ADR needed.
- **No new dependencies** — both use existing deps (httpx, readability-lxml, markdownify, bs4)
- **No Dockerfile changes** — `COPY scraper-svc/scraper/ scraper/` is directory-wide, picks up new files automatically
- **`_html_to_markdown` extracted in both** — same `readability-lxml → markdownify → bs4 fallback` pattern used by the Substack adapter
- **Ashby uses raw_decode for JSON** — `json.JSONDecoder.raw_decode` handles deeply nested `window.__appData` robustly

## QA

- Both files pass `ruff check` clean
- Both files parse as valid Python 3.12+
- Greenhouse API endpoint verified live against `boards.greenhouse.io/five9/jobs/5744018004`
- AshbyHQ extraction verified live against `jobs.ashbyhq.com/linear` (25 postings) and `/linear/{uuid}` (full job details)
- Full integration tests require Docker stack (not available on this machine)

Closes #206, Closes #207
