### PR TITLE
gitignore: add docker-compose.override.yml + ofelia local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ __pypackages__/
 .planning/
 .coverage
 graphify-out/
+docker-compose.override.yml
+ofelia/config.local.ini
 
 # OS files
 .DS_Store


### PR DESCRIPTION
Adds two gitignore patterns for deployment-specific files that should never be tracked:

- `docker-compose.override.yml` — Docker Compose docs explicitly recommend ignoring this file. It's meant for local overrides (port mappings, volume mounts, env vars) that differ per environment.
- `ofelia/config.local.ini` — local Ofelia job config that varies per VPS. The tracked `config.ini` serves as the template; `config.local.ini` supplies instance-specific schedules and targets.

Both patterns are already used locally in the VPS deployment this repo runs on, and match standard docker/ofelia project conventions.