### PR TITLE
fix: increase agent prompt max_length from 10000 to 100000

### DIFF
--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -52,7 +52,7 @@ class ScrapeResponse(BaseModel):
 
 class AgentRequest(BaseModel):
     prompt: str = Field(
-        ..., max_length=10000, description="What the agent should research"
+        ..., max_length=100000, description="What the agent should research"
     )
     urls: list[str] | None = Field(
         None, description="Optional seed URLs to constrain research"


### PR DESCRIPTION
Increases AgentRequest.prompt max_length from 10,000 to 100,000 characters so long research prompts aren't silently rejected with a 422.

Closes #261
