### PR TITLE
fix: log Qdrant lookup failures instead of silently swallowing them

### DIFF
--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -868,7 +868,11 @@ async def index_page(body: IndexRequest):
         if existing and existing[0].payload:
             existing_payload = existing[0].payload
     except Exception:
-        pass
+        logger.warning(
+            "Qdrant lookup failed during index for %s — proceeding as new page",
+            body.url,
+            exc_info=True,
+        )
 
     # Embed the content
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Summary

`semantic-svc/app.py:873-874` uses bare `except Exception: pass` when querying Qdrant for an existing page before indexing:

```python
try:
    existing = qdrant.query_points(...)
    if existing and existing[0].payload:
        existing_payload = existing[0].payload
except Exception:
    pass
```

If Qdrant is unreachable, misconfigured, or returns malformed data, the error is silently swallowed and indexing proceeds as if the page is new — potentially creating duplicate vectors and silently corrupting the index.

## Fix

1. Catch specific Qdrant exceptions (QdrantException, connection errors)
2. Log at WARNING level when Qdrant is unreachable
3. Decide: should the index operation fail when Qdrant can't be reached, or proceed with a warning?
4. At minimum: `logger.warning("Qdrant lookup failed during index — proceeding as new page", exc_info=True)`
