### PR TITLE
fix: narrow exception handling in semantic-svc model loading

### DIFF
--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -107,7 +107,7 @@ async def lifespan(app: FastAPI):
         )
         _models_ready = True
         logger.info("Models loaded — semantic-svc ready")
-    except Exception:
+    except (OSError, RuntimeError, ValueError):
         logger.exception(
             "Failed to load semantic models — /health will report 'starting'"
         )


### PR DESCRIPTION
## Summary

`semantic-svc/app.py:110` catches bare `except Exception` during model loading:

```python
try:
    _rerank_model = await loop.run_in_executor(...)
    _models_ready = True
except Exception:
    logger.exception("Failed to load semantic models...")
```

While the logging is good (uses `logger.exception` which includes full traceback), the catch is too broad. If model loading fails due to a non-recoverable error, the app starts with `_models_ready = False` and every search request produces errors — but the root cause traceback is buried in startup logs.

## Fix

Catch specific failure modes: `OSError` (model file missing), `RuntimeError` (CUDA OOM), `ValueError` (invalid model config). Let truly unexpected exceptions propagate to crash the app so the orchestrator (Docker/supervisor) can restart it.

Also consider: should the app refuse to start (exit non-zero) if model loading fails, rather than starting degraded? A degraded start that can never recover is misleading.
