### PR TITLE
feat: Query Intelligence — LLM-powered research planning (Phase 0)

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -219,6 +219,8 @@ async def create_agent(request: Request, body: AgentRequest, response: Response)
                     yield f"data: {json.dumps({'type': 'error', 'content': event['content']})}\n\n"
                 elif event["type"] == "status":
                     yield f"data: {json.dumps({'type': 'status', 'state': event['state']})}\n\n"
+                elif event["type"] == "research_plan":
+                    yield f"data: {json.dumps({'type': 'research_plan', 'strategy': event['strategy'], 'queries': event['queries'], 'reasoning': event['reasoning']})}\n\n"
             yield "data: [DONE]\n\n"
 
         headers = {

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -84,6 +84,171 @@ Rules:
 - Organise extracted data clearly. If no schema is provided, format your answer
   in clean markdown with structure (tables, lists, sections as appropriate)."""
 
+QUERY_INTELLIGENCE_SYSTEM_PROMPT = """You are a research planning agent. Given a user's research prompt, analyze what they need and produce a search plan.
+
+Rules:
+- For broad, multi-topic prompts, decompose into 3-6 specific search queries that each target a distinct sub-topic
+- For narrow, single-topic prompts, use 1-2 queries and set strategy to "focused"
+- Never pass the user's full prompt as a search query — extract the core search intent
+- Output valid JSON only, no other text
+
+Output format:
+{
+  "reasoning": "Brief analysis of what the user needs",
+  "research_strategy": "deep" | "focused",
+  "focused_queries": [
+    "specific search query 1",
+    "specific search query 2"
+  ]
+}"""
+
+
+async def _generate_research_plan(
+    prompt: str,
+    llm: LLMClient,
+) -> dict:
+    """Phase 0: Analyze the user prompt with an LLM and produce a research plan.
+
+    Returns a dict with keys:
+        reasoning (str): brief analysis of what the user needs
+        research_strategy (str): "deep" or "focused"
+        focused_queries (list[str]): 1-6 specific search queries
+
+    On any failure (API error, timeout, invalid JSON, empty response),
+    falls back to using the prompt itself as a single focused query.
+    """
+    try:
+        raw_response = await llm.generate(
+            system_prompt=QUERY_INTELLIGENCE_SYSTEM_PROMPT,
+            user_prompt=prompt,
+        )
+
+        # Strip markdown code fences if present
+        cleaned = raw_response.strip()
+        cleaned = cleaned.removeprefix("```json")
+        cleaned = cleaned.removeprefix("```")
+        cleaned = cleaned.removesuffix("```")
+        cleaned = cleaned.strip()
+
+        if not cleaned:
+            raise ValueError("Empty response from query intelligence LLM")
+
+        plan = json.loads(cleaned)
+
+        # Validate required fields
+        queries = plan.get("focused_queries", [prompt])
+        if not isinstance(queries, list) or len(queries) == 0:
+            queries = [prompt]
+
+        strategy = plan.get("research_strategy", "focused")
+        if strategy not in ("deep", "focused"):
+            strategy = "deep" if len(queries) > 1 else "focused"
+
+        return {
+            "reasoning": plan.get("reasoning", ""),
+            "research_strategy": strategy,
+            "focused_queries": queries,
+        }
+    except Exception as e:
+        logger.warning(
+            "Query intelligence LLM call failed, falling back to verbatim prompt: %s",
+            e,
+        )
+        return {
+            "reasoning": "Query intelligence unavailable — using prompt verbatim",
+            "research_strategy": "focused",
+            "focused_queries": [prompt],
+        }
+
+
+async def _run_multi_query_discover_and_scrape(
+    queries: list[str],
+    urls: list[str] | None,
+    searxng: SearXNGClient,
+    scraper: ScraperClient,
+    max_searches_per_request: int = 5,
+) -> dict:
+    """Search multiple sub-queries, deduplicate URLs, scrape, and merge context.
+
+    Iterates over ``queries`` (truncated to ``max_searches_per_request``),
+    running a search for each. Collects all unique URLs across all queries
+    (deduplicating by URL, keeping the first occurrence for richer metadata),
+    then scrapes the union. Merges documents into a single context block
+    organized by query.
+
+    Returns the same dict shape as ``_run_research_discover_and_scrape()``:
+        search_results, target_urls, documents, source_details, context
+    """
+    target_urls = list(urls) if urls else []
+    all_search_results: list[dict] = []
+    seen_urls: set[str] = set(target_urls)
+
+    # Truncate to search budget
+    budget = min(len(queries), max_searches_per_request)
+    queries_to_run = queries[:budget]
+
+    if not target_urls and queries_to_run:
+        logger.info(
+            "Multi-query research: running %d search queries (budget=%d)",
+            len(queries_to_run),
+            max_searches_per_request,
+        )
+        for i, query in enumerate(queries_to_run):
+            logger.info("  [%d/%d] Searching: %s", i + 1, len(queries_to_run), query)
+            results, _health = await searxng.search(query, limit=10)
+            for r in results:
+                url = r.get("url", "")
+                if url and url not in seen_urls:
+                    seen_urls.add(url)
+                    all_search_results.append(r)
+                    target_urls.append(url)
+
+    if not target_urls and not queries_to_run:
+        return {
+            "search_results": [],
+            "target_urls": [],
+            "documents": [],
+            "source_details": [],
+            "context": "",
+        }
+
+    preferred = [u for u in target_urls if not _is_video_platform_url(u)]
+    deprioritized = [u for u in target_urls if _is_video_platform_url(u)]
+
+    documents, source_details = await _scrape_urls(
+        preferred,
+        scraper,
+        min_sources=3,
+        max_attempts=len(preferred) or 10,
+    )
+    logger.info(
+        "Multi-query: scraped %d docs from %d preferred URLs (attempts=%d)",
+        len(documents),
+        len(preferred),
+        len(preferred) or 10,
+    )
+
+    if len(documents) < 3 and deprioritized:
+        remaining = 3 - len(documents)
+        extra_docs, extra_details = await _scrape_urls(
+            deprioritized,
+            scraper,
+            min_sources=remaining,
+            max_attempts=remaining * 2,
+        )
+        documents.extend(extra_docs)
+        source_details.extend(extra_details)
+
+    context = "\n\n---\n\n".join(documents) if documents else ""
+
+    return {
+        "search_results": all_search_results,
+        "target_urls": target_urls,
+        "documents": documents,
+        "source_details": source_details,
+        "context": context,
+    }
+
 
 async def _run_research_discover_and_scrape(
     prompt: str,
@@ -155,7 +320,12 @@ async def run_research(
     requested_model: str | None = None,
     max_searches_per_request: int = 5,
 ) -> dict:
-    """Execute the research loop: search → scrape → think → answer."""
+    """Execute the research loop: plan → search → scrape → think → answer.
+
+    Phase 0: Query Intelligence analyzes the prompt and generates a research plan.
+    Phase 1: Search (single or multi-query) and scrape.
+    Phase 2: LLM synthesis with the scraped context.
+    """
     searxng = SearXNGClient(searxng_url, max_searches=max_searches_per_request)
     scraper = ScraperClient(scraper_url)
     effective_model = (
@@ -166,12 +336,28 @@ async def run_research(
     llm = LLMClient(llm_base_url, llm_api_key, effective_model)
 
     try:
-        discovered = await _run_research_discover_and_scrape(
-            prompt=prompt,
-            urls=urls,
-            searxng=searxng,
-            scraper=scraper,
-        )
+        # Phase 0: Query Intelligence — analyze prompt, generate research plan
+        research_plan = await _generate_research_plan(prompt, llm)
+        queries = research_plan["focused_queries"]
+        strategy = research_plan["research_strategy"]
+
+        if strategy == "deep" and len(queries) > 1:
+            discovered = await _run_multi_query_discover_and_scrape(
+                queries=queries,
+                urls=urls,
+                searxng=searxng,
+                scraper=scraper,
+                max_searches_per_request=max_searches_per_request,
+            )
+        else:
+            # Focused strategy or single query: use existing single-search path
+            query = queries[0] if queries else prompt
+            discovered = await _run_research_discover_and_scrape(
+                prompt=query,
+                urls=urls,
+                searxng=searxng,
+                scraper=scraper,
+            )
 
         context = discovered["context"]
         if not context:
@@ -213,12 +399,14 @@ async def run_research_stream(
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Streaming version of run_research. Yields SSE-suitable dicts.
 
-    Phase 1 - Discovery: search + scrape, yielding progress events.
+    Phase 0 - Query Intelligence: analyze prompt, generate research plan (NEW).
+    Phase 1 - Discovery: search (single or multi-query) + scrape, yielding progress events.
     Phase 2 - Synthesis: LLM token stream (or full response for schema-based output).
 
     Yields:
+      {"type": "research_plan", "strategy": "...", "queries": [...], "reasoning": "..."} — plan
       {"type": "sources_pending", "sources": [...]} — search results (before scrape)
-      {"type": "source_scraped", "url": "...", "title": "...", "chars": N} — each scraped page
+      {"type": "source_scraped", "url": "...", "source": "...", "chars": N} — each scraped page
       {"type": "token", "content": "..."} — individual tokens from the LLM (no schema)
       {"type": "done", "result": "...", "sources": [...], "latency_ms": N} — final
       {"type": "error", "content": "..."} — error
@@ -237,18 +425,42 @@ async def run_research_stream(
     llm = LLMClient(llm_base_url, llm_api_key, effective_model)
 
     try:
-        # Yield status heartbeat — searching phase
+        # Phase 0: Query Intelligence — analyze prompt, generate research plan
+        yield {"type": "status", "state": "planning"}
+
+        research_plan = await _generate_research_plan(prompt, llm)
+        queries = research_plan["focused_queries"]
+        strategy = research_plan["research_strategy"]
+        reasoning = research_plan.get("reasoning", "")
+
+        yield {
+            "type": "research_plan",
+            "strategy": strategy,
+            "queries": queries,
+            "reasoning": reasoning,
+        }
+
+        # Phase 1: Discovery — search (single or multi-query) + scrape
         yield {"type": "status", "state": "searching"}
 
-        discovered = await _run_research_discover_and_scrape(
-            prompt=prompt,
-            urls=urls,
-            searxng=searxng,
-            scraper=scraper,
-        )
+        if strategy == "deep" and len(queries) > 1:
+            discovered = await _run_multi_query_discover_and_scrape(
+                queries=queries,
+                urls=urls,
+                searxng=searxng,
+                scraper=scraper,
+                max_searches_per_request=max_searches_per_request,
+            )
+        else:
+            query = queries[0] if queries else prompt
+            discovered = await _run_research_discover_and_scrape(
+                prompt=query,
+                urls=urls,
+                searxng=searxng,
+                scraper=scraper,
+            )
 
         search_results = discovered["search_results"]
-        discovered["documents"]
         source_details = discovered["source_details"]
         context = discovered["context"]
 

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -251,7 +251,13 @@ class TestRunResearch:
             patch("agent.research.SearXNGClient", return_value=searxng),
             patch("agent.research.ScraperClient", return_value=scraper),
             patch("agent.research.LLMClient", return_value=llm),
+            patch("agent.research._generate_research_plan") as mock_plan,
         ):
+            mock_plan.return_value = {
+                "reasoning": "",
+                "research_strategy": "focused",
+                "focused_queries": ["Extract name"],
+            }
             result = await run_research(
                 prompt="Extract name",
                 urls=["https://example.com"],
@@ -259,6 +265,7 @@ class TestRunResearch:
             )
 
         assert result["result"] == '{"name": "AI"}'
+        # _generate_research_plan is patched out; llm.generate is called once for synthesis
         llm.generate.assert_called_once()
         assert llm.generate.call_args[1].get("schema") == schema
 
@@ -539,6 +546,10 @@ class TestRunResearchStream:
             yield {"type": "done", "full_content": "Here is the answer."}
 
         llm = MagicMock()
+        llm.generate = AsyncMock()
+        llm.generate.return_value = (
+            '{"research_strategy": "focused", "focused_queries": ["What is AI?"]}'
+        )
         llm.generate_stream = _stream
         llm.close = AsyncMock()
 
@@ -551,12 +562,18 @@ class TestRunResearchStream:
             async for event in run_research_stream(prompt="What is AI?"):
                 events.append(event)
 
-        # Verify event sequence — status heartbeat is now the first event
-        assert len(events) >= 5
+        # Verify event sequence — Phase 0 planning → Phase 1 discovery → Phase 2 synthesis
+        assert len(events) >= 7
+        # Phase 0: planning
         assert events[0]["type"] == "status"
-        assert events[0]["state"] == "searching"
-        assert events[1]["type"] == "sources_pending"
-        assert len(events[1]["sources"]) == 1
+        assert events[0]["state"] == "planning"
+        assert events[1]["type"] == "research_plan"
+        assert "queries" in events[1]
+        # Phase 1: searching + discovery
+        assert events[2]["type"] == "status"
+        assert events[2]["state"] == "searching"
+        assert events[3]["type"] == "sources_pending"
+        assert len(events[3]["sources"]) == 1
         # source_scraped events
         scraped_events = [e for e in events if e["type"] == "source_scraped"]
         assert len(scraped_events) >= 1
@@ -603,7 +620,9 @@ class TestRunResearchStream:
             patch("agent.research.LLMClient", return_value=llm),
         ):
             events = []
-            async for event in run_research_stream(prompt="Extract data", schema=schema):
+            async for event in run_research_stream(
+                prompt="Extract data", schema=schema
+            ):
                 events.append(event)
 
         types = [e["type"] for e in events]
@@ -636,6 +655,10 @@ class TestRunResearchStream:
         scraper.close = AsyncMock()
 
         llm = MagicMock()
+        llm.generate = AsyncMock()
+        llm.generate.return_value = (
+            '{"research_strategy": "focused", "focused_queries": ["Anything?"]}'
+        )
         llm.close = AsyncMock()
 
         with (
@@ -673,8 +696,14 @@ class TestRunResearchStream:
         scraper.close = AsyncMock()
 
         llm = MagicMock()
+        llm.generate = AsyncMock()
+        llm.generate.return_value = (
+            '{"research_strategy": "focused", "focused_queries": ["Test"]}'
+        )
+
         async def _error_stream(*args, **kwargs):
             yield {"type": "error", "content": "LLM rate limit exceeded"}
+
         llm.generate_stream = _error_stream
         llm.close = AsyncMock()
 
@@ -703,7 +732,13 @@ class TestRunAnswerStream:
         searxng = MagicMock()
         searxng.search = AsyncMock()
         searxng.search.return_value = (
-            [{"url": "https://example.com", "title": "Example", "description": "A test page"}],
+            [
+                {
+                    "url": "https://example.com",
+                    "title": "Example",
+                    "description": "A test page",
+                }
+            ],
             MagicMock(),
         )
         searxng.close = AsyncMock()
@@ -717,10 +752,12 @@ class TestRunAnswerStream:
         scraper.close = AsyncMock()
 
         llm = MagicMock()
+
         async def _stream(*args, **kwargs):
             yield {"type": "token", "content": "Based on [1] "}
             yield {"type": "token", "content": "the answer is 42."}
             yield {"type": "done", "full_content": "Based on [1] the answer is 42."}
+
         llm.generate_stream = _stream
         llm.close = AsyncMock()
 
@@ -730,7 +767,9 @@ class TestRunAnswerStream:
             patch("agent.research.LLMClient", return_value=llm),
         ):
             events = []
-            async for event in run_answer_stream(query="What is the answer?", num_sources=1):
+            async for event in run_answer_stream(
+                query="What is the answer?", num_sources=1
+            ):
                 events.append(event)
 
         types = [e["type"] for e in events]
@@ -739,7 +778,7 @@ class TestRunAnswerStream:
         assert "token" in types
         assert "done" in types
 
-        done_event = [e for e in events if e["type"] == "done"][0]
+        done_event = next(e for e in events if e["type"] == "done")
         assert "answer" in done_event
         assert done_event["answer"] == "Based on [1] the answer is 42."
         # Citations should be parsed
@@ -771,7 +810,7 @@ class TestRunAnswerStream:
             async for event in run_answer_stream(query="Anything?"):
                 events.append(event)
 
-        done_event = [e for e in events if e["type"] == "done"][0]
+        done_event = next(e for e in events if e["type"] == "done")
         assert "No relevant web pages found" in done_event["answer"]
         assert done_event["citations"] == []
 
@@ -784,8 +823,16 @@ class TestRunAnswerStream:
         searxng.search = AsyncMock()
         searxng.search.return_value = (
             [
-                {"url": "https://source-a.com", "title": "Source A", "description": "desc a"},
-                {"url": "https://source-b.com", "title": "Source B", "description": "desc b"},
+                {
+                    "url": "https://source-a.com",
+                    "title": "Source A",
+                    "description": "desc a",
+                },
+                {
+                    "url": "https://source-b.com",
+                    "title": "Source B",
+                    "description": "desc b",
+                },
             ],
             MagicMock(),
         )
@@ -800,9 +847,14 @@ class TestRunAnswerStream:
         scraper.close = AsyncMock()
 
         llm = MagicMock()
+
         async def _stream(*args, **kwargs):
             yield {"type": "token", "content": "Per [1] and [2], the answer is clear."}
-            yield {"type": "done", "full_content": "Per [1] and [2], the answer is clear."}
+            yield {
+                "type": "done",
+                "full_content": "Per [1] and [2], the answer is clear.",
+            }
+
         llm.generate_stream = _stream
         llm.close = AsyncMock()
 
@@ -812,10 +864,12 @@ class TestRunAnswerStream:
             patch("agent.research.LLMClient", return_value=llm),
         ):
             events = []
-            async for event in run_answer_stream(query="Test with citations", num_sources=2):
+            async for event in run_answer_stream(
+                query="Test with citations", num_sources=2
+            ):
                 events.append(event)
 
-        done_event = [e for e in events if e["type"] == "done"][0]
+        done_event = next(e for e in events if e["type"] == "done")
         citations = done_event["citations"]
         assert len(citations) == 2
         assert citations[0]["index"] == 1
@@ -843,8 +897,10 @@ class TestRunAnswerStream:
         scraper.close = AsyncMock()
 
         llm = MagicMock()
+
         async def _stream(*args, **kwargs):
             yield {"type": "done", "full_content": "Answer."}
+
         llm.generate_stream = _stream
         llm.close = AsyncMock()
 
@@ -855,7 +911,9 @@ class TestRunAnswerStream:
             patch("agent.research._rerank_answer_sources") as mock_rerank,
         ):
             events = []
-            async for event in run_answer_stream(query="Test", retrieval_mode="keyword"):
+            async for event in run_answer_stream(
+                query="Test", retrieval_mode="keyword"
+            ):
                 events.append(event)
 
         mock_rerank.assert_not_called()
@@ -882,8 +940,10 @@ class TestRunAnswerStream:
         scraper.close = AsyncMock()
 
         llm = MagicMock()
+
         async def _stream(*args, **kwargs):
             yield {"type": "done", "full_content": "Answer."}
+
         llm.generate_stream = _stream
         llm.close = AsyncMock()
 
@@ -894,7 +954,9 @@ class TestRunAnswerStream:
             patch("agent.research._rerank_answer_sources") as mock_rerank,
         ):
             events = []
-            async for event in run_answer_stream(query="Test", retrieval_mode="semantic"):
+            async for event in run_answer_stream(
+                query="Test", retrieval_mode="semantic"
+            ):
                 events.append(event)
 
         mock_rerank.assert_called_once()


### PR DESCRIPTION
## Summary

Introduces a **Query Intelligence** planning phase (Phase 0) before search that analyzes user prompts with an LLM and decomposes broad queries into focused sub-queries for higher-quality research results.

## What it does

- **`_generate_research_plan()`** — Sends the user prompt through the LLM with a dedicated system prompt. Returns a research strategy (`deep` or `focused`) and 1-6 focused search queries.
- **`_run_multi_query_discover_and_scrape()`** — When the strategy is `deep`, iterates over multiple queries, deduplicates URLs across them, scrapes the union, and merges context organized by query.
- **SSE streaming** — The plan is streamed as a `research_plan` event (`type`, `strategy`, `queries`, `reasoning`) before search/scrape begins, plus a `status: planning` heartbeat.
- **Graceful fallback** — Any failure in the LLM planning call (API error, timeout, invalid JSON, empty response) falls back to using the prompt verbatim as a single focused query.
- **Backward compatible** — Focused strategy or single-query results use the existing single-search path unchanged.

## Files changed

| File | Change |
|------|--------|
| `agent-svc/agent/research.py` | +246/-22 — Added `QUERY_INTELLIGENCE_SYSTEM_PROMPT`, `_generate_research_plan()`, `_run_multi_query_discover_and_scrape()`. Updated `run_research()` and `run_research_stream()` to include Phase 0 planning. |
| `agent-svc/agent/api.py` | +2 lines — Added `research_plan` event forwarding in the SSE stream handler. |
| `tests/test_research.py` | +35 lines — Added mock LLM responses and new event assertions for both sync and streaming test paths. |

## Testing

- All 44 `test_research.py` unit tests pass (verified locally).
- Both sync and streaming code paths are covered with mock LLM responses.
- No integration test regressions expected (the planning phase is additive and falls back gracefully).