### PR TITLE
fix: log semantic indexing failures instead of silently swallowing them

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -963,11 +963,18 @@ async def get_llmstxt_status(request: Request, job_id: str):
 
 async def _index_scrape(url: str, title: str, content: str, request) -> None:
     """Fire-and-forget index a scraped page in the vector index."""
+    semantic = None
     try:
         from .semantic_client import SemanticClient
 
         semantic = SemanticClient(request.app.state.semantic_url)
         await semantic.index_page(url, title, content[:2000])
-        await semantic.close()
     except Exception:
-        pass
+        logger.warning(
+            "Semantic indexing failed for %s — page will not appear in vector search",
+            url,
+            exc_info=True,
+        )
+    finally:
+        if semantic is not None:
+            await semantic.close()


### PR DESCRIPTION
## Summary

`agent-svc/agent/api.py:968-973` swallows all errors during semantic indexing of scraped pages:

```python
try:
    semantic = SemanticClient(...)
    await semantic.index_page(url, title, content[:2000])
    await semantic.close()
except Exception:
    pass
```

When the semantic service is down, scraped pages are returned to the user but never indexed — with zero indication. This is a data-loss-by-silence pattern.

## Fix

1. Log at WARNING level when indexing fails: `logger.warning("Semantic indexing failed for %s", url, exc_info=True)`
2. Consider whether the scrape should still succeed when indexing fails, or whether indexing should be fire-and-forget with retry
3. The `SemanticClient.close()` should be in a `finally` block regardless of success/failure
