### PR TITLE
fix: allow dependabot PRs to pass CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,7 +55,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -104,10 +104,13 @@ jobs:
     needs: build-and-push
     runs-on: [self-hosted, groktocrawl, docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up .env
         run: cp .env.sample .env
+
+      - name: Force-remove all stale project containers
+        run: docker ps -a --filter name=groktocrawl -q | xargs -r docker rm -f || true
 
       - name: Clean up stale containers from previous run
         run: docker compose down --remove-orphans --timeout 30 || true

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -15,7 +15,7 @@ jobs:
       depth: ${{ steps.check.outputs.depth }}
       security: ${{ steps.check.outputs.security }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - id: check
@@ -44,7 +44,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
@@ -54,3 +54,4 @@ jobs:
           automatic_review: true
           review_depth: ${{ needs.assess-depth.outputs.depth }}
           automatic_security_review: ${{ needs.assess-depth.outputs.security }}
+          allowed_bots: "dependabot[bot]"


### PR DESCRIPTION
## Summary

Dependabot PRs (224-228) all fail CI with the same two errors. This PR fixes the infrastructure so they — and all future dependabot PRs — can pass.

## Changes

### `droid-review.yml`

- **Added `allowed_bots: "dependabot[bot]"`** to the droid-action step. Without this, the Factory-AI/droid-action rejects dependabot as a non-human actor with: `Workflow initiated by non-human actor: dependabot (type: Bot)`
- **Bumped `actions/checkout` from v5 to v6** in both jobs

### `docker.yml`

- **Added force-removal of stale project containers** before `docker compose up`. The existing `docker compose down --remove-orphans` pattern misses containers from runs that didn't terminate cleanly. The new step (`docker ps -a --filter name=groktocrawl -q | xargs -r docker rm -f`) catches ALL project containers regardless of state
- **Bumped `actions/checkout` from v4 to v6** in both jobs

### Labels

Created missing labels referenced by `dependabot.yml`:

- `dependencies` (blue #0366d6) — "PRs that update dependencies"
- `python` (blue #0366d6) — "Python dependency updates"  
- `ci` (blue #0075ca) — "CI/CD and GitHub Actions"

## After merge

Close dependabot PRs 224-228 as superseded. Dependabot will regenerate them on the next Monday cycle. With these fixes, the regenerated PRs should pass CI.

## Test plan

- CI workflow changes: validated by CI running on this PR
- Label creation: verified via `gh api repos/groktopus/groktocrawl/labels`
- Dependabot pass: can only be validated post-merge when dependabot regenerates PRs
