### PR TITLE
feat: add .dockerignore to reduce Docker build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# GroktoCrawl Docker build context exclusions
+# Keeps build contexts lean and cache-friendly for CI and local dev.
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.eggs/
+dist/
+build/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Tests
+tests/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Docs
+docs/
+droid-wiki/
+
+# Skills (Hermes agent skill directory)
+skills/
+
+# CI
+.github/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Environment
+.env
+.env.*
+
+# macOS
+.DS_Store
+
+# Markdown docs
+*.md
+!AGENTS.md
+!CONTRIBUTING.md
+!README.md
+
+# Docker (don't recurse)
+docker-compose*.yml
+Dockerfile*
+.dockerignore
+
+# Misc
+*.log


### PR DESCRIPTION
## Summary

No `.dockerignore` file exists in the repo root. Every `docker build` sends the entire repo (including test files, docs, droid-wiki, and other services' source) to the Docker daemon. This:

1. Slows CI builds (unnecessary context transfer)
2. Bloats layer cache invalidation (any file change in any dir busts the build cache)
3. Some services already use `context: ./service-dir` in their Dockerfiles, but the CI matrix overrides this with `context: .`

## Fix

1. Create a root `.dockerignore` excluding: `tests/`, `docs/`, `droid-wiki/`, `skills/`, `.github/`, `*.md`, `__pycache__/`, `*.pyc`, `.git/`
2. Audit the CI matrix in `.github/workflows/docker.yml` — ensure per-service contexts match what the Dockerfiles expect
3. For services that legitimately need the full context (agent-svc, scraper-svc), document why in a comment
