### PR TITLE
fix: remove unused RQ queue code

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -5,12 +5,10 @@ Targets Firecrawl v2 API compatibility where possible.
 
 import logging
 from datetime import UTC
-from typing import Any
 
 import httpx
 from bs4 import BeautifulSoup
 from fastapi import APIRouter, Request, Response
-from rq import Queue
 
 from common.url import extract_domain, is_same_origin
 
@@ -83,10 +81,6 @@ def _get_client_ip(request: Request) -> str:
     if request.client:
         return request.client.host
     return "unknown"
-
-
-def _enqueue(queue: Queue, func: str, **kwargs: Any) -> None:
-    queue.enqueue(func, **kwargs)
 
 
 @router.get("/v2/activity", response_model=ActivityResponse)

--- a/agent-svc/agent/app.py
+++ b/agent-svc/agent/app.py
@@ -9,7 +9,6 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
 from redis import Redis
-from rq import Queue
 
 from .api import router
 from .auth import (
@@ -103,7 +102,6 @@ def create_app() -> FastAPI:
         f"redis://{settings.valkey_host}:{settings.valkey_port}/{settings.valkey_db}"
     )
     conn = Redis.from_url(redis_url, decode_responses=True)
-    queue = Queue(connection=conn)
     store = JobStore(redis_url)
     scraper_client = ScraperClient(settings.scraper_url)
     searxng_client = SearXNGClient(settings.searxng_url)
@@ -124,7 +122,6 @@ def create_app() -> FastAPI:
 
     # ── App state ───────────────────────────────────────────────
     app.state.redis = conn
-    app.state.queue = queue
     app.state.job_store = store
     app.state.scraper_client = scraper_client
     app.state.searxng_client = searxng_client

--- a/agent-svc/pyproject.toml
+++ b/agent-svc/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
-    "rq>=2.2.0",
     "redis>=5.2.0",
     "httpx>=0.28.0",
     "pydantic>=2.10.0",


### PR DESCRIPTION
## Summary

Removes the unused RQ (Redis Queue) dependency from agent-svc. All jobs are processed inline via `asyncio.create_task()` as documented in AGENTS.md. The `Queue` object was created and stored in `app.state.queue` but never read — the `_enqueue()` function that would consume it was also dead code (defined but never called).

**Files changed (3 files, 10 deletions):**
- `agent-svc/agent/app.py` — remove `from rq import Queue`, `Queue()` construction, `app.state.queue`
- `agent-svc/agent/api.py` — remove `from rq import Queue`, `_enqueue()` function, unused `Any` import
- `agent-svc/pyproject.toml` — remove `rq>=2.2.0` dependency

The `redis>=5.2.0` package is **kept** — it's the Valkey client, actively used by `SlidingWindowRateLimiter` and `app.state.redis`.

## Related Issue

Closes #196

## Type of Change

- [x] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)

## Test Plan

- [x] Integration tests pass: `docker compose exec agent-svc python3 /app/agent/tests/test_stack.py`
- [ ] New tests added for the change *(not applicable — dead code removal)*
- [x] Manual verification done: Docker build succeeds, container starts, `/health` returns OK, `/v2/answer` responds correctly

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) *(not applicable — no API or behavior change)*
- [ ] I have added tests that prove my fix is effective or my feature works *(not applicable — dead code removal)*
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure *(not applicable)*

## Notes for Reviewers

Straightforward dead-code removal. The RQ queue was wired up but never consumed — `_enqueue()` was the only caller of `queue.enqueue()` and it was never called anywhere. Verified by grepping for `_enqueue` and `app.state.queue` across the entire agent-svc codebase (zero consumers found).

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
