### PR TITLE
feat: add portal-svc health probe to agent-svc

### DIFF
--- a/agent-svc/agent/app.py
+++ b/agent-svc/agent/app.py
@@ -220,6 +220,7 @@ def create_app() -> FastAPI:
             searxng_url=app.state.searxng_url,
             scraper_url=app.state.scraper_url,
             browser_url="http://browser-svc:8012",
+            portal_url="http://portal-svc:8081",
         )
         # Record health check outcomes as metrics
         dh_gauge = METRICS.gauge(

--- a/agent-svc/agent/health.py
+++ b/agent-svc/agent/health.py
@@ -16,13 +16,20 @@ import httpx
 async def check_valkey(url: str) -> dict[str, Any]:
     """Probe Valkey via PING."""
     from redis import Redis
+
     start = time.monotonic()
     try:
-        r = Redis.from_url(url, decode_responses=True, socket_connect_timeout=3, socket_timeout=3)
+        r = Redis.from_url(
+            url, decode_responses=True, socket_connect_timeout=3, socket_timeout=3
+        )
         r.ping()
         r.close()
         elapsed = (time.monotonic() - start) * 1000
-        return {"status": "ok", "latency_ms": round(elapsed, 1), "detail": "Valkey PING ok"}
+        return {
+            "status": "ok",
+            "latency_ms": round(elapsed, 1),
+            "detail": "Valkey PING ok",
+        }
     except Exception as e:
         elapsed = (time.monotonic() - start) * 1000
         return {"status": "down", "latency_ms": round(elapsed, 1), "detail": str(e)}
@@ -39,7 +46,12 @@ async def check_searxng(url: str) -> dict[str, Any]:
         async with httpx.AsyncClient(timeout=10) as client:
             resp = await client.get(
                 f"{url.rstrip('/')}/search",
-                params={"q": "groktocrawl-healthcheck", "format": "json", "pageno": 1, "categories": "general"},
+                params={
+                    "q": "groktocrawl-healthcheck",
+                    "format": "json",
+                    "pageno": 1,
+                    "categories": "general",
+                },
                 headers={"User-Agent": "GroktoCrawl/0.1", "Accept": "application/json"},
             )
             elapsed = (time.monotonic() - start) * 1000
@@ -60,13 +72,25 @@ async def check_searxng(url: str) -> dict[str, Any]:
                     "detail": f"SearXNG ok ({engines_ok}/{engines_total} engines)",
                 }
             elapsed = (time.monotonic() - start) * 1000
-            return {"status": "down", "latency_ms": round(elapsed, 1), "detail": f"SearXNG returned HTTP {resp.status_code}"}
-    except asyncio.TimeoutError:
+            return {
+                "status": "down",
+                "latency_ms": round(elapsed, 1),
+                "detail": f"SearXNG returned HTTP {resp.status_code}",
+            }
+    except TimeoutError:
         elapsed = (time.monotonic() - start) * 1000
-        return {"status": "down", "latency_ms": round(elapsed, 1), "detail": "SearXNG connection timed out"}
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": "SearXNG connection timed out",
+        }
     except Exception as e:
         elapsed = (time.monotonic() - start) * 1000
-        return {"status": "down", "latency_ms": round(elapsed, 1), "detail": f"SearXNG error: {e}"}
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": f"SearXNG error: {e}",
+        }
 
 
 async def check_scraper(url: str) -> dict[str, Any]:
@@ -81,14 +105,30 @@ async def check_scraper(url: str) -> dict[str, Any]:
             resp = await client.get(f"{url.rstrip('/')}/", timeout=10)
             elapsed = (time.monotonic() - start) * 1000
             if resp.status_code < 500:
-                return {"status": "ok", "latency_ms": round(elapsed, 1), "detail": f"Scraper responded HTTP {resp.status_code}"}
-            return {"status": "degraded", "latency_ms": round(elapsed, 1), "detail": f"Scraper returned HTTP {resp.status_code}"}
-    except asyncio.TimeoutError:
+                return {
+                    "status": "ok",
+                    "latency_ms": round(elapsed, 1),
+                    "detail": f"Scraper responded HTTP {resp.status_code}",
+                }
+            return {
+                "status": "degraded",
+                "latency_ms": round(elapsed, 1),
+                "detail": f"Scraper returned HTTP {resp.status_code}",
+            }
+    except TimeoutError:
         elapsed = (time.monotonic() - start) * 1000
-        return {"status": "down", "latency_ms": round(elapsed, 1), "detail": "Scraper connection timed out"}
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": "Scraper connection timed out",
+        }
     except Exception as e:
         elapsed = (time.monotonic() - start) * 1000
-        return {"status": "down", "latency_ms": round(elapsed, 1), "detail": f"Scraper error: {e}"}
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": f"Scraper error: {e}",
+        }
 
 
 async def check_browser(url: str) -> dict[str, Any]:
@@ -99,14 +139,64 @@ async def check_browser(url: str) -> dict[str, Any]:
             resp = await client.get(f"{url.rstrip('/')}/", timeout=10)
             elapsed = (time.monotonic() - start) * 1000
             if resp.status_code < 500:
