### PR TITLE
docs: promote ADR-0034 to accepted (post-merge)

### DIFF
--- a/docs/adr/0034-lifespan-model-loading.md
+++ b/docs/adr/0034-lifespan-model-loading.md
@@ -1,6 +1,6 @@
 # ADR-0034: Lifespan-Based Model Loading and Startup Readiness for semantic-svc
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Deciders:** Magnus Hedemark, Jasper (AI Agent)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0031 | [Centralized Settings Object](0031-centralized-settings-object.md) | accepted |
 | 0032 | [Standardized Error Response Model](0032-standardized-error-response-model.md) | accepted |
 | 0033 | [Search Volume Controls](0033-search-volume-controls.md) | accepted |
-| 0034 | [Lifespan-Based Model Loading and Startup Readiness](0034-lifespan-model-loading.md) | proposed |
+| 0034 | [Lifespan-Based Model Loading and Startup Readiness](0034-lifespan-model-loading.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
Promote ADR-0034 from proposed to accepted — deployment-verified on hal2000.

Closes #193 (post-merge ADR status promotion, per pipeline convention)
