### PR TITLE
fix: add LLM health check and SSE status heartbeat to agent endpoint

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -165,10 +165,14 @@ async def create_agent(request: Request, body: AgentRequest, response: Response)
         from .llm import LLMClient
 
         health_logger = logging.getLogger(__name__)
+        effective_model = (
+            body.model if body.model and body.model != "default"
+            else request.app.state.llm_model
+        )
         llm_check = LLMClient(
             base_url=request.app.state.llm_base_url,
             api_key=request.app.state.llm_api_key,
-            model=request.app.state.llm_model,
+            model=effective_model,
         )
         if not await llm_check.check_health():
             health_logger.error("LLM backend unreachable. Agent disabled.")

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -161,6 +161,25 @@ async def create_agent(request: Request, body: AgentRequest, response: Response)
 
     # Streaming path — run inline, return SSE
     if body.stream:
+        # Pre-flight LLM health check — fail fast before opening the stream
+        from .llm import LLMClient
+
+        health_logger = logging.getLogger(__name__)
+        llm_check = LLMClient(
+            base_url=request.app.state.llm_base_url,
+            api_key=request.app.state.llm_api_key,
+            model=request.app.state.llm_model,
+        )
+        if not await llm_check.check_health():
+            health_logger.error("LLM backend unreachable. Agent disabled.")
+            await llm_check.close()
+            from fastapi import HTTPException
+
+            raise HTTPException(
+                status_code=503,
+                detail="LLM backend is not available. Cannot process agent request.",
+            )
+        await llm_check.close()
         from fastapi.responses import StreamingResponse
 
         async def event_stream():
@@ -192,6 +211,8 @@ async def create_agent(request: Request, body: AgentRequest, response: Response)
                     yield f"data: {json.dumps({'type': 'done', 'result': event['result'], 'sources': event['sources'], 'latency_ms': event['latency_ms']})}\n\n"
                 elif event["type"] == "error":
                     yield f"data: {json.dumps({'type': 'error', 'content': event['content']})}\n\n"
+                elif event["type"] == "status":
+                    yield f"data: {json.dumps({'type': 'status', 'state': event['state']})}\n\n"
             yield "data: [DONE]\n\n"
 
         headers = {

--- a/agent-svc/agent/llm.py
+++ b/agent-svc/agent/llm.py
@@ -197,5 +197,40 @@ class LLMClient:
             logger.error("LLM call failed: %s", e)
             return f"Error: LLM call failed: {e}"
 
+    async def check_health(self) -> bool:
+        """Check if the LLM backend is reachable and responding.
+
+        Sends a minimal request (max_tokens=1, stream=False) with a
+        short 5s timeout. Returns True if the backend responds with
+        HTTP 200, False otherwise. Never raises exceptions.
+        """
+        body = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+            "stream": False,
+        }
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.post(
+                    f"{self.base_url}/chat/completions",
+                    headers=headers,
+                    json=body,
+                )
+                if resp.status_code == 200:
+                    return True
+                logger.error(
+                    "LLM health check failed: HTTP %d — %s",
+                    resp.status_code,
+                    resp.text[:500],
+                )
+                return False
+        except Exception as e:
+            logger.error("LLM health check failed: %s", e)
+            return False
+
     async def close(self):
         await self._client.aclose()

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -236,6 +236,9 @@ async def run_research_stream(
     llm = LLMClient(llm_base_url, llm_api_key, effective_model)
 
     try:
+        # Yield status heartbeat — searching phase
+        yield {"type": "status", "state": "searching"}
+
         discovered = await _run_research_discover_and_scrape(
             prompt=prompt,
             urls=urls,
@@ -283,6 +286,9 @@ async def run_research_stream(
                 "latency_ms": elapsed,
             }
             return
+
+        # Yield status heartbeat — synthesizing phase
+        yield {"type": "status", "state": "synthesizing"}
 
         # Phase 2: Synthesis
         # If schema is provided, use synchronous generation (structured JSON output)

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -551,10 +551,12 @@ class TestRunResearchStream:
             async for event in run_research_stream(prompt="What is AI?"):
                 events.append(event)
 
-        # Verify event sequence
-        assert len(events) >= 4
-        assert events[0]["type"] == "sources_pending"
-        assert len(events[0]["sources"]) == 1
+        # Verify event sequence — status heartbeat is now the first event
+        assert len(events) >= 5
+        assert events[0]["type"] == "status"
+        assert events[0]["state"] == "searching"
+        assert events[1]["type"] == "sources_pending"
+        assert len(events[1]["sources"]) == 1
         # source_scraped events
         scraped_events = [e for e in events if e["type"] == "source_scraped"]
         assert len(scraped_events) >= 1


### PR DESCRIPTION
## Summary
Pre-flight LLM health check before opening SSE stream + status heartbeat events at phase boundaries. Prevents silent empty-output failures when the LLM backend is unavailable.

## Changes
- **agent-svc/agent/llm.py** — Added `check_health()`: lightweight ping with 5s timeout, returns True/False
- **agent-svc/agent/api.py** — Pre-flight check returns 503 if LLM is unreachable; status event handler added to SSE stream
- **agent-svc/agent/research.py** — Status heartbeats at `searching` and `synthesizing` phase boundaries

## How it works
1. Before opening the SSE stream, the server pings the LLM backend with a 1-token request (5s timeout)
2. If the LLM is down, the server returns HTTP 503 with a clear error message — no SSE stream at all
3. During the SSE stream, status events tell the CLI whether the server is searching vs synthesizing
4. The CLI can detect a server that stopped producing events (no status heartbeat received within expected time)

Closes #262
