### PR TITLE
fix, remove dead try, except in _compute_domain_category

### DIFF
--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -235,10 +235,7 @@ def _compute_domain_category(url: str) -> str:
         news (0.3), social (0.4), blog (0.6), api (0.7),
         unknown (0.8), reference (1.0), docs (1.2)
     """
-    try:
-        netloc = urllib.parse.urlparse(url).netloc.lower()
-    except Exception:
-        return "unknown"
+    netloc = urllib.parse.urlparse(url).netloc.lower()
 
     if not netloc:
         return "unknown"


### PR DESCRIPTION
Removes the dead try, except block in _compute_domain_category in semantic-svc, app.py.

urllib.parse.urlparse always returns a valid ParseResult for any string and never raises, so the except branch was unreachable. The existing empty netloc guard at the line below already covers the unknown case.

Closes #246.