### PR TITLE
fix: install system deps for Playwright Chromium in scraper-svc and browser-svc Dockerfiles

### DIFF
--- a/browser-svc/Dockerfile
+++ b/browser-svc/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY browser-svc/pyproject.toml .
 RUN pip install --no-cache-dir -e .
 RUN python -m playwright install chromium
+RUN python -m playwright install-deps chromium
 
 COPY browser-svc/browser_svc/ browser_svc/
 COPY common/ common/

--- a/scraper-svc/Dockerfile
+++ b/scraper-svc/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --no-cache-dir -e .
 # Install with playwright extras for Tier 3
 RUN pip install --no-cache-dir -e ".[playwright]"
 RUN python -m playwright install chromium
+RUN python -m playwright install-deps chromium
 
 COPY scraper-svc/scraper/ scraper/
 COPY common/ common/


### PR DESCRIPTION
## Summary

Adds `RUN python -m playwright install-deps chromium` to both the scraper-svc and browser-svc Dockerfiles.

## Problem

Both Docker images use `python:3.13-slim` (Debian 13 Trixie) and install Chromium via `playwright install chromium`, but never run `playwright install-deps` to install the system shared libraries the browser needs to execute. The result is that **any scrape requiring browser rendering returns a 502 error.**

Error from both containers:
```
chrome-headless-shell: error while loading shared libraries: libglib-2.0.so.0: cannot open shared object file: No such file or directory
```

## Files changed

- `scraper-svc/Dockerfile` — added `RUN python -m playwright install-deps chromium`
- `browser-svc/Dockerfile` — added `RUN python -m playwright install-deps chromium`

## QA

- `search` (SlopSearX) — unaffected
- `scrape` on adapter-handled sites (GitHub, YouTube, etc.) — unaffected (adapters skip the browser pipeline)
- Browser render (Tier 3 generic fallback) — **fixed** after this change
- `agent` / `answer` relying on scraped content — **fixed** once browser pipeline works

Closes #258

Filed by Jasper (AI agent on behalf of Magnus Hedemark)