-                return {"status": "ok", "latency_ms": round(elapsed, 1), "detail": f"Browser responded HTTP {resp.status_code}"}
-            return {"status": "degraded", "latency_ms": round(elapsed, 1), "detail": f"Browser returned HTTP {resp.status_code}"}
-    except asyncio.TimeoutError:
+                return {
+                    "status": "ok",
+                    "latency_ms": round(elapsed, 1),
+                    "detail": f"Browser responded HTTP {resp.status_code}",
+                }
+            return {
+                "status": "degraded",
+                "latency_ms": round(elapsed, 1),
+                "detail": f"Browser returned HTTP {resp.status_code}",
+            }
+    except TimeoutError:
         elapsed = (time.monotonic() - start) * 1000
-        return {"status": "down", "latency_ms": round(elapsed, 1), "detail": "Browser connection timed out"}
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": "Browser connection timed out",
+        }
     except Exception as e:
         elapsed = (time.monotonic() - start) * 1000
-        return {"status": "down", "latency_ms": round(elapsed, 1), "detail": f"Browser error: {e}"}
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": f"Browser error: {e}",
+        }
+
+
+async def check_portal(url: str) -> dict[str, Any]:
+    """Probe portal-svc by hitting its /health endpoint."""
+    start = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(f"{url.rstrip('/')}/health", timeout=10)
+            elapsed = (time.monotonic() - start) * 1000
+            if resp.status_code < 500:
+                return {
+                    "status": "ok",
+                    "latency_ms": round(elapsed, 1),
+                    "detail": f"Portal responded HTTP {resp.status_code}",
+                }
+            return {
+                "status": "degraded",
+                "latency_ms": round(elapsed, 1),
+                "detail": f"Portal returned HTTP {resp.status_code}",
+            }
+    except TimeoutError:
+        elapsed = (time.monotonic() - start) * 1000
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": "Portal connection timed out",
+        }
+    except Exception as e:
+        elapsed = (time.monotonic() - start) * 1000
+        return {
+            "status": "down",
+            "latency_ms": round(elapsed, 1),
+            "detail": f"Portal error: {e}",
+        }
 
 
 async def check_all(
@@ -114,6 +204,7 @@ async def check_all(
     searxng_url: str = "http://searxng:8080",
     scraper_url: str = "http://scraper-svc:8001",
     browser_url: str = "http://browser-svc:8012",
+    portal_url: str = "http://portal-svc:8081",
 ) -> dict[str, Any]:
     """Probe all dependencies and return aggregated health.
 
@@ -127,14 +218,26 @@ async def check_all(
         check_searxng(searxng_url),
         check_scraper(scraper_url),
         check_browser(browser_url),
+        check_portal(portal_url),
         return_exceptions=True,
     )
 
     probes = {
-        "valkey": results[0] if not isinstance(results[0], BaseException) else {"status": "error", "detail": str(results[0])},
-        "searxng": results[1] if not isinstance(results[1], BaseException) else {"status": "error", "detail": str(results[1])},
-        "scraper": results[2] if not isinstance(results[2], BaseException) else {"status": "error", "detail": str(results[2])},
-        "browser": results[3] if not isinstance(results[3], BaseException) else {"status": "error", "detail": str(results[3])},
+        "valkey": results[0]
+        if not isinstance(results[0], BaseException)
+        else {"status": "error", "detail": str(results[0])},
+        "searxng": results[1]
+        if not isinstance(results[1], BaseException)
+        else {"status": "error", "detail": str(results[1])},
+        "scraper": results[2]
+        if not isinstance(results[2], BaseException)
+        else {"status": "error", "detail": str(results[2])},
+        "browser": results[3]
+        if not isinstance(results[3], BaseException)
+        else {"status": "error", "detail": str(results[3])},
+        "portal": results[4]
+        if not isinstance(results[4], BaseException)
+        else {"status": "error", "detail": str(results[4])},
     }
 
     statuses = [v["status"] for v in probes.values()]


### PR DESCRIPTION
## Summary

Adds a `check_portal()` health probe for portal-svc to agent-svc's dependency checks. Portal-svc already had a `/health` endpoint — this wires it into the aggregate health reporting.

## Files Changed

| File | Action | Details |
|------|--------|---------|
| `agent-svc/agent/health.py` | **Patch** | New `check_portal()` function following `check_browser()` pattern. Wired into `check_all()`. |
| `agent-svc/agent/app.py` | **Patch** | Passes `portal_url` to `check_all()` |

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Refactor (health observability coverage)

## Test Plan

- [x] Manual verification — syntax and import checked, follows established pattern
- [ ] Integration tests — requires Docker stack; tests pass in CI via self-hosted runner

## Checklist

- [x] Code follows project conventions (type hints, async/await, existing probe pattern)
- [ ] Documentation — pattern-following, no new env vars or CLI surface
- [ ] No new dependencies — uses existing httpx
- [x] No ADR needed — pattern-following (3 existing probes, same framework)

Closes #189
