### PR TITLE
feat(crawl-status-response-enhancement): enhance CrawlStatusResponse with timestamps, per-page metadata, and field validation

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -294,17 +294,25 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
     store: JobStore = request.app.state.job_store
     job_id = store.create_job(kind="crawl", payload=body.model_dump())
 
+    # Resolve limit vs max_pages conflict (stricter wins, per VAL-CRAWL-089)
+    effective_max_pages = body.max_pages
+    if body.limit is not None:
+        effective_max_pages = min(body.max_pages, body.limit)
+
     from .worker import _process_crawl_async
 
     request.app.state.task_tracker.create_background_task(
         _process_crawl_async(
             job_id=job_id,
             url=body.url,
-            max_pages=body.max_pages,
+            max_pages=effective_max_pages,
             max_depth=body.max_depth,
             scraper_url=request.app.state.scraper_url,
             webhook_config=body.webhook,
             task_tracker=request.app.state.task_tracker,
+            ignore_query_parameters=body.ignore_query_parameters,
+            include_paths=body.include_paths,
+            exclude_paths=body.exclude_paths,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -8,10 +8,7 @@ from datetime import UTC
 from typing import Any
 
 import httpx
-from bs4 import BeautifulSoup
 from fastapi import APIRouter, Request, Response
-
-from common.url import extract_domain, is_same_origin
 
 from .exceptions import (
     BrowserError,
@@ -744,22 +741,33 @@ async def map_site(request: Request, body: MapRequest) -> MapResponse:
             resp = await client.get(body.url)
             if resp.status_code != 200:
                 raise UpstreamError(detail=f"Site returned HTTP {resp.status_code}")
-            soup = BeautifulSoup(resp.text, "html.parser")
-            links: list[str] = []
-            for a in soup.find_all("a", href=True):
-                href: str = a["href"]  # type: ignore[assignment,union-attr]
-                if href.startswith("/"):
-                    href = f"{extract_domain(body.url, include_scheme=True)}{href}"
-                href_start = href.startswith(body.url.rstrip("/")) or is_same_origin(
-                    body.url, href
-                )
-                if href_start and href not in links:
-                    links.append(href)
-                    if len(links) >= body.limit:
-                        break
+
+            # Use shared LinkExtractor instead of inline BeautifulSoup parsing
+            from urllib.parse import urlparse
+
+            from .link_extractor import extract_links, filter_links
+
+            all_links = extract_links(resp.text, body.url)
+
+            # Filter links by domain scope (default: same-origin only)
+            base_domain = (urlparse(body.url).hostname or "").lower()
+            filtered = filter_links(
+                all_links,
+                base_domain=base_domain,
+                allow_subdomains=body.allow_subdomains,
+                allow_external_links=body.allow_external_links,
+            )
+
+            # Apply limit (truncates AFTER filtering)
+            result = filtered[: body.limit]
+
+            # Apply search filter (case-insensitive substring match)
             if body.search:
-                links = [link for link in links if body.search.lower() in link.lower()]
-            return MapResponse(links=links)
+                result = [
+                    link for link in result if body.search.lower() in link.lower()
+                ]
+
+            return MapResponse(links=result)
     except Exception as e:
         logger.error("Map failed for %s: %s", body.url, e)
         raise UpstreamError(detail=str(e)) from e

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -327,12 +327,31 @@ async def get_crawl_status(request: Request, job_id: str) -> CrawlStatusResponse
     if job is None:
         raise NotFoundError(detail="Job not found", details={"job_id": job_id})
     data = job.get("data") or {}
+
+    # Compute duration in milliseconds from created_at to completed_at
+    created_at = job.get("created_at")
+    completed_at = job.get("completed_at")
+    duration: int | None = None
+    if created_at and completed_at:
+        try:
+            from datetime import datetime as _dt
+
+            created_dt = _dt.fromisoformat(created_at)
+            completed_dt = _dt.fromisoformat(completed_at)
+            duration = int((completed_dt - created_dt).total_seconds() * 1000)
+        except (ValueError, TypeError):
+            duration = None
+
     return CrawlStatusResponse(
         status=job.get("status", "processing"),
         completed=data.get("completed", 0),
         total=data.get("total", 0),
         data=data.get("pages"),
         error=job.get("error"),
+        created_at=created_at,
+        completed_at=completed_at,
+        expires_at=job.get("expires_at"),
+        duration=duration,
     )
 
 

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -313,6 +313,8 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             ignore_query_parameters=body.ignore_query_parameters,
             include_paths=body.include_paths,
             exclude_paths=body.exclude_paths,
+            regex_on_full_url=body.regex_on_full_url,
+            verbose=body.verbose,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -1,0 +1,450 @@
+"""CrawlEngine — BFS crawl orchestrator for GroktoCrawl.
+
+Manages a queue of (url, depth) tuples, tracks seen URLs for dedup,
+enforces ``max_pages`` and ``max_depth`` limits, uses the shared
+``LinkExtractor`` to discover child links, integrates with
+``ScraperClient`` for per-page fetching, and writes progress to the
+job store for status polling.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from .link_extractor import extract_links, filter_links
+from .scraper_client import ScraperClient
+from .store import JobStore
+
+logger = logging.getLogger(__name__)
+
+
+# ── Data types ───────────────────────────────────────────────────
+
+
+@dataclass
+class CrawlOptions:
+    """Options controlling crawl behavior.
+
+    Attributes:
+        max_pages: Maximum number of pages to scrape (hard stop).
+        max_depth: Maximum link-follow depth. Pages at max_depth are
+            scraped but their links are not followed.
+        include_paths: If set, only URLs whose path matches at least one
+            of these glob/regex patterns are scraped.
+        exclude_paths: URLs whose path matches any of these glob/regex
+            patterns are excluded (takes precedence over include).
+        ignore_query_parameters: If True, query-string variants of the
+            same base URL are collapsed to one fetch.
+        regex_on_full_url: If True, include/exclude paths are treated as
+            regex patterns (default: glob).
+        allow_subdomains: If True, follow links to subdomains.
+        allow_external_links: If True, follow links to external domains.
+    """
+
+    max_pages: int = 10
+    max_depth: int = 2
+    include_paths: list[str] | None = None
+    exclude_paths: list[str] | None = None
+    ignore_query_parameters: bool = False
+    regex_on_full_url: bool = False
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
+
+
+@dataclass
+class CrawlResult:
+    """Result of a crawl run."""
+
+    pages: list[dict] = field(default_factory=list)
+    total: int = 0
+    completed: int = 0
+    errors: list[dict] = field(default_factory=list)
+
+
+# ── Public functions ─────────────────────────────────────────────
+
+
+def _clean_path(path: str) -> str:
+    """Clean up a URL path by collapsing dot segments and normalizing.
+
+    Collapses ``/./`` and ``/../`` segments, and reduces ``/.`` at the
+    end to ``/``.
+    """
+    import posixpath
+
+    if not path:
+        return "/"
+
+    # posixpath.normpath collapses dot segments
+    cleaned = posixpath.normpath(path)
+
+    # normpath strips trailing slash, but root should remain /
+    if not cleaned:
+        return "/"
+
+    return cleaned
+
+
+def normalize_url(url: str, ignore_query_parameters: bool = False) -> str:
+    """Normalize a URL for dedup within a crawl run.
+
+    Steps:
+        1. Strip fragment identifier.
+        2. Lowercase scheme and host.
+        3. Remove default ports (80 for http, 443 for https).
+        4. Normalize trailing slash (remove for non-root paths).
+        5. Collapse ``/./`` and ``/../`` path segments.
+        6. Optionally strip query string entirely.
+        7. Sort query parameters if keeping them.
+
+    Args:
+        url: The URL to normalize.
+        ignore_query_parameters: If True, strip the query string.
+
+    Returns:
+        Normalized URL string.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname.lower() if parsed.hostname else ""
+    port = parsed.port
+    path = _clean_path(parsed.path or "/")
+
+    # Build netloc without default ports
+    netloc = hostname
+    if port is not None and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        netloc = f"{hostname}:{port}"
+
+    # Normalize trailing slash for non-root paths
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+
+    # Handle query parameters
+    if ignore_query_parameters:
+        query = ""
+    else:
+        # Sort query params for consistency
+        parsed_qs = parsed.query
+        if parsed_qs:
+            params = sorted(parsed_qs.split("&"))
+            query = "&".join(params)
+        else:
+            query = ""
+
+    normalized = urlunparse((scheme, netloc, path, parsed.params, query, ""))
+    return normalized
+
+
+async def fetch_html(url: str, timeout: float = 15.0) -> str | None:
+    """Fetch raw HTML from a URL for link extraction purposes.
+
+    This is a lightweight HTTP GET that follows redirects and returns
+    the response text. It is used by ``CrawlEngine`` to discover child
+    links from scraped pages, separate from the content scraping done
+    via ``ScraperClient``.
+
+    Args:
+        url: The URL to fetch.
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        The response text (HTML), or ``None`` if the fetch failed.
+    """
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
+            resp = await client.get(url)
+            if resp.status_code == 200:
+                return resp.text
+            logger.debug("fetch_html got status %d for %s", resp.status_code, url)
+            return None
+    except Exception as e:
+        logger.debug("fetch_html failed for %s: %s", url, e)
+        return None
+
+
+def _match_path(
+    url: str,
+    include_paths: list[str] | None,
+    exclude_paths: list[str] | None,
+    regex_on_full_url: bool = False,
+) -> bool:
+    """Check whether a URL passes include/exclude path filters.
+
+    Args:
+        url: The full URL to check.
+        include_paths: If set, URL must match at least one pattern.
+        exclude_paths: If set, URL must not match any pattern
+            (takes precedence).
+        regex_on_full_url: If True, patterns are regex; else glob.
+
+    Returns:
+        True if the URL should be crawled (passes all filters).
+    """
+    import re
+
+    target = url if regex_on_full_url else urlparse(url).path
+
+    if regex_on_full_url:
+        # Regex mode
+        if exclude_paths:
+            for pattern in exclude_paths:
+                try:
+                    if re.search(pattern, target):
+                        return False
+                except re.error:
+                    continue
+        if include_paths:
+            for pattern in include_paths:
+                try:
+                    if re.search(pattern, target):
+                        return True
+                except re.error:
+                    continue
+            return False  # include_paths set but none matched
+    else:
+        # Glob mode — convert glob patterns to regex
+        if exclude_paths:
+            for pattern in exclude_paths:
+                regex = _glob_to_regex(pattern)
+                try:
+                    if re.search(regex, target):
+                        return False
+                except re.error:
+                    continue
+        if include_paths:
+            for pattern in include_paths:
+                regex = _glob_to_regex(pattern)
+                try:
+                    if re.search(regex, target):
+                        return True
+                except re.error:
+                    continue
+            return False  # include_paths set but none matched
+
+    return True  # No include_paths constraint, or passed all
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Convert a simple glob pattern to an anchored regex pattern.
+
+    Supports ``*`` (match any chars except ``/``), ``**`` (match any
+    chars including ``/``), and ``?`` (match single char).
+
+    The returned pattern is anchored with ``^`` and ``$`` so that
+    ``re.search`` matches the full target string, not a substring.
+    """
+    i, n = 0, len(pattern)
+    inner: list[str] = []
+    while i < n:
+        c = pattern[i]
+        if c == "*" and i + 1 < n and pattern[i + 1] == "*":
+            inner.append(".*")
+            i += 2
+        elif c == "*":
+            inner.append("[^/]*")
+            i += 1
+        elif c == "?":
+            inner.append(".")
+            i += 1
+        elif c in ".^$+{}[]\\|()":
+            inner.append("\\" + c)
+            i += 1
+        else:
+            inner.append(c)
+            i += 1
+    return "^" + "".join(inner) + "$"
+
+
+# ── CrawlEngine ──────────────────────────────────────────────────
+
+
+class CrawlEngine:
+    """BFS crawl orchestrator.
+
+    Usage::
+
+        engine = CrawlEngine(scraper_client, options=CrawlOptions(max_pages=5))
+        result = await engine.run("https://example.com", job_id="...")
+    """
+
+    def __init__(
+        self,
+        scraper_client: ScraperClient,
+        store: JobStore | None = None,
+        options: CrawlOptions | None = None,
+    ):
+        self.scraper = scraper_client
+        self.store = store
+        self.options = options or CrawlOptions()
+        self._seen: set[str] = set()
+        self._queue: deque[tuple[str, int]] = deque()
+        self._pages: list[dict] = []
+        self._errors: list[dict] = []
+        self._cancel_flag: bool = False
+        self._update_interval: float = 1.0
+        self._html_client: httpx.AsyncClient | None = None
+
+    async def _get_html(self, url: str) -> str | None:
+        """Get HTML for a URL, using an internal persistent client."""
+        if self._html_client is None:
+            self._html_client = httpx.AsyncClient(follow_redirects=True, timeout=15.0)
+        try:
+            resp = await self._html_client.get(url)
+            if resp.status_code == 200:
+                return resp.text
+            return None
+        except Exception:
+            return None
+
+    async def close(self) -> None:
+        """Close the internal HTTP client."""
+        if self._html_client is not None:
+            await self._html_client.aclose()
+            self._html_client = None
+
+    async def run(self, start_url: str, job_id: str | None = None) -> CrawlResult:
+        """Execute a BFS crawl starting from ``start_url``.
+
+        Args:
+            start_url: The URL to begin crawling from.
+            job_id: Optional job ID for periodic store updates.
+
+        Returns:
+            A ``CrawlResult`` with scraped pages, totals, and errors.
+        """
+        parsed_start = urlparse(start_url)
+        base_domain = parsed_start.hostname.lower() if parsed_start.hostname else ""
+
+        # Seed the BFS queue
+        self._queue.append((start_url, 0))
+        last_store_update = time.monotonic()
+
+        while self._queue and len(self._pages) < self.options.max_pages:
+            if self._cancel_flag:
+                logger.info("Crawl cancelled via cancel flag")
+                break
+
+            url, depth = self._queue.popleft()
+            normalized = self.normalize_url(url)
+
+            # Dedup check
+            if normalized in self._seen:
+                logger.debug("Skipping already-seen URL: %s", url)
+                continue
+
+            # Max depth check: pages at max_depth are scraped but not
+            # followed; pages beyond max_depth are skipped entirely.
+            if depth > self.options.max_depth:
+                logger.debug("Skipping URL beyond max_depth: %s (depth=%d)", url, depth)
+                continue
+
+            # Mark as seen immediately to prevent re-enqueue
+            self._seen.add(normalized)
+
+            # Path filter check
+            if not _match_path(
+                url,
+                self.options.include_paths,
+                self.options.exclude_paths,
+                self.options.regex_on_full_url,
+            ):
+                logger.debug("Skipping URL excluded by path filter: %s", url)
+                continue
+
+            # Scrape the page
+            result = await self.scraper.scrape(url)
+
+            if not result.get("success"):
+                error_msg = result.get("error", "Unknown scrape error")
+                self._errors.append({"url": url, "error": error_msg})
+                logger.warning("Scrape failed for %s: %s", url, error_msg)
+
+                # Start URL failure — return error immediately
+                if depth == 0:
+                    logger.error("Start URL scrape failed: %s", error_msg)
+                    result_obj = CrawlResult(
+                        pages=[],
+                        total=0,
+                        completed=0,
+                        errors=self._errors,
+                    )
+                    await self.close()
+                    return result_obj
+                continue
+
+            # Record successful page
+            data = result.get("data", {})
+            page = {
+                "url": url,
+                "markdown": data.get("markdown", ""),
+            }
+            self._pages.append(page)
+
+            # Discover child links if within max_depth
+            if depth < self.options.max_depth:
+                html = await self._get_html(url)
+                if html:
+                    child_links = extract_links(html, url)
+                    child_links = filter_links(
+                        child_links,
+                        base_domain=base_domain,
+                        allow_subdomains=self.options.allow_subdomains,
+                        allow_external_links=self.options.allow_external_links,
+                    )
+                    for child_url in child_links:
+                        child_normalized = self.normalize_url(child_url)
+                        if child_normalized not in self._seen:
+                            self._queue.append((child_url, depth + 1))
+
+            # Periodic job store update
+            if self.store is not None and job_id is not None:
+                now = time.monotonic()
+                if now - last_store_update >= self._update_interval:
+                    self._update_store(job_id)
+                    last_store_update = now
+
+        # Final store update
+        if self.store is not None and job_id is not None:
+            self._update_store(job_id)
+
+        await self.close()
+
+        return CrawlResult(
+            pages=self._pages,
+            total=len(self._pages) + len(self._queue),
+            completed=len(self._pages),
+            errors=self._errors,
+        )
+
+    def normalize_url(self, url: str) -> str:
+        """Normalize a URL using this engine's options."""
+        return normalize_url(
+            url, ignore_query_parameters=self.options.ignore_query_parameters
+        )
+
+    def cancel(self) -> None:
+        """Signal the crawl to stop at the next opportunity."""
+        self._cancel_flag = True
+
+    def _update_store(self, job_id: str) -> None:
+        """Write current progress to the job store."""
+        if self.store is None:
+            return
+        try:
+            payload = {
+                "completed": len(self._pages),
+                "total": len(self._pages) + len(self._queue),
+                "pages": self._pages,
+                "errors": self._errors,
+            }
+            self.store.complete_job(job_id, payload)
+        except Exception:
+            logger.warning("Failed to update job store", exc_info=True)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -9,7 +9,10 @@ job store for status polling.
 
 from __future__ import annotations
 
+import json
 import logging
+import posixpath
+import re
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -76,8 +79,6 @@ def _clean_path(path: str) -> str:
     Collapses ``/./`` and ``/../`` segments, and reduces ``/.`` at the
     end to ``/``.
     """
-    import posixpath
-
     if not path:
         return "/"
 
@@ -188,8 +189,6 @@ def _match_path(
     Returns:
         True if the URL should be crawled (passes all filters).
     """
-    import re
-
     target = url if regex_on_full_url else urlparse(url).path
 
     if regex_on_full_url:
@@ -435,7 +434,13 @@ class CrawlEngine:
         self._cancel_flag = True
 
     def _update_store(self, job_id: str) -> None:
-        """Write current progress to the job store."""
+        """Write current progress to the job data key (not meta).
+
+        Updates only the ``data`` key in Valkey so the job's ``meta``
+        status (``processing``) remains unchanged during the crawl.
+        The caller's final ``store.complete_job()`` call sets both the
+        final data and the ``completed`` status.
+        """
         if self.store is None:
             return
         try:
@@ -445,6 +450,11 @@ class CrawlEngine:
                 "pages": self._pages,
                 "errors": self._errors,
             }
-            self.store.complete_job(job_id, payload)
+            # Write data key directly without changing meta status
+            self.store.redis.set(
+                f"job:{job_id}:data",
+                json.dumps(payload),
+                ex=86400,
+            )
         except Exception:
             logger.warning("Failed to update job store", exc_info=True)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -16,6 +16,7 @@ import re
 import time
 from collections import deque
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from urllib.parse import urlparse, urlunparse
 
 import httpx
@@ -400,8 +401,10 @@ class CrawlEngine:
                 logger.debug("Skipping URL excluded by path filter: %s", url)
                 continue
 
-            # Scrape the page
+            # Scrape the page with timing
+            scrape_start = time.monotonic()
             result = await self.scraper.scrape(url)
+            scrape_duration_ms = int((time.monotonic() - scrape_start) * 1000)
 
             if not result.get("success"):
                 error_msg = result.get("error", "Unknown scrape error")
@@ -421,11 +424,46 @@ class CrawlEngine:
                     return result_obj
                 continue
 
-            # Record successful page
+            # Record successful page with enriched metadata
             data = result.get("data", {})
+            metadata = data.get("metadata") or {}
+            og = metadata.get("og") or {}
+            meta = metadata.get("meta") or {}
+            title = (
+                og.get("title")
+                or meta.get("title")
+                or data.get("title")
+                or metadata.get("title")
+                or ""
+            )
+            description = (
+                og.get("description")
+                or meta.get("description")
+                or metadata.get("description")
+                or ""
+            )
+            source = data.get("source", "unknown")
+            status_code = metadata.get("statusCode") or data.get("status_code") or 200
+            content_type = (
+                metadata.get("content-type")
+                or metadata.get("contentType")
+                or "text/html"
+            )
+            scraped_at = datetime.now(UTC).isoformat()
+
             page = {
                 "url": url,
                 "markdown": data.get("markdown", ""),
+                "metadata": {
+                    "title": title,
+                    "description": description,
+                    "source": source,
+                },
+                "title": title,
+                "status_code": status_code,
+                "content_type": content_type,
+                "scraped_at": scraped_at,
+                "duration_ms": scrape_duration_ms,
             }
             self._pages.append(page)
 

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -46,6 +46,7 @@ class CrawlOptions:
             same base URL are collapsed to one fetch.
         regex_on_full_url: If True, include/exclude paths are treated as
             regex patterns (default: glob).
+        verbose: If True, track filtered-out URLs with reasons.
         allow_subdomains: If True, follow links to subdomains.
         allow_external_links: If True, follow links to external domains.
     """
@@ -56,6 +57,7 @@ class CrawlOptions:
     exclude_paths: list[str] | None = None
     ignore_query_parameters: bool = False
     regex_on_full_url: bool = False
+    verbose: bool = False
     allow_subdomains: bool = False
     allow_external_links: bool = False
 
@@ -68,6 +70,7 @@ class CrawlResult:
     total: int = 0
     completed: int = 0
     errors: list[dict] = field(default_factory=list)
+    filtered_out: list[dict] = field(default_factory=list)
 
 
 # ── Public functions ─────────────────────────────────────────────
@@ -231,6 +234,32 @@ def _match_path(
     return True  # No include_paths constraint, or passed all
 
 
+def _matches_pattern(
+    target: str, pattern: str, regex_on_full_url: bool = False
+) -> bool:
+    """Check whether ``target`` matches a single path pattern.
+
+    Args:
+        target: The string (path or full URL) to check.
+        pattern: The glob or regex pattern to match against.
+        regex_on_full_url: If True, ``pattern`` is a regex; else glob.
+
+    Returns:
+        True if the target matches the pattern.
+    """
+    if regex_on_full_url:
+        try:
+            return bool(re.search(pattern, target))
+        except re.error:
+            return False
+    else:
+        regex = _glob_to_regex(pattern)
+        try:
+            return bool(re.search(regex, target))
+        except re.error:
+            return False
+
+
 def _glob_to_regex(pattern: str) -> str:
     """Convert a simple glob pattern to an anchored regex pattern.
 
@@ -287,6 +316,7 @@ class CrawlEngine:
         self._queue: deque[tuple[str, int]] = deque()
         self._pages: list[dict] = []
         self._errors: list[dict] = []
+        self._filtered_out: list[dict] = []
         self._cancel_flag: bool = False
         self._update_interval: float = 1.0
         self._html_client: httpx.AsyncClient | None = None
@@ -348,13 +378,25 @@ class CrawlEngine:
             # Mark as seen immediately to prevent re-enqueue
             self._seen.add(normalized)
 
-            # Path filter check
+            # Determine the URL for path filtering.
+            # When ignore_query_parameters is True, strip query params
+            # before matching so that patterns match against the path
+            # only (VAL-SCOPE-073).
+            filter_url = (
+                urlparse(url)._replace(query="").geturl()
+                if self.options.ignore_query_parameters
+                else url
+            )
             if not _match_path(
-                url,
+                filter_url,
                 self.options.include_paths,
                 self.options.exclude_paths,
                 self.options.regex_on_full_url,
             ):
+                if self.options.verbose:
+                    filter_reason = self._get_filter_reason(filter_url)
+                    if filter_reason:
+                        self._filtered_out.append(filter_reason)
                 logger.debug("Skipping URL excluded by path filter: %s", url)
                 continue
 
@@ -421,6 +463,7 @@ class CrawlEngine:
             total=len(self._pages) + len(self._queue),
             completed=len(self._pages),
             errors=self._errors,
+            filtered_out=self._filtered_out,
         )
 
     def normalize_url(self, url: str) -> str:
@@ -432,6 +475,47 @@ class CrawlEngine:
     def cancel(self) -> None:
         """Signal the crawl to stop at the next opportunity."""
         self._cancel_flag = True
+
+    def _get_filter_reason(self, url: str) -> dict | None:
+        """Determine which path filter excluded a URL and why.
+
+        Only called when ``verbose`` is True and the URL has already
+        been determined to NOT pass ``_match_path()``.
+
+        Returns:
+            A dict with ``url``, ``reason``, and ``pattern`` keys, or
+            ``None`` if no filter reason could be determined.
+        """
+        target = url if self.options.regex_on_full_url else urlparse(url).path
+
+        # Check exclude_paths first (they bypass include_paths)
+        if self.options.exclude_paths:
+            for pattern in self.options.exclude_paths:
+                if _matches_pattern(target, pattern, self.options.regex_on_full_url):
+                    return {
+                        "url": url,
+                        "reason": "exclude_paths",
+                        "pattern": pattern,
+                    }
+
+        # Check include_paths
+        if self.options.include_paths:
+            for pattern in self.options.include_paths:
+                if _matches_pattern(target, pattern, self.options.regex_on_full_url):
+                    # Would match include, so not excluded by include
+                    return {
+                        "url": url,
+                        "reason": "include_paths",
+                        "pattern": None,
+                    }
+            # No include_paths matched
+            return {
+                "url": url,
+                "reason": "include_paths",
+                "pattern": None,
+            }
+
+        return None
 
     def _update_store(self, job_id: str) -> None:
         """Write current progress to the job data key (not meta).

--- a/agent-svc/agent/link_extractor.py
+++ b/agent-svc/agent/link_extractor.py
@@ -1,0 +1,230 @@
+"""Shared LinkExtractor module for extracting and filtering links from HTML.
+
+Provides ``extract_links()``, ``filter_links()``, and ``classify_links()``
+functions used by the crawl engine, ``/v2/map`` endpoint, and
+``llmstxt.py``.
+
+All functions are stateless — they accept inputs and return results
+without any stored state.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+def extract_links(html: str, base_url: str) -> list[str]:
+    """Extract and normalize all ``<a href>`` links from HTML.
+
+    Args:
+        html: Raw HTML content to parse.
+        base_url: The page URL used to resolve relative links. A
+            ``<base>`` tag in the HTML overrides this for relative
+            resolution but not for domain classification.
+
+    Returns:
+        List of absolute, fragment-stripped, deduplicated URLs with
+        ``http`` or ``https`` schemes. URLs are in discovery order
+        (first occurrence wins for duplicates).
+
+    Features:
+        - Resolves relative URLs against ``base_url`` (or ``<base>`` tag
+          if present in the HTML)
+        - Strips fragment identifiers (``#section``)
+        - Filters out non-http/https schemes (``mailto:``, ``tel:``,
+          ``javascript:``, etc.)
+        - Deduplicates URLs within the same page
+        - Handles malformed HTML gracefully (returns empty list instead
+          of raising exceptions)
+    """
+    if not html or not base_url:
+        return []
+
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception:
+        logger.warning("Failed to parse HTML from %s", base_url)
+        return []
+
+    # Determine effective base URL for relative resolution.
+    # <base> tag overrides the page URL.
+    effective_base: str = base_url
+    base_tag = soup.find("base", href=True)
+    if base_tag is not None and hasattr(base_tag, "get"):
+        href_val = base_tag.get("href")
+        if href_val:
+            effective_base = str(href_val)
+
+    seen: set[str] = set()
+    result: list[str] = []
+
+    try:
+        for a_tag in soup.find_all("a", href=True):
+            if not hasattr(a_tag, "get"):
+                continue
+            href_val = a_tag.get("href")
+            if href_val is None:
+                continue
+            href = _resolve_href_value(str(href_val))
+            if not href:
+                continue
+
+            # Resolve relative URLs against the effective base
+            try:
+                full_url = urljoin(effective_base, href)
+            except Exception:
+                continue
+
+            # Parse the resolved URL
+            try:
+                parsed = urlparse(full_url)
+            except Exception:
+                continue
+
+            # Filter out non-http/https schemes
+            scheme = parsed.scheme.lower()
+            if scheme and scheme not in ("http", "https"):
+                continue
+
+            # Strip fragment identifier
+            clean_url = _strip_fragment(full_url)
+
+            # Deduplicate within this page
+            if clean_url in seen:
+                continue
+            seen.add(clean_url)
+
+            result.append(clean_url)
+
+    except Exception:
+        logger.warning("Error extracting links from %s", base_url, exc_info=True)
+
+    return result
+
+
+def filter_links(
+    links: list[str],
+    *,
+    base_domain: str | None = None,
+    allow_subdomains: bool = False,
+    allow_external_links: bool = False,
+) -> list[str]:
+    """Filter a list of URLs by domain classification.
+
+    Args:
+        links: List of absolute URL strings (as returned by ``extract_links()``).
+        base_domain: The hostname of the base domain (e.g., ``"example.com"``).
+            If ``None``, only URLs that parse to a valid netloc are kept.
+        allow_subdomains: If ``True``, URLs on subdomains of the base domain
+            are included (e.g., ``docs.example.com`` when base is ``example.com``).
+        allow_external_links: If ``True``, URLs on entirely different domains
+            are included.
+
+    Returns:
+        Filtered list of URL strings matching the configured scope.
+    """
+    result: list[str] = []
+
+    for url in links:
+        parsed = urlparse(url)
+        hostname = parsed.hostname.lower() if parsed.hostname else ""
+
+        if not hostname:
+            # Shouldn't happen with absolute URLs, but be safe
+            result.append(url)
+            continue
+
+        if base_domain is None:
+            result.append(url)
+            continue
+
+        base = base_domain.lower()
+
+        if hostname == base:
+            # Internal (same domain) — always included
+            result.append(url)
+        elif _is_subdomain(hostname, base) and allow_subdomains:
+            result.append(url)
+        elif (
+            not _is_subdomain(hostname, base)
+            and hostname != base
+            and allow_external_links
+        ):
+            result.append(url)
+        # subdomain without allow_subdomains → skip
+        # external without allow_external_links → skip
+
+    return result
+
+
+def classify_links(links: list[str], base_url: str) -> dict[str, list[str]]:
+    """Classify a list of URLs by domain relationship to the base URL.
+
+    Args:
+        links: List of absolute URL strings.
+        base_url: The base URL used to determine the origin domain.
+
+    Returns:
+        Dict with keys ``"internal"``, ``"subdomain"``, and ``"external"``,
+        each containing a list of URL strings.
+    """
+    parsed_base = urlparse(base_url)
+    base_hostname = parsed_base.hostname.lower() if parsed_base.hostname else ""
+
+    result: dict[str, list[str]] = {
+        "internal": [],
+        "subdomain": [],
+        "external": [],
+    }
+
+    for url in links:
+        parsed = urlparse(url)
+        hostname = parsed.hostname.lower() if parsed.hostname else ""
+
+        if not hostname:
+            result["internal"].append(url)
+        elif hostname == base_hostname:
+            result["internal"].append(url)
+        elif _is_subdomain(hostname, base_hostname):
+            result["subdomain"].append(url)
+        else:
+            result["external"].append(url)
+
+    return result
+
+
+# ── Internal helpers ───────────────────────────────────────────────
+
+
+def _strip_fragment(url: str) -> str:
+    """Strip the fragment identifier from a URL, preserving the rest."""
+    try:
+        idx = url.index("#")
+        return url[:idx]
+    except ValueError:
+        return url
+
+
+def _is_subdomain(hostname: str, base: str) -> bool:
+    """Check whether ``hostname`` is a subdomain of ``base``.
+
+    ``blog.example.com`` is a subdomain of ``example.com``.
+    ``example.com`` is NOT a subdomain of ``example.com``.
+    ``other.com`` is NOT a subdomain of ``example.com``.
+    Comparison is case-insensitive.
+    """
+    hostname_lower = hostname.lower()
+    base_lower = base.lower()
+    if hostname_lower == base_lower:
+        return False
+    return hostname_lower.endswith("." + base_lower)
+
+
+def _resolve_href_value(href: str) -> str:
+    """Normalize an href attribute value to a string."""
+    return href.strip()

--- a/agent-svc/agent/llmstxt.py
+++ b/agent-svc/agent/llmstxt.py
@@ -7,12 +7,12 @@ the site's key pages.
 
 import logging
 import re
-from urllib.parse import urljoin
 
 import httpx
-from bs4 import BeautifulSoup
 
 from common.url import extract_domain
+
+from .link_extractor import extract_links, filter_links
 
 logger = logging.getLogger(__name__)
 
@@ -124,10 +124,11 @@ def _extract_description(text: str, max_chars: int = 300) -> str:
 
 
 async def discover_pages(url: str, max_pages: int = 50) -> list[str]:
-    """Discover page URLs on a site by fetching the homepage and finding same-domain links."""
-    discovered: list[str] = []
-    seen = set()
+    """Discover page URLs on a site by fetching the homepage and finding same-domain links.
 
+    Uses the shared LinkExtractor module for HTML link extraction and filtering,
+    replacing the previous inline BeautifulSoup parsing.
+    """
     try:
         async with httpx.AsyncClient(follow_redirects=True, timeout=15) as client:
             resp = await client.get(url)
@@ -135,29 +136,23 @@ async def discover_pages(url: str, max_pages: int = 50) -> list[str]:
                 logger.warning("Failed to fetch %s: %d", url, resp.status_code)
                 return [url]  # fallback: just return the input URL
 
-            soup = BeautifulSoup(resp.text, "html.parser")
-            from urllib.parse import urlparse
+            # Use the shared LinkExtractor for link extraction and filtering.
+            # Pass the domain-only base URL to match previous urljoin(base_url, href)
+            # behavior where base_url was the scheme+domain without path.
+            site_base = extract_domain(url, include_scheme=True)
+            all_links = extract_links(resp.text, site_base)
 
-            base_netloc = urlparse(url).netloc.lower()
-            base_url = extract_domain(url, include_scheme=True)
-            for a in soup.find_all("a", href=True):
-                href = a["href"].strip()  # type: ignore[union-attr]
-                full_url = urljoin(base_url, href)
+            # Filter to same-host only (backward compatible — external links excluded)
+            base_domain = extract_domain(url)
+            filtered = filter_links(
+                all_links,
+                base_domain=base_domain,
+                allow_subdomains=False,
+                allow_external_links=False,
+            )
 
-                # Skip external links, anchors, mailto, etc.
-                full_parsed = urlparse(full_url)
-                if full_parsed.netloc and full_parsed.netloc.lower() != base_netloc:
-                    continue
-                if not full_parsed.scheme.startswith("http"):
-                    continue
-                if full_url in seen:
-                    continue
-
-                seen.add(full_url)
-                discovered.append(full_url)
-
-                if len(discovered) >= max_pages:
-                    break
+            # Apply max_pages limit (LinkExtractor returns links in discovery order)
+            discovered = filtered[:max_pages]
 
     except Exception as e:
         logger.warning("Page discovery failed for %s: %s", url, e)

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -90,8 +90,12 @@ class AgentCancelResponse(BaseModel):
 
 class CrawlRequest(BaseModel):
     url: str
-    max_pages: int = 10
-    max_depth: int = 2
+    max_pages: int = Field(
+        default=10, ge=1, description="Maximum pages to scrape, must be >= 1"
+    )
+    max_depth: int = Field(
+        default=2, ge=0, description="Maximum link-follow depth, must be >= 0"
+    )
     limit: int | None = None
     ignore_sitemap: bool = False
     ignore_query_parameters: bool = False
@@ -149,6 +153,10 @@ class CrawlStatusResponse(BaseModel):
     credits_used: int | None = None
     data: list[dict[str, Any]] | None = None
     error: str | None = None
+    created_at: str | None = None
+    completed_at: str | None = None
+    expires_at: str | None = None
+    duration: int | None = None
 
 
 class BatchScrapeRequest(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -3,7 +3,7 @@
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ErrorDetail(BaseModel):
@@ -97,6 +97,8 @@ class CrawlRequest(BaseModel):
     ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
+    regex_on_full_url: bool = False
+    verbose: bool = False
     webhook: dict[str, Any] | None = None
 
     @field_validator("url")
@@ -111,6 +113,27 @@ class CrawlRequest(BaseModel):
         if not parsed.netloc:
             raise ValueError("URL must have a network location (host)")
         return value
+
+    @model_validator(mode="after")
+    def validate_regex_patterns(self) -> "CrawlRequest":
+        """When regex_on_full_url is True, validate that all path
+        patterns are valid Python regular expressions."""
+        if not self.regex_on_full_url:
+            return self
+        import re as _re
+
+        for field_name in ("include_paths", "exclude_paths"):
+            patterns = getattr(self, field_name)
+            if not patterns:
+                continue
+            for i, pattern in enumerate(patterns):
+                try:
+                    _re.compile(pattern)
+                except _re.error as exc:
+                    raise ValueError(
+                        f"Invalid regex in {field_name}[{i}]: '{pattern}' — {exc}"
+                    ) from exc
+        return self
 
 
 class CrawlCreateResponse(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -147,6 +147,8 @@ class MapRequest(BaseModel):
     url: str
     limit: int = 100
     search: str | None = None
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
 
 
 class MapResponse(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -1,8 +1,9 @@
 """Pydantic models matching the Firecrawl v2 agent API contract."""
 
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ErrorDetail(BaseModel):
@@ -91,10 +92,25 @@ class CrawlRequest(BaseModel):
     url: str
     max_pages: int = 10
     max_depth: int = 2
+    limit: int | None = None
     ignore_sitemap: bool = False
+    ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
     webhook: dict[str, Any] | None = None
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        """Validate that url is a well-formed HTTP/HTTPS URL."""
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            raise ValueError("URL must have a scheme (http:// or https://)")
+        if parsed.scheme.lower() not in ("http", "https"):
+            raise ValueError(f"URL scheme must be http or https, got '{parsed.scheme}'")
+        if not parsed.netloc:
+            raise ValueError("URL must have a network location (host)")
+        return value
 
 
 class CrawlCreateResponse(BaseModel):

--- a/agent-svc/agent/store.py
+++ b/agent-svc/agent/store.py
@@ -6,13 +6,18 @@ Uses the same valkey connection for both the API and the worker.
 
 import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from redis import Redis
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _expires_iso() -> str:
+    """Return ISO 8601 timestamp for 24 hours from now."""
+    return (datetime.now(UTC) + timedelta(hours=24)).isoformat()
 
 
 def _default_ttl() -> int:
@@ -39,6 +44,7 @@ class JobStore:
             "kind": kind,
             "status": "processing",
             "created_at": _now_iso(),
+            "expires_at": _expires_iso(),
             "payload": payload or {},
         }
         self.redis.set(f"job:{job_id}:meta", json.dumps(meta), ex=_default_ttl())

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -111,6 +111,8 @@ async def _process_crawl_async(
     ignore_query_parameters: bool = False,
     include_paths: list[str] | None = None,
     exclude_paths: list[str] | None = None,
+    regex_on_full_url: bool = False,
+    verbose: bool = False,
 ) -> None:
     settings = _get_worker_settings()
     store = JobStore(
@@ -127,6 +129,8 @@ async def _process_crawl_async(
             ignore_query_parameters=ignore_query_parameters,
             include_paths=include_paths,
             exclude_paths=exclude_paths,
+            regex_on_full_url=regex_on_full_url,
+            verbose=verbose,
         )
         engine = CrawlEngine(scraper, store=store, options=options)
         result = await engine.run(url, job_id=job_id)
@@ -152,12 +156,14 @@ async def _process_crawl_async(
                     )
                 )
 
-        payload = {
+        payload: dict[str, Any] = {
             "completed": result.completed,
             "total": result.total,
             "pages": result.pages,
             "errors": result.errors,
         }
+        if verbose:
+            payload["filtered_out"] = result.filtered_out
         return payload
 
     await _run_job_with_observability(

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -108,6 +108,9 @@ async def _process_crawl_async(
     scraper_url: str,
     webhook_config: dict[str, Any] | None = None,
     task_tracker: Any = None,
+    ignore_query_parameters: bool = False,
+    include_paths: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
 ) -> None:
     settings = _get_worker_settings()
     store = JobStore(
@@ -116,25 +119,45 @@ async def _process_crawl_async(
     scraper = ScraperClient(scraper_url)
 
     async def work_fn() -> dict[str, Any]:
-        result = await scraper.scrape(url)
-        pages = []
-        if result.get("success"):
-            data = result["data"]
-            pages.append({"url": url, "markdown": data.get("markdown", "")})
-            # Extract title from metadata if available
-            metadata = data.get("metadata") or {}
-            og = metadata.get("og") or {}
-            meta = metadata.get("meta") or {}
-            title = og.get("title") or meta.get("title") or data.get("title", "")
+        from .crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(
+            max_pages=max_pages,
+            max_depth=max_depth,
+            ignore_query_parameters=ignore_query_parameters,
+            include_paths=include_paths,
+            exclude_paths=exclude_paths,
+        )
+        engine = CrawlEngine(scraper, store=store, options=options)
+        result = await engine.run(url, job_id=job_id)
+
+        # Fire-and-forget indexing for each page
+        for page in result.pages:
+            page_url = page.get("url", "")
+            markdown = page.get("markdown", "")
             if task_tracker is not None:
                 task_tracker.create_background_task(
-                    _index_page_async(url, title, data.get("markdown", "")[:2000])
+                    _index_page_async(
+                        page_url,
+                        "",
+                        markdown[:2000],
+                    )
                 )
             else:
                 asyncio.create_task(
-                    _index_page_async(url, title, data.get("markdown", "")[:2000])
+                    _index_page_async(
+                        page_url,
+                        "",
+                        markdown[:2000],
+                    )
                 )
-        payload = {"completed": len(pages), "total": 1, "pages": pages}
+
+        payload = {
+            "completed": result.completed,
+            "total": result.total,
+            "pages": result.pages,
+            "errors": result.errors,
+        }
         return payload
 
     await _run_job_with_observability(

--- a/firecrawl-crawl-feature-research.md
+++ b/firecrawl-crawl-feature-research.md
@@ -1,0 +1,404 @@
+# Firecrawl Crawl API — Comprehensive Feature Research
+
+Generated 2026-06-19 from Firecrawl docs, blog guides, API reference, and glossary.
+
+Sources consulted:
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-post
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-get
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-delete
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-get-errors
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-active
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-params-preview
+- https://docs.firecrawl.dev/api-reference/endpoint/scrape (for scrapeOptions reference)
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-started
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-page
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-completed
+- https://www.firecrawl.dev/blog/mastering-the-crawl-endpoint-in-firecrawl
+- https://www.firecrawl.dev/glossary/web-crawling-apis/deduplicate-crawl-pages-rag
+
+---
+
+## 1. INITIATION / CONFIGURATION
+
+### `url` (string, required)
+The base URL to start crawling from.
+**GroktoCrawl:** ✅ HAS — `CrawlRequest.url`
+
+### `prompt` (string)
+Natural language description of what to crawl. Firecrawl translates this into the crawl parameters (includePaths, excludePaths, maxDiscoveryDepth, etc.). Explicitly-set parameters override the NL-derived equivalents.
+**GroktoCrawl:** ❌ MISSING — No NL→param translation for crawl.
+
+### `webhook` (object)
+A webhook specification object with `url`, `events`, and optional `metadata`.
+Firecrawl sends three event types for crawls:
+- `crawl.started` — job started
+- `crawl.page` — each page scraped (with the page data)
+- `crawl.completed` — job finished (empty data; results via GET)
+
+All webhooks include `X-Firecrawl-Signature` header (HMAC-SHA256).
+**GroktoCrawl:** ⚠️ PARTIAL — Has `webhook` field in CrawlRequest and `deliver_webhook()` function with HMAC signing, but only fires on "completed"/"failed". No per-page webhooks, no "started" event. No `events` filter or `metadata` echo.
+
+### POST `/v2/crawl/params-preview`
+NL prompt → params preview endpoint. Takes `url` + `prompt`, returns derived parameters (includePaths, excludePaths, maxDepth, crawlEntireDomain, allowExternalLinks, allowSubdomains, ignoreRobotsTxt, robotsUserAgent, deduplicateSimilarURLs, delay, limit, etc.).
+**GroktoCrawl:** ❌ MISSING — No params-preview endpoint.
+
+---
+
+## 2. DISCOVERY & SCOPE
+
+### `sitemap` (enum: "include" | "skip" | "only", default: "include")
+- `"include"` — use sitemap alongside HTML link discovery
+- `"skip"` — ignore sitemap, only follow HTML links
+- `"only"` — only crawl URLs from sitemap (+ start URL), no HTML link discovery
+**GroktoCrawl:** ❌ MISSING — `CrawlRequest` has `ignore_sitemap: bool` which only covers the binary skip/include case but isn't actually implemented in the worker. No "only" mode.
+
+### `maxDiscoveryDepth` (integer)
+Maximum depth from root. Root page = depth 0, its direct links = depth 1, etc. Pages at max depth are still scraped but their links are not followed. Sitemap-discovered pages count as depth 0.
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlRequest.max_depth` field exists but worker doesn't actually do any link discovery at all (only scrapes the starting URL).
+
+### `limit` (integer, default: 10000)
+Maximum number of pages to crawl. Firecrawl pre-checks credits against limit before starting; returns 402 if insufficient.
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlRequest.max_pages` (default: 10) but worker ignores it (single page only).
+
+### `includePaths` (string[])
+URL pathname regex patterns to include in the crawl. Only matching paths are included. The starting URL is also checked — if it doesn't match, crawl may return 0 pages.
+**GroktoCrawl:** ✅ HAS (in model) — Not yet implemented in worker.
+
+### `excludePaths` (string[])
+URL pathname regex patterns that exclude matching URLs from the crawl.
+**GroktoCrawl:** ✅ HAS (in model) — Not yet implemented in worker.
+
+### `regexOnFullURL` (boolean, default: false)
+When true, includePaths/excludePaths regex patterns match against the full URL (including query parameters), not just pathname.
+**GroktoCrawl:** ❌ MISSING
+
+### `crawlEntireDomain` (boolean, default: false)
+- `false`: Only crawls deeper (child) URLs. `/features/x` → `/features/x/tips` ✅ but won't follow `/pricing` or `/`.
+- `true`: Follows any internal links including siblings and parents.
+**GroktoCrawl:** ❌ MISSING
+
+### `allowExternalLinks` (boolean, default: false)
+Allow following links to external domains.
+**GroktoCrawl:** ❌ MISSING
+
+### `allowSubdomains` (boolean, default: false)
+Allow following links to subdomains of the main domain.
+**GroktoCrawl:** ❌ MISSING
+
+### `ignoreQueryParameters` (boolean, default: false)
+Do not re-scrape the same path with different query parameters. This is URL-level deduplication: `?ref=abc` and `?ref=xyz` collapse to one fetch.
+**GroktoCrawl:** ❌ MISSING
+
+### Deduplication Strategy (automatic, not a parameter)
+Per Firecrawl glossary, they do multi-layer dedup:
+1. **URL normalization** (pre-fetch): trailing slashes, tracking params, protocol variants
+2. **Canonical tag check** (post-fetch): `<link rel="canonical">`
+3. **Exact content hash** (post-fetch): on extracted text, not raw HTML
+4. **Near-duplicate filtering** (optional): embedding similarity for syndicated/template-heavy content
+
+Firecrawl handles URL-level dedup automatically within a crawl run. `ignoreQueryParameters` reduces the volume needing downstream content dedup.
+**GroktoCrawl:** ❌ MISSING — No dedup at any layer (only fetches one URL).
+
+---
+
+## 3. RATE LIMITING & CONCURRENCY
+
+### `delay` (number, seconds)
+Delay between scrapes. Setting this forces `maxConcurrency` to 1. Different from `waitFor` (which is per-page render time in ms).
+**GroktoCrawl:** ❌ MISSING
+
+### `maxConcurrency` (integer)
+Maximum number of concurrent scrapes for this crawl. If not specified, uses team's account-level concurrency limit.
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 4. robots.txt
+
+### `ignoreRobotsTxt` (boolean, default: false)
+Ignore website's robots.txt rules. **Enterprise only.**
+**GroktoCrawl:** ❌ MISSING
+
+### `robotsUserAgent` (string)
+Custom User-Agent for robots.txt evaluation. **Enterprise only.**
+**GroktoCrawl:** ❌ MISSING
+
+Note: The errors endpoint (`GET /v2/crawl/{id}/errors`) returns a `robotsBlocked` list of URLs skipped due to robots.txt.
+
+---
+
+## 5. SCRAPE OPTIONS (via `scrapeOptions` object)
+
+Firecrawl's crawl `scrapeOptions` mirrors the `/v2/scrape` endpoint options exactly. They apply to every page in the crawl.
+
+### Formats
+Array of format strings or format objects:
+- `"markdown"` — clean markdown (default)
+- `"html"` — cleaned HTML
+- `"rawHtml"` — raw HTML
+- `"links"` — array of links found on page
+- `"images"` — images metadata
+- `"screenshot"` — temporary PNG URL (expires 24h)
+- `"json"` — structured extraction with LLM (takes `{ type: "json", schema: {...} }`)
+- `"summary"` — LLM summary
+- `"changeTracking"` — compares against previous scrape
+- `"branding"` — logo, colors, fonts, typography, spacing, components
+- `"product"` — title, variants, price, availability, images
+- `"audio"` — audio extraction
+- `"video"` — video extraction
+- `"question"` — ask a question about the page
+- `"highlights"` — content highlights
+
+**GroktoCrawl:** ❌ MISSING — No `scrapeOptions` passthrough in CrawlRequest model at all. The worker hardcodes `scraper.scrape(url)` with no format control.
+
+### `onlyMainContent` (boolean, default: true)
+Return only main page content, excluding headers/navs/footers. Deterministic HTML-level filter, no LLM.
+**GroktoCrawl:** ❌ MISSING
+
+### `onlyCleanContent` (boolean, default: false)
+**Beta.** LLM-based pass over generated markdown to remove residual boilerplate that `onlyMainContent` can miss (cookie banners, ads, social widgets, breadcrumbs, newsletter signups, comments, related-article lists). Preserves headings, lists, tables, code blocks, images, inline links. Skipped when markdown exceeds the cleaning model's token limit. Not supported on zero-data-retention requests.
+**GroktoCrawl:** ❌ MISSING
+
+### `includeTags` (string[])
+Tags/classes/IDs to include in output.
+**GroktoCrawl:** ❌ MISSING
+
+### `excludeTags` (string[])
+Tags/classes/IDs to exclude from output.
+**GroktoCrawl:** ❌ MISSING
+
+### `maxAge` (integer, default: 172800000 ms = 2 days)
+Cache control: return cached version if younger than this. Can speed up scrapes by ~500%.
+**GroktoCrawl:** ❌ MISSING — No caching layer.
+
+### `minAge` (integer)
+Cache-only mode: only checks cache, never triggers fresh scrape. Minimum age of cached data. If no match, returns 404 `SCRAPE_NO_CACHED_DATA`. Set to 1 to accept any cached data.
+**GroktoCrawl:** ❌ MISSING
+
+### `headers` (object)
+Custom headers sent with the scrape request (cookies, user-agent, etc.).
+**GroktoCrawl:** ❌ MISSING
+
+### `waitFor` (integer, default: 0)
+Milliseconds to wait before fetching content, in addition to Firecrawl's smart wait.
+**GroktoCrawl:** ❌ MISSING
+
+### `mobile` (boolean, default: false)
+Emulate mobile device scraping. Useful for responsive pages and mobile screenshots.
+**GroktoCrawl:** ❌ MISSING
+
+### `skipTlsVerification` (boolean, default: true)
+Skip TLS certificate verification.
+**GroktoCrawl:** ❌ MISSING (scraper-svc may have this internally, but not configurable from crawl API)
+
+### `timeout` (integer, default: 60000 ms, min: 1000, max: 300000)
+Per-page request timeout.
+**GroktoCrawl:** ❌ MISSING (per-page timeout not configurable)
+
+### `parsers` (object[])
+Controls file processing. When `"pdf"` is included (default), PDFs are extracted to markdown (1 credit per page). Empty array returns PDF as base64 (flat 1 credit).
+**GroktoCrawl:** ❌ MISSING
+
+### `actions` (object[])
+Browser actions to perform before grabbing content:
+- `wait` (by duration ms)
+- `waitFor` (wait for element selector)
+- `screenshot` (full page or element)
+- `click` (by selector)
+- `write` (type text)
+- `press` (press a key)
+- `scroll` (scroll to element or by pixels)
+- `scrape` (scrape current state)
+- `executeJavascript` (run JS)
+- `generatePDF` (generate PDF of current state)
+
+**GroktoCrawl:** ❌ MISSING — Browser actions exist on the separate `/v2/browser` endpoint but not as scrape options.
+
+### `location` (object: { country, languages })
+Location settings for proxy selection and language/timezone emulation. Defaults to `"US"`.
+**GroktoCrawl:** ❌ MISSING
+
+### `removeBase64Images` (boolean, default: true)
+Remove base64-encoded images from markdown output. Alt text preserved with placeholder.
+**GroktoCrawl:** ❌ MISSING
+
+### `blockAds` (boolean, default: true)
+Enable ad blocking and cookie popup blocking.
+**GroktoCrawl:** ❌ MISSING
+
+### `proxy` (enum: "basic" | "enhanced" | "auto", default: "auto")
+- `basic`: Fast, for sites with minimal anti-bot
+- `enhanced`: For advanced anti-bot sites. Costs up to 5 credits/request.
+- `auto`: Tries basic first, falls back to enhanced on failure. Only bills enhanced credits if fallback used.
+**GroktoCrawl:** ❌ MISSING
+
+### `storeInCache` (boolean, default: true)
+Whether to store the page in Firecrawl's cache. Set to false for data protection concerns. Some params (actions, headers) force this to false.
+**GroktoCrawl:** ❌ MISSING
+
+### `lockdown` (boolean, default: false)
+Cache-only mode: never makes outbound request. On cache miss, returns 404 `SCRAPE_LOCKDOWN_CACHE_MISS`. URL is never logged on miss. Treated as zero data retention. Default `maxAge` extended to 2 years. Billed at 5 credits on hit, 1 on miss. Designed for compliance/air-gapped environments.
+**GroktoCrawl:** ❌ MISSING
+
+### `redactPII` (boolean | object, default: false)
+Redact PII from returned markdown. Pass `true` for defaults, or an object to tune mode, entities, and replacement style.
+**GroktoCrawl:** ❌ MISSING
+
+### `profile` (object: { name, saveChanges })
+Enable persistent browser storage across scrape and interact sessions. Sessions with the same profile name share browser state (cookies, localStorage, session data).
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 6. RESULTS & STATUS
+
+### `POST /v2/crawl` — Create
+Response: `{ success: true, id: string, url: string }`
+**GroktoCrawl:** ✅ HAS — `CrawlCreateResponse { success, id }`. Missing the `url` field in response.
+
+### `GET /v2/crawl/{id}` — Status
+Response fields:
+- `status` (string): "scraping" | "completed" | "failed"
+- `total` (int): total pages attempted
+- `completed` (int): pages successfully scraped
+- `creditsUsed` (int): credits consumed
+- `expiresAt` (datetime): when results expire
+- `createdAt` (datetime): when job started
+- `completedAt` (datetime): when job finished (terminal states only)
+- `duration` (number): elapsed seconds
+- `next` (string | null): URL for next 10MB chunk if response > 10MB
+- `data` (array): scraped page documents, each with markdown, html, rawHtml, links, screenshot, metadata
+
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlStatusResponse` has `status`, `completed`, `total`, `credits_used`, `data`, `error`. Missing: `expiresAt`, `createdAt`, `completedAt`, `duration`, `next` (pagination), full per-page metadata shape.
+
+### `DELETE /v2/crawl/{id}` — Cancel
+Response: `{ status: "cancelled" }`
+**GroktoCrawl:** ✅ HAS — Returns `{ success: true }` via `AgentCancelResponse`. Slightly different response shape but functionally equivalent.
+
+### `GET /v2/crawl/{id}/errors` — Errors
+Response:
+- `errors[]`: array of `{ id, timestamp, url, error }`
+- `robotsBlocked[]`: array of URL strings blocked by robots.txt
+
+**GroktoCrawl:** ❌ MISSING
+
+### `GET /v2/crawl/active` — Active crawls
+Lists all active crawls for the authenticated team with full options.
+**GroktoCrawl:** ⚠️ PARTIAL — Has `GET /v2/activity` which lists all active jobs across all types. No crawl-specific filtering, and no per-job options display.
+
+### Webhook Events (3 for crawl)
+- `crawl.started` — `{ type, id, webhookId, data: [], metadata: {} }`
+- `crawl.page` — `{ success, type, id, webhookId, data: [pageDoc], error: string | null, metadata: {} }` — fires per page as scraped
+- `crawl.completed` — `{ success, type, id, webhookId, data: [], metadata: {} }`
+
+All include HMAC signature via `X-Firecrawl-Signature` header (uses specific webhook secret, not the API token).
+**GroktoCrawl:** ❌ MISSING — Only fires one webhook on completion/failure. No per-page events, no started event, no webhookId for dedup, no metadata echo.
+
+### SDK Delivery Modes
+- `crawl()` — synchronous, blocks until done
+- `start_crawl()` + `get_crawl_status()` — async polling
+- `AsyncFirecrawl.watcher()` — WebSocket streaming (with HTTP polling fallback)
+- Webhooks — HTTP POST push
+
+**GroktoCrawl:** ⚠️ PARTIAL — Has sync create + poll (store-based). No WebSocket streaming. No SDK-level watcher.
+
+---
+
+## 7. ADVANCED / SECURITY
+
+### `zeroDataRetention` (boolean, default: false)
+If true, enables zero data retention for this crawl. Must contact Firecrawl to enable.
+**GroktoCrawl:** ❌ MISSING
+
+### Prompt-to-Params Translation (NL → Crawl Config)
+The `prompt` field in crawl POST is translated via LLM into crawl parameters. The `/v2/crawl/params-preview` endpoint exposes this translation. Different prompts produce different includePaths, maxDepth, etc.
+**GroktoCrawl:** ❌ MISSING
+
+### Credit Pre-check
+Before starting a crawl, Firecrawl checks that your remaining credits can cover the `limit`. If not, returns `402 Payment Required`.
+**GroktoCrawl:** ❌ MISSING — No credit system.
+
+### `deduplicateSimilarURLs` (in params-preview output)
+A parameter surfaced in params-preview that controls URL dedup similarity. Not directly documented as a crawl POST parameter but appears in the preview output.
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 8. ENDPOINT SUMMARY (Full Firecrawl Crawl Surface)
+
+| Method | Path | GroktoCrawl Status |
+|--------|------|-------------------|
+| POST | `/v2/crawl` | ✅ EXISTS (minimal impl) |
+| GET | `/v2/crawl/{id}` | ✅ EXISTS (partial fields) |
+| DELETE | `/v2/crawl/{id}` | ✅ EXISTS |
+| GET | `/v2/crawl/{id}/errors` | ❌ MISSING |
+| GET | `/v2/crawl/active` | ⚠️ PARTIAL (generic activity endpoint) |
+| POST | `/v2/crawl/params-preview` | ❌ MISSING |
+
+## 9. GROKTOCRAWL CRITICAL GAPS SUMMARY
+
+The current GroktoCrawl crawl implementation is fundamentally a **single-page scrape with a crawl-shaped API shell**:
+
+1. **No link discovery** — the worker only scrapes the starting URL. `max_pages`, `max_depth`, `include_paths`, `exclude_paths`, `ignore_sitemap` fields exist in the model but are never used in processing.
+
+2. **No scrapeOptions passthrough** — all format control, content filtering, JS rendering, proxy selection, caching, PII redaction, ad blocking, and browser actions are missing.
+
+3. **No concurrency** — no `delay`, `maxConcurrency`, or parallel scraping infrastructure.
+
+4. **No deduplication** — no URL normalization, canonical checking, content hashing, or near-duplicate filtering.
+
+5. **Missing endpoints** — `/errors`, `/params-preview`, crawl-specific `/active`.
+
+6. **Minimal webhooks** — only completion/failure, no per-page events, no started event, no webhookId for dedup.
+
+7. **No caching** — no `maxAge`/`minAge`/`storeInCache`/`lockdown` infrastructure.
+
+8. **No NL→params translation** — no `prompt` field or params-preview.
+
+9. **Response shape gaps** — missing `expiresAt`, `createdAt`, `completedAt`, `duration`, `next` (pagination), full per-page metadata.
+
+10. **Missing Firecrawl API fields** — `crawlEntireDomain`, `allowExternalLinks`, `allowSubdomains`, `ignoreQueryParameters`, `regexOnFullURL`, `sitemap` modes (enum not bool), `scrapeOptions`, `zeroDataRetention`, full webhook shape.
+
+## 10. PRIORITY IMPLEMENTATION ORDER (RECOMMENDATION)
+
+### Tier 1 — Core crawl functionality (MVP)
+1. Link discovery engine (HTML link extraction, sitemap parsing)
+2. Depth-first / breadth-first traversal with `maxDepth` / `maxDiscoveryDepth`
+3. `limit` enforcement (stop at `maxPages`)
+4. `includePaths` / `excludePaths` filtering with regex
+5. URL-level dedup within a crawl run
+6. `ignoreQueryParameters` for query-string collapse
+
+### Tier 2 — Scope and discovery
+7. `sitemap` modes (include/skip/only) with proper sitemap parsing
+8. `crawlEntireDomain` (sibling/parent URL following)
+9. `allowSubdomains`
+10. `allowExternalLinks` (with safety guard)
+11. `regexOnFullURL`
+
+### Tier 3 — Scrape options passthrough
+12. `scrapeOptions` model with all format/content/rendering fields
+13. Pass scrapeOptions through to scraper-svc
+14. `onlyMainContent`, `includeTags`, `excludeTags`
+15. `waitFor`, `timeout`, `mobile`, `headers`
+
+### Tier 4 — Concurrency and rate limiting
+16. `maxConcurrency` with asyncio semaphore or task pool
+17. `delay` (between-request pacing)
+18. Parallel scraping infrastructure
+
+### Tier 5 — Caching and advanced features
+19. Response caching layer (`maxAge`/`minAge`)
+20. Content dedup (canonical check, content hash)
+21. `robots.txt` parsing and enforcement
+22. `GET /v2/crawl/{id}/errors` endpoint
+23. `GET /v2/crawl/active` (or enhance existing activity)
+
+### Tier 6 — Full parity
+24. NL→params translation (`prompt` field + `/v2/crawl/params-preview`)
+25. Per-page webhooks (`crawl.page` events)
+26. WebSocket streaming (`watcher()` equivalent)
+27. `lockdown`, `redactPII`, `profile`, `zeroDataRetention`
+28. Advanced scrapeOptions (`actions`, `location`, `proxy`, `blockAds`, `parsers`, `removeBase64Images`)
+29. Response shape parity (all fields: `expiresAt`, `createdAt`, `completedAt`, `duration`, `next`, full metadata, per-page `links`/`screenshot`/`html`/`rawHtml`)
+30. Credit system with pre-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ skip-magic-trailing-comma = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 addopts = "--cov=agent-svc/agent --cov=scraper-svc/scraper --cov=browser-svc/browser_svc --cov=parse-svc/parse_svc --cov=portal-svc/portal --cov=semantic-svc --cov-report=term-missing --cov-fail-under=20 --durations=10 -n auto"
 
 [tool.mypy]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""pytest configuration for GroktoCrawl unit tests.
+
+Adds the project root and agent-svc to the Python path so that unit tests
+can import the agent modules directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add project root to path (for common.* imports)
+_root = Path(__file__).resolve().parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+# Add agent-svc to path (for agent.* imports)
+_agent_svc = _root / "agent-svc"
+if _agent_svc.exists() and str(_agent_svc) not in sys.path:
+    sys.path.insert(0, str(_agent_svc))

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -270,8 +270,9 @@ def mock_scraper():
 
 @pytest.fixture
 def mock_store():
-    """Create a mock JobStore."""
+    """Create a mock JobStore with a mock Redis client."""
     store = MagicMock()
+    store.redis = MagicMock()
     store.complete_job = MagicMock()
     return store
 
@@ -728,8 +729,8 @@ class TestCrawlEngine:
         result = await engine.run("http://example.com/", job_id="test-job-123")
 
         assert result.completed == 1
-        # complete_job should have been called at least once (final update)
-        assert mock_store.complete_job.call_count >= 1
+        # redis.set should have been called at least once (final update)
+        assert mock_store.redis.set.call_count >= 1
 
     @pytest.mark.asyncio
     async def test_crawl_with_include_paths(self, mock_scraper):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,921 @@
+"""Unit tests for the CrawlEngine in agent-svc/agent/crawler.py.
+
+Covers:
+- URL normalization (fragments, trailing slash, ignore_query_parameters)
+- Path filtering (glob and regex)
+- Glob-to-regex conversion
+- CrawlEngine BFS traversal
+- max_pages and max_depth enforcement
+- URL dedup within a crawl run
+- Start URL failure handling
+- Child page error handling
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── normalize_url tests ──────────────────────────────────────────
+
+
+class TestNormalizeUrl:
+    """Tests for the ``normalize_url()`` function."""
+
+    def test_strips_fragment(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com/page#section")
+            == "https://example.com/page"
+        )
+
+    def test_lowercases_scheme(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("HTTPS://EXAMPLE.COM/PAGE") == "https://example.com/PAGE"
+
+    def test_lowercases_host(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("https://Example.COM/Page") == "https://example.com/Page"
+
+    def test_removes_default_http_port(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("http://example.com:80/page") == "http://example.com/page"
+
+    def test_removes_default_https_port(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com:443/page") == "https://example.com/page"
+        )
+
+    def test_keeps_non_default_port(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com:8080/page")
+            == "https://example.com:8080/page"
+        )
+
+    def test_normalizes_trailing_slash(self):
+        from agent.crawler import normalize_url
+
+        # Non-root paths with trailing slash -> no trailing slash
+        assert normalize_url("https://example.com/page/") == "https://example.com/page"
+        assert normalize_url("https://example.com/page") == "https://example.com/page"
+
+    def test_keeps_root_slash(self):
+        from agent.crawler import normalize_url
+
+        # Root path / should stay as /
+        assert normalize_url("https://example.com/") == "https://example.com/"
+
+    def test_normalizes_dot_path(self):
+        from agent.crawler import normalize_url
+
+        # /. should collapse to /
+        assert normalize_url("https://example.com/.") == "https://example.com/"
+        assert normalize_url("https://example.com/a/./b") == "https://example.com/a/b"
+
+    def test_ignore_query_parameters_strips_query(self):
+        from agent.crawler import normalize_url
+
+        result = normalize_url(
+            "https://example.com/page?a=1&b=2", ignore_query_parameters=True
+        )
+        assert result == "https://example.com/page"
+
+    def test_ignore_query_parameters_default_false_keeps_query(self):
+        from agent.crawler import normalize_url
+
+        result = normalize_url("https://example.com/page?a=1&b=2")
+        assert "a=1" in result
+        assert "b=2" in result
+
+    def test_sorts_query_parameters(self):
+        from agent.crawler import normalize_url
+
+        # Different order but same params -> same result
+        r1 = normalize_url("https://example.com/page?b=2&a=1")
+        r2 = normalize_url("https://example.com/page?a=1&b=2")
+        assert r1 == r2
+        assert "a=1" in r1
+        assert "b=2" in r1
+
+    def test_fragment_and_query_stripped_together(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com/page?a=1#section")
+            == "https://example.com/page?a=1"
+        )
+
+
+# ── Glob-to-regex tests ──────────────────────────────────────────
+
+
+class TestGlobToRegex:
+    """Tests for the ``_glob_to_regex()`` helper."""
+
+    def test_literal_string(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/about")
+        assert re.search(pattern, "/about")
+        assert not re.search(pattern, "/aboutus")
+
+    def test_single_star(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/section/*")
+        assert re.search(pattern, "/section/page-1")
+        assert re.search(pattern, "/section/foo")
+        assert not re.search(pattern, "/section/sub/page")
+
+    def test_double_star(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/section/**")
+        assert re.search(pattern, "/section/page-1")
+        assert re.search(pattern, "/section/sub/page")
+        assert not re.search(pattern, "/other")
+
+    def test_question_mark(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/page-?")
+        assert re.search(pattern, "/page-1")
+        assert re.search(pattern, "/page-a")
+        assert not re.search(pattern, "/page-12")
+
+    def test_special_chars_escaped(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/file.html")
+        assert re.search(pattern, "/file.html")
+        assert not re.search(pattern, "/fileXhtml")
+
+
+# ── Path matching tests ─────────────────────────────────────────
+
+
+class TestMatchPath:
+    """Tests for the ``_match_path()`` function."""
+
+    def test_no_filters_passes(self):
+        from agent.crawler import _match_path
+
+        assert _match_path("https://example.com/page", None, None) is True
+
+    def test_include_paths_matches(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-1",
+                ["/section/*"],
+                None,
+            )
+            is True
+        )
+
+    def test_include_paths_no_match(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/about",
+                ["/section/*"],
+                None,
+            )
+            is False
+        )
+
+    def test_exclude_paths_excludes(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/admin/secret",
+                None,
+                ["/admin/*"],
+            )
+            is False
+        )
+
+    def test_exclude_overrides_include(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-2",
+                ["/section/*"],
+                ["/section/page-2"],
+            )
+            is False
+        )
+
+    def test_regex_mode_on_full_url(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-1?ref=abc",
+                ["section/page-[12]"],
+                None,
+                regex_on_full_url=True,
+            )
+            is True
+        )
+
+    def test_regex_mode_no_match(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-3",
+                ["section/page-[12]"],
+                None,
+                regex_on_full_url=True,
+            )
+            is False
+        )
+
+
+# ── CrawlEngine tests ────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_scraper():
+    """Create a mock ScraperClient that returns successful results."""
+    client = MagicMock()
+    client.scrape = AsyncMock()
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_store():
+    """Create a mock JobStore."""
+    store = MagicMock()
+    store.complete_job = MagicMock()
+    return store
+
+
+class MockPage:
+    """Helper to create a mock scrape result for a given URL."""
+
+    @staticmethod
+    def success(
+        url: str, markdown: str = "# Page Content", html: str | None = None
+    ) -> dict:
+        return {
+            "success": True,
+            "data": {
+                "markdown": markdown,
+                "source": "playwright",
+                "metadata": {"title": "Test Page"},
+            },
+        }
+
+    @staticmethod
+    def failure(url: str, error: str = "Scrape failed") -> dict:
+        return {"success": False, "error": error}
+
+
+class TestCrawlEngine:
+    """Tests for the CrawlEngine BFS crawl loop."""
+
+    @pytest.mark.asyncio
+    async def test_single_page_crawl(self, mock_scraper, mock_store):
+        """A crawl with max_pages=1 returns just the start URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape.return_value = MockPage.success("http://example.com/")
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.total >= 1
+        assert len(result.pages) == 1
+        assert result.pages[0]["url"] == "http://example.com/"
+        assert result.errors == []
+
+    @pytest.mark.asyncio
+    async def test_max_pages_enforcement(self, mock_scraper):
+        """Crawl stops after max_pages pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Mock scraper to always succeed
+        mock_scraper.scrape.return_value = MockPage.success("http://example.com/page")
+        mock_scraper.scrape.side_effect = None  # reset
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=3, max_depth=2),
+        )
+
+        # We need a link-rich start page. Mock the HTML fetch too.
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="/page1">Page 1</a>
+                <a href="/page2">Page 2</a>
+                <a href="/page3">Page 3</a>
+                </body></html>
+            """
+
+            # Set up scraper to return appropriate markdown per URL
+            async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+                return MockPage.success(url, f"# Content of {url}")
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 3
+        assert len(result.pages) == 3
+        # Should have the start URL and 2 children (due to max_pages=3)
+
+    @pytest.mark.asyncio
+    async def test_max_depth_0(self, mock_scraper):
+        """max_depth=0 scrapes only the start URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=0),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="/pricing">Pricing</a>
+                <a href="/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert len(result.pages) == 1
+        assert result.pages[0]["url"] == "http://example.com/"
+
+    @pytest.mark.asyncio
+    async def test_max_depth_1(self, mock_scraper):
+        """max_depth=1 scrapes start URL and direct children."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/contact">Contact</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + 3 children = 4 pages
+        assert result.completed == 4
+        assert len(result.pages) == 4
+
+        # Verify BFS order: start URL first, then children
+        assert result.pages[0]["url"] == "http://example.com/"
+
+    @pytest.mark.asyncio
+    async def test_url_dedup(self, mock_scraper):
+        """No duplicate URLs within a single crawl run."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Start page has duplicate links to the same page
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/pricing">Pricing (again)</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/pricing#section">Pricing with fragment</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + pricing + about = 3 unique pages
+        # (pricing appears 3 times in links but should be scraped once)
+        urls = [p["url"] for p in result.pages]
+        assert len(urls) == len(set(urls)), f"Duplicate URLs found: {urls}"
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_fragment_stripped_dedup(self, mock_scraper):
+        """Links /page#a and /page#b normalize to same URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/about#section1">About 1</a>
+                <a href="http://example.com/about#section2">About 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + about = 2 pages (fragments collapsed)
+        assert result.completed == 2
+        about_pages = [p for p in result.pages if "about" in p["url"]]
+        assert len(about_pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_normalization(self, mock_scraper):
+        """/pricing and /pricing/ are treated as the same URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/pricing/">Pricing with slash</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + pricing = 2 pages (trailing slash collapsed)
+        assert result.completed == 2
+        pricing_pages = [p for p in result.pages if "pricing" in p["url"]]
+        assert len(pricing_pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_ignore_query_parameters_collapses_variants(self, mock_scraper):
+        """When ignore_query_parameters=True, query variants collapse."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                ignore_query_parameters=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page?a=1">Page a=1</a>
+                <a href="http://example.com/page?b=2">Page b=2</a>
+                <a href="http://example.com/page">Page no query</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # With ignore_query_parameters, /page?a=1, /page?b=2, /page all collapse
+        # to /page. So we should have start URL + page = 2 pages
+        assert result.completed == 2
+        page_entries = [p for p in result.pages if "page" in p["url"]]
+        assert len(page_entries) == 1
+
+    @pytest.mark.asyncio
+    async def test_child_scrape_failure_collected(self, mock_scraper):
+        """Child page scrape failures are collected, not fatal."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            if "fail" in url:
+                return MockPage.failure(url, "Connection refused")
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good">Good page</a>
+                <a href="http://example.com/fail">Failing page</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + good page = 2 successful scrapes
+        assert result.completed == 2
+        assert len(result.pages) == 2
+        # One error for the failing page
+        assert len(result.errors) == 1
+        assert "fail" in result.errors[0]["url"]
+        assert result.errors[0]["error"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_start_url_failure_returns_immediately(self, mock_scraper):
+        """Start URL failure returns error immediately."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.failure("http://example.com/", "Connection refused")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert result.pages == []
+        assert len(result.errors) == 1
+        assert result.errors[0]["url"] == "http://example.com/"
+        assert result.errors[0]["error"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_bfs_order(self, mock_scraper):
+        """Pages appear in BFS order: start URL, then depth-1, then depth-2."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Track which HTML is returned for each URL to simulate link structure
+        html_responses = {
+            "http://example.com/": """
+                <html><body>
+                <a href="http://example.com/child-a">Child A</a>
+                <a href="http://example.com/child-b">Child B</a>
+                </body></html>
+            """,
+            "http://example.com/child-a": """
+                <html><body>
+                <a href="http://example.com/grandchild">Grandchild</a>
+                </body></html>
+            """,
+            "http://example.com/child-b": """
+                <html><body>
+                <p>No links here</p>
+                </body></html>
+            """,
+        }
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.side_effect = lambda url: html_responses.get(url)
+
+            result = await engine.run("http://example.com/")
+
+        # Expected BFS order:
+        # [start, child-a, child-b, grandchild]
+        assert len(result.pages) == 4
+        assert result.pages[0]["url"] == "http://example.com/"
+        assert result.pages[1]["url"] == "http://example.com/child-a"
+        assert result.pages[2]["url"] == "http://example.com/child-b"
+        assert result.pages[3]["url"] == "http://example.com/grandchild"
+
+    @pytest.mark.asyncio
+    async def test_empty_site_no_links(self, mock_scraper):
+        """A page with no outgoing links returns only the start page."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", "No links here")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert len(result.pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_pages_larger_than_available(self, mock_scraper):
+        """When max_pages > available pages, crawl completes when queue is empty."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", "Just one page")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=100, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_job_store_updates(self, mock_scraper, mock_store):
+        """Job store is updated with progress during crawl."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+        # Use short update interval for testing
+        engine._update_interval = 0.01
+
+        result = await engine.run("http://example.com/", job_id="test-job-123")
+
+        assert result.completed == 1
+        # complete_job should have been called at least once (final update)
+        assert mock_store.complete_job.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_include_paths(self, mock_scraper):
+        """Only URLs matching include_paths are crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/section/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Section 1</a>
+                <a href="http://example.com/section/page-2">Section 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL doesn't match /section/*, so only section pages are crawled
+        # But start URL is included since include_paths only filters child discovery
+        # actually... wait, let me re-examine the logic.
+
+        # The current code checks self._should_crawl before scraping, which
+        # includes a call to _match_path. But the start URL is the first URL
+        # and should also be checked against include_paths.
+
+        # Looking at the architecture.md:
+        # "Path filters apply to all URLs including the start URL — if start URL
+        # doesn't match include_paths, crawl returns 0 pages"
+
+        # Wait, but my current implementation checks _match_path AFTER adding to seen
+        # but BEFORE scraping... Actually, looking at my crawl loop:
+
+        # 1. Pop from queue
+        # 2. Normalize
+        # 3. Check dedup - skip if seen
+        # 4. Check max_depth - skip if too deep (but depth=0 is fine)
+        # 5. Add to seen
+        # 6. Check path filters - if not match, continue
+        # 7. Scrape
+        # 8. Extract links if depth < max_depth
+
+        # So the start URL IS checked against include_paths. If it doesn't match,
+        # it's skipped. That means the start URL would need to match include_paths
+        # to be crawled.
+
+        # For this test, let's check that "/section/*" doesn't match "/about"
+        about_pages = [p for p in result.pages if "about" in p["url"]]
+        assert len(about_pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_exclude_paths(self, mock_scraper):
+        """URLs matching exclude_paths are skipped."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=["/admin/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/admin/secret">Admin</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing + about = 3 pages, admin excluded
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/admin/secret" not in urls
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_markdown_handled_gracefully(self, mock_scraper):
+        """A page with empty markdown is still included."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", markdown="")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.pages[0]["markdown"] == ""
+
+    @pytest.mark.asyncio
+    async def test_cancel_flag_stops_crawl(self, mock_scraper):
+        """Setting cancel flag stops the crawl loop."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            # Cancel after the first page is scraped
+            original_scrape = mock_scraper.scrape
+
+            async def scrape_with_cancel(url: str, force_browser: bool = False) -> dict:
+                result = await original_scrape(url, force_browser)
+                engine.cancel()
+                return result
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_with_cancel)
+
+            result = await engine.run("http://example.com/")
+
+        # Should have at least 1 page (start URL was scraped before cancel)
+        assert result.completed >= 1
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_self_referencing_links(self, mock_scraper):
+        """Self-referencing links don't cause infinite loops."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            # Page links to itself and to a child
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/">Self link</a>
+                <a href="http://example.com/.">Self link dot</a>
+                <a href="http://example.com/page1">Page 1</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should complete without infinite loop
+        # Start URL + page1 = 2 pages
+        assert result.completed == 2

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -920,3 +920,526 @@ class TestCrawlEngine:
         # Should complete without infinite loop
         # Start URL + page1 = 2 pages
         assert result.completed == 2
+
+
+# ── Path filtering tests ────────────────────────────────────────
+
+
+class TestPathFiltering:
+    """Tests for path filtering in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_include_paths_start_url_matches(self, mock_scraper):
+        """When start URL matches include_paths, it is crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/blog/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/blog/post1">Blog Post 1</a>
+                <a href="http://example.com/blog/post2">Blog Post 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/blog/index")
+
+        # Start URL matches /blog/*, children under /blog/ are included
+        assert result.completed >= 2  # start + at least one blog child
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/blog/index" in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_include_paths_start_url_no_match_returns_zero(self, mock_scraper):
+        """When start URL doesn't match include_paths, 0 pages are crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/section/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Section 1</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL / doesn't match /section/* so it's skipped
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_include_paths_regex_mode(self, mock_scraper):
+        """include_paths with regex_on_full_url=True uses regex matching."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/page-[12]"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/section/page-3">Page 3</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page-1")
+
+        # Start URL /section/page-1 should match /section/page-[12]
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" in urls
+        assert "http://example.com/section/page-3" not in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_include_paths_empty_is_identity(self, mock_scraper):
+        """Empty include_paths list means 'include all' (identity)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # All URLs should pass (identity filter)
+        assert result.completed >= 2
+
+    @pytest.mark.asyncio
+    async def test_exclude_paths_empty_is_identity(self, mock_scraper):
+        """Empty exclude_paths list means 'exclude none' (identity)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=[],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # All URLs should pass (identity filter)
+        assert result.completed >= 2
+
+    @pytest.mark.asyncio
+    async def test_exclude_overrides_include(self, mock_scraper):
+        """exclude_paths takes precedence over include_paths."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/*"],
+                exclude_paths=["/section/page-2"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/index")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" not in urls  # excluded
+        assert "http://example.com/about" not in urls  # not in include_paths
+
+    @pytest.mark.asyncio
+    async def test_exclude_all_returns_zero_pages(self, mock_scraper):
+        """exclude_paths matching everything returns 0 pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                exclude_paths=["/*"],
+            ),
+        )
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_include_nonexistent_returns_zero_pages(self, mock_scraper):
+        """include_paths that match nothing returns 0 pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/nonexistent/*"],
+            ),
+        )
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_glob_double_star_matches_any_depth(self, mock_scraper):
+        """Glob ** matches across directory boundaries."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=20,
+                max_depth=3,
+                include_paths=["/blog/**"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/blog/2024/01/post">Deep post</a>
+                <a href="http://example.com/blog/2024">Year index</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/blog/index")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/blog/index" in urls
+        # Deep paths under /blog/ should match /blog/**
+        assert "http://example.com/blog/2024" in urls
+        assert "http://example.com/blog/2024/01/post" in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_query_params(self, mock_scraper):
+        """regex_on_full_url matches against full URL including query params."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[r"\?ref=partner"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page?ref=partner">Partner link</a>
+                <a href="http://example.com/page?ref=other">Other link</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/start?ref=partner")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/page?ref=partner" in urls
+        assert "http://example.com/page?ref=other" not in urls
+
+    @pytest.mark.asyncio
+    async def test_verbose_tracks_filtered_out_urls(self, mock_scraper):
+        """Verbose mode collects URLs that were filtered out with reasons."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/*"],
+                exclude_paths=["/section/secret"],
+                verbose=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/secret">Secret</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL / doesn't match /section/* → should be filtered out
+        assert result.completed == 0
+        assert len(result.pages) == 0
+        if result.filtered_out:
+            # At least one filtered URL should be recorded
+            assert any(f["reason"] == "include_paths" for f in result.filtered_out)
+
+    @pytest.mark.asyncio
+    async def test_verbose_tracks_exclude_reason(self, mock_scraper):
+        """Verbose mode records exclude_paths as filter reason."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=["/admin/*"],
+                verbose=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/admin/secret">Admin</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed >= 2  # start URL + pricing
+        if result.filtered_out:
+            assert any(f["reason"] == "exclude_paths" for f in result.filtered_out), (
+                "Expected exclude_paths reason in filtered_out"
+            )
+
+    @pytest.mark.asyncio
+    async def test_glob_escapes_regex_special_chars(self, mock_scraper):
+        """Glob mode treats regex special chars as literals."""
+        from agent.crawler import _match_path
+
+        # In glob mode, '.' should be literal, not 'any char'
+        assert _match_path(
+            "http://example.com/file.html",
+            ["/file.html"],
+            None,
+            regex_on_full_url=False,
+        )
+        # Should NOT match fileXhtml when . is treated literally
+        assert not _match_path(
+            "http://example.com/fileXhtml",
+            ["/file.html"],
+            None,
+            regex_on_full_url=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_exclude_paths(self, mock_scraper):
+        """exclude_paths with regex_on_full_url=True uses regex matching."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=[r"/section/page-[23]"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/section/page-3">Page 3</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" not in urls
+        assert "http://example.com/section/page-3" not in urls
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_ignore_query_params(self, mock_scraper):
+        """ignoreQueryParameters strips query first, then regex applies to path.
+
+        Per VAL-SCOPE-073: when both regexOnFullURL and ignoreQueryParameters
+        are set, query string is stripped from the URL BEFORE regex matching.
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[r"/page$"],
+                regex_on_full_url=True,
+                ignore_query_parameters=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/other-page?ref=test">Other page with query</a>
+                <a href="http://example.com/pages">Pages (plural)</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/page")
+
+        # Start URL /page matches /page$ include pattern
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/page" in urls
+        # With ignore_query_parameters, /other-page?ref=test normalizes to /other-page
+        # and the filter_url (without query) matches /page$? No — /other-page doesn't end with /page
+        # So /other-page should be excluded by the path filter
+        assert "http://example.com/other-page" not in urls
+        # /pages should NOT match /page$ (because $ anchors to end)
+        assert "http://example.com/pages" not in urls

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1443,3 +1443,266 @@ class TestPathFiltering:
         assert "http://example.com/other-page" not in urls
         # /pages should NOT match /page$ (because $ anchors to end)
         assert "http://example.com/pages" not in urls
+
+
+# ── CrawlStatusResponse enhancement tests ────────────────────────
+
+
+class TestCrawlStatusResponseModel:
+    """Tests for CrawlStatusResponse model with new timestamp fields."""
+
+    def test_crawl_status_response_has_timestamp_fields(self):
+        """CrawlStatusResponse model includes created_at, completed_at, expires_at, duration."""
+        from agent.models import CrawlStatusResponse
+
+        # While processing (no completed_at, no duration)
+        resp = CrawlStatusResponse(
+            status="processing",
+            completed=0,
+            total=5,
+            created_at="2026-01-15T10:00:00+00:00",
+            expires_at="2026-01-16T10:00:00+00:00",
+        )
+        assert resp.created_at == "2026-01-15T10:00:00+00:00"
+        assert resp.expires_at == "2026-01-16T10:00:00+00:00"
+        assert resp.completed_at is None
+        assert resp.duration is None
+
+        # On completion (all four fields present)
+        resp2 = CrawlStatusResponse(
+            status="completed",
+            completed=5,
+            total=5,
+            created_at="2026-01-15T10:00:00+00:00",
+            completed_at="2026-01-15T10:00:05+00:00",
+            expires_at="2026-01-16T10:00:00+00:00",
+            duration=5000,
+        )
+        assert resp2.created_at is not None
+        assert resp2.completed_at is not None
+        assert resp2.expires_at is not None
+        assert resp2.duration == 5000
+        # Verify created_at < completed_at <= expires_at
+        assert resp2.created_at < resp2.completed_at <= resp2.expires_at
+
+    def test_crawl_status_response_defaults(self):
+        """CrawlStatusResponse defaults to processing state with no timestamp fields."""
+        from agent.models import CrawlStatusResponse
+
+        resp = CrawlStatusResponse()
+        assert resp.status == "processing"
+        assert resp.completed == 0
+        assert resp.total == 0
+        assert resp.created_at is None
+        assert resp.completed_at is None
+        assert resp.expires_at is None
+        assert resp.duration is None
+
+
+# ── CrawlRequest validation tests ────────────────────────────────
+
+
+class TestCrawlRequestValidation:
+    """Tests for CrawlRequest field validation."""
+
+    def test_max_pages_positive_accepts_valid(self):
+        """max_pages >= 1 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_pages=1)
+        assert req.max_pages == 1
+
+        req2 = CrawlRequest(url="http://example.com", max_pages=100)
+        assert req2.max_pages == 100
+
+    def test_max_pages_zero_rejected(self):
+        """max_pages=0 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_pages"):
+            CrawlRequest(url="http://example.com", max_pages=0)
+
+    def test_max_depth_non_negative_accepts_valid(self):
+        """max_depth >= 0 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_depth=0)
+        assert req.max_depth == 0
+
+        req2 = CrawlRequest(url="http://example.com", max_depth=5)
+        assert req2.max_depth == 5
+
+    def test_max_depth_negative_rejected(self):
+        """max_depth=-1 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_depth"):
+            CrawlRequest(url="http://example.com", max_depth=-1)
+
+    def test_max_depth_default_is_two(self):
+        """Default max_depth is 2."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.max_depth == 2
+
+    def test_max_pages_default_is_ten(self):
+        """Default max_pages is 10."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.max_pages == 10
+
+
+# ── Store tests ──────────────────────────────────────────────────
+
+
+class TestJobStoreExpiresAt:
+    """Tests for JobStore expires_at field."""
+
+    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    def test_create_job_includes_expires_at(self):
+        """JobStore.create_job sets expires_at in job metadata."""
+        from agent.store import JobStore
+
+        store = JobStore()
+        job_id = store.create_job(kind="crawl", payload={"url": "http://example.com"})
+        try:
+            meta_raw = store.redis.get(f"job:{job_id}:meta")
+            assert meta_raw is not None
+
+            import json
+
+            meta = json.loads(meta_raw)
+            assert "expires_at" in meta
+            assert meta["expires_at"] is not None
+            # expires_at should be a valid ISO 8601 string
+            from datetime import datetime
+
+            parsed = datetime.fromisoformat(meta["expires_at"])
+            assert parsed is not None
+
+            # expires_at should be ~24h after created_at
+            created = datetime.fromisoformat(meta["created_at"])
+            diff = parsed - created
+            assert 23 * 3600 <= diff.total_seconds() <= 25 * 3600  # ~24h window
+        finally:
+            store.redis.delete(f"job:{job_id}:meta")
+
+    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    def test_complete_job_sets_completed_at(self):
+        """JobStore.complete_job sets completed_at in metadata."""
+        from agent.store import JobStore
+
+        store = JobStore()
+        job_id = store.create_job(kind="crawl", payload={"url": "http://example.com"})
+        try:
+            store.complete_job(job_id, {"completed": 1, "total": 1})
+
+            meta_raw = store.redis.get(f"job:{job_id}:meta")
+            assert meta_raw is not None
+
+            import json
+
+            meta = json.loads(meta_raw)
+            assert "completed_at" in meta
+            assert meta["completed_at"] is not None
+            # completed_at should be a valid ISO 8601 string
+            from datetime import datetime
+
+            parsed = datetime.fromisoformat(meta["completed_at"])
+            assert parsed is not None
+            assert meta["status"] == "completed"
+        finally:
+            store.redis.delete(f"job:{job_id}:meta")
+            store.redis.delete(f"job:{job_id}:data")
+
+
+# ── Per-page metadata enrichment tests ──────────────────────────
+
+
+class TestPerPageMetadata:
+    """Tests for per-page metadata enrichment in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_page_includes_title_and_metadata(self, mock_scraper):
+        """Each page in crawl results includes title, metadata dict with title/description/source,
+        status_code, content_type, scraped_at, and duration_ms."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Mock scraper to return enriched data with metadata
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return {
+                "success": True,
+                "data": {
+                    "markdown": f"# Content of {url}",
+                    "source": "playwright",
+                    "metadata": {
+                        "title": "Test Page",
+                        "description": "A test page description",
+                        "sourceURL": url,
+                        "statusCode": 200,
+                        "content-type": "text/html",
+                    },
+                },
+            }
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=0),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert len(result.pages) == 1
+        page = result.pages[0]
+
+        # Verify metadata fields
+        assert page["url"] == "http://example.com/"
+        assert page["markdown"] == "# Content of http://example.com/"
+        assert page["title"] == "Test Page"
+        assert page["metadata"]["title"] == "Test Page"
+        assert page["metadata"]["description"] == "A test page description"
+        assert page["metadata"]["source"] == "playwright"
+        assert page["status_code"] == 200
+        assert page["content_type"] == "text/html"
+        assert page["scraped_at"] is not None
+        assert isinstance(page["duration_ms"], int)
+        assert page["duration_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_page_metadata_falls_back_gracefully(self, mock_scraper):
+        """When scraper returns minimal data, metadata fields fall back to defaults."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Minimal scraper response
+        mock_scraper.scrape = AsyncMock(
+            return_value={"success": True, "data": {"markdown": "Just text"}}
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=0),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert len(result.pages) == 1
+        page = result.pages[0]
+
+        assert page["url"] == "http://example.com/"
+        assert page["markdown"] == "Just text"
+        assert page["title"] == ""  # falls back to empty string
+        assert page["metadata"]["title"] == ""
+        assert page["metadata"]["description"] == ""
+        assert page["metadata"]["source"] == "unknown"
+        assert page["status_code"] == 200  # default
+        assert page["content_type"] == "text/html"  # default
+        assert page["scraped_at"] is not None
+        assert isinstance(page["duration_ms"], int)

--- a/tests/test_link_extractor.py
+++ b/tests/test_link_extractor.py
@@ -1,0 +1,407 @@
+"""Unit tests for the shared LinkExtractor module.
+
+Tests the ``extract_links()``, ``filter_links()``, and ``classify_links()``
+functions from ``agent-svc/agent/link_extractor.py`` without needing a
+running Docker stack.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Add agent-svc to sys.path so we can import the agent package directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agent-svc"))
+
+from agent.link_extractor import (
+    _is_subdomain,
+    _strip_fragment,
+    classify_links,
+    extract_links,
+    filter_links,
+)
+
+# ── extract_links() tests ──────────────────────────────────────────
+
+
+class TestExtractLinks:
+    """Tests for extract_links() — core link extraction."""
+
+    def test_basic_link_extraction(self):
+        """Should extract all <a href> links from simple HTML."""
+        html = """
+        <html>
+        <body>
+            <a href="/page1">Page 1</a>
+            <a href="/page2">Page 2</a>
+            <a href="/page3">Page 3</a>
+        </body>
+        </html>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 3
+        assert "https://example.com/page1" in links
+        assert "https://example.com/page2" in links
+        assert "https://example.com/page3" in links
+
+    def test_absolute_links_preserved(self):
+        """Should preserve already-absolute URLs unchanged."""
+        html = '<a href="https://other.com/page">Link</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://other.com/page" in links
+
+    def test_relative_urls_resolved(self):
+        """Should resolve relative hrefs against base_url (VAL-CRAWL-035)."""
+        html = '<a href="/about">About</a><a href="contact">Contact</a>'
+        links = extract_links(html, "https://example.com/sub/")
+        assert "https://example.com/about" in links
+        assert "https://example.com/sub/contact" in links
+
+    def test_fragment_stripped(self):
+        """Should strip fragment identifiers from extracted URLs (VAL-CRAWL-036)."""
+        html = '<a href="/about#team">Team</a><a href="/pricing#plans">Plans</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://example.com/about" in links
+        assert "https://example.com/pricing" in links
+        # No fragment-bearing URLs should be present
+        for link in links:
+            assert "#" not in link
+
+    def test_duplicates_deduplicated(self):
+        """Should deduplicate identical URLs (VAL-CRAWL-058)."""
+        html = """
+        <a href="/page">First</a>
+        <a href="/page">Second</a>
+        <a href="https://example.com/page">Third (absolute dup)</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/page"]
+
+    def test_fragment_variants_deduplicated(self):
+        """Fragment variants of same URL should resolve to same base URL."""
+        html = '<a href="/about#team">Team</a><a href="/about#history">History</a>'
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/about"]
+
+    def test_non_http_schemes_filtered(self):
+        """Should filter out mailto:, tel:, javascript:, ftp: (VAL-CRAWL-057)."""
+        html = """
+        <a href="mailto:user@example.com">Email</a>
+        <a href="tel:+1234567890">Call</a>
+        <a href="javascript:void(0)">JS</a>
+        <a href="ftp://files.example.com">FTP</a>
+        <a href="/valid-page">Valid</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/valid-page"]
+
+    def test_malformed_html_graceful(self):
+        """Malformed HTML should not crash — graceful degradation (VAL-CRAWL-056)."""
+        html = """<html><body><a href="/page1">Page1<a href="/page2">Page2"""
+        links = extract_links(html, "https://example.com")
+        assert len(links) >= 1
+
+    def test_completely_garbled_html(self):
+        """Completely garbled HTML should not crash."""
+        html = "not even close to valid html <<<<>>>> ### %% ^^^^"
+        links = extract_links(html, "https://example.com")
+        assert isinstance(links, list)
+
+    def test_empty_html(self):
+        """Empty HTML should return empty list."""
+        assert extract_links("", "https://example.com") == []
+
+    def test_none_html(self):
+        """None-like empty HTML should return empty list."""
+        assert extract_links("", "https://example.com") == []
+
+    def test_base_tag_respected(self):
+        """<base> tag should override base_url for relative resolution (VAL-CRAWL-074)."""
+        html = """
+        <html>
+        <head><base href="https://other.example.com/sub/"></head>
+        <body>
+            <a href="page">Relative to base</a>
+            <a href="/root">Root-relative</a>
+        </body>
+        </html>
+        """
+        links = extract_links(html, "https://example.com")
+        assert "https://other.example.com/sub/page" in links
+        assert "https://other.example.com/root" in links
+
+    def test_links_with_no_href_ignored(self):
+        """<a> tags without href attribute should be ignored."""
+        html = '<a>No href</a><a href="">Empty href</a><a href="/ok">OK</a>'
+        links = extract_links(html, "https://example.com")
+        assert links == ["https://example.com/ok"]
+
+    def test_trailing_whitespace_in_href(self):
+        """Href with leading/trailing whitespace should be trimmed."""
+        html = '<a href="  /page  ">Spaced</a>'
+        links = extract_links(html, "https://example.com")
+        assert links == ["https://example.com/page"]
+
+    def test_same_page_link_handled(self):
+        """A link to '#' should resolve to the base URL without fragment."""
+        html = '<a href="#">Top</a>'
+        links = extract_links(html, "https://example.com")
+        # urljoin("#", "https://example.com") returns "https://example.com"
+        assert links == ["https://example.com"]
+
+    def test_protocol_relative_url(self):
+        """Protocol-relative URLs (//example.com/path) should resolve correctly."""
+        html = '<a href="//cdn.example.com/file.js">CDN</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://cdn.example.com/file.js" in links
+
+    def test_multiple_nested_a_tags(self):
+        """Links nested in complex HTML structures should all be found."""
+        html = """
+        <div><ul><li><a href="/deep1">Deep</a></li></ul></div>
+        <p><span><a href="/deep2">Nested</a></span></p>
+        <a href="/top">Top</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 3
+        assert "https://example.com/deep1" in links
+        assert "https://example.com/deep2" in links
+        assert "https://example.com/top" in links
+
+    def test_no_links_in_html(self):
+        """HTML with no <a> tags should return empty list."""
+        html = "<html><body><p>No links here</p></body></html>"
+        assert extract_links(html, "https://example.com") == []
+
+
+# ── filter_links() tests ────────────────────────────────────────────
+
+
+class TestFilterLinks:
+    """Tests for filter_links() — scope-based filtering."""
+
+    def test_internal_links_included_by_default(self):
+        """Internal (same-domain) links should always be included."""
+        links = [
+            "https://example.com/page1",
+            "https://example.com/page2",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 2
+
+    def test_subdomain_excluded_by_default(self):
+        """Subdomain links should be excluded when allow_subdomains=False."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+    def test_subdomain_included_when_allowed(self):
+        """Subdomain links should be included when allow_subdomains=True."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+            "https://blog.example.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 3
+        assert "https://docs.example.com/page" in filtered
+
+    def test_external_excluded_by_default(self):
+        """External links should be excluded when allow_external_links=False."""
+        links = [
+            "https://example.com/page",
+            "https://other.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+    def test_external_included_when_allowed(self):
+        """External links should be included when allow_external_links=True."""
+        links = [
+            "https://example.com/page",
+            "https://other.com/page",
+            "https://another.org/path",
+        ]
+        filtered = filter_links(
+            links,
+            base_domain="example.com",
+            allow_external_links=True,
+        )
+        assert len(filtered) == 3
+        assert "https://other.com/page" in filtered
+
+    def test_subdomain_and_external_combined(self):
+        """Both subdomain and external flags should work together."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+            "https://other.com/page",
+        ]
+        filtered = filter_links(
+            links,
+            base_domain="example.com",
+            allow_subdomains=True,
+            allow_external_links=True,
+        )
+        assert len(filtered) == 3
+
+    def test_empty_links_list(self):
+        """Empty links list should return empty list."""
+        assert filter_links([], base_domain="example.com") == []
+
+    def test_no_base_domain(self):
+        """Without base_domain, all links should pass through."""
+        links = ["https://example.com/page", "https://other.com/page"]
+        filtered = filter_links(links)
+        assert len(filtered) == 2
+
+    def test_different_schemes_same_domain(self):
+        """HTTP and HTTPS on same domain should both be internal."""
+        links = [
+            "http://example.com/page1",
+            "https://example.com/page2",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 2
+
+    def test_subdomain_with_port(self):
+        """Subdomain with port should still be recognized as subdomain."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com:8080/page",
+        ]
+        # Without allow_subdomains
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+        # With allow_subdomains
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 2
+
+    def test_multi_level_subdomain(self):
+        """Multi-level subdomains should be recognized."""
+        links = ["https://deep.docs.example.com/page"]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 0
+
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 1
+
+
+# ── classify_links() tests ─────────────────────────────────────────
+
+
+class TestClassifyLinks:
+    """Tests for classify_links() — domain classification."""
+
+    def test_classify_internal(self):
+        """Same-domain URLs should be classified as internal."""
+        links = ["https://example.com/page", "https://example.com/about"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com/page" in result["internal"]
+        assert "https://example.com/about" in result["internal"]
+        assert result["subdomain"] == []
+        assert result["external"] == []
+
+    def test_classify_subdomain(self):
+        """Subdomain URLs should be classified as subdomain."""
+        links = ["https://docs.example.com/page", "https://blog.example.com/"]
+        result = classify_links(links, "https://example.com")
+        assert result["internal"] == []
+        assert "https://docs.example.com/page" in result["subdomain"]
+        assert "https://blog.example.com/" in result["subdomain"]
+        assert result["external"] == []
+
+    def test_classify_external(self):
+        """Different-domain URLs should be classified as external."""
+        links = ["https://other.com/page", "https://another.org/"]
+        result = classify_links(links, "https://example.com")
+        assert result["internal"] == []
+        assert result["subdomain"] == []
+        assert "https://other.com/page" in result["external"]
+
+    def test_classify_mixed(self):
+        """Mixed internal/subdomain/external URLs should be classified correctly."""
+        links = [
+            "https://example.com/internal",
+            "https://docs.example.com/subdomain",
+            "https://other.com/external",
+        ]
+        result = classify_links(links, "https://example.com")
+        assert len(result["internal"]) == 1
+        assert len(result["subdomain"]) == 1
+        assert len(result["external"]) == 1
+
+    def test_classify_with_port_difference(self):
+        """Port difference does not change internal classification."""
+        links = ["https://example.com:8080/page"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com:8080/page" in result["internal"]
+
+    def test_classify_with_path(self):
+        """URLs with paths are still classified by domain."""
+        links = ["https://example.com/sub/deep/page"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com/sub/deep/page" in result["internal"]
+
+    def test_classify_empty_links(self):
+        """Empty links should return all-empty categories."""
+        result = classify_links([], "https://example.com")
+        assert result == {"internal": [], "subdomain": [], "external": []}
+
+
+# ── Helper function tests ──────────────────────────────────────────
+
+
+class TestStripFragment:
+    """Tests for the _strip_fragment helper."""
+
+    def test_strips_fragment(self):
+        assert (
+            _strip_fragment("https://example.com/page#section")
+            == "https://example.com/page"
+        )
+
+    def test_no_fragment(self):
+        assert _strip_fragment("https://example.com/page") == "https://example.com/page"
+
+    def test_empty_url(self):
+        assert _strip_fragment("") == ""
+
+    def test_fragment_with_query(self):
+        assert (
+            _strip_fragment("https://example.com/page?a=1#section")
+            == "https://example.com/page?a=1"
+        )
+
+
+class TestIsSubdomain:
+    """Tests for the _is_subdomain helper."""
+
+    def test_subdomain(self):
+        assert _is_subdomain("docs.example.com", "example.com")
+
+    def test_same_domain(self):
+        assert not _is_subdomain("example.com", "example.com")
+
+    def test_different_domain(self):
+        assert not _is_subdomain("other.com", "example.com")
+
+    def test_multi_level_subdomain(self):
+        assert _is_subdomain("a.b.example.com", "example.com")
+
+    def test_not_subdomain_with_prefix(self):
+        """notexample.com is not a subdomain of example.com."""
+        assert not _is_subdomain("notexample.com", "example.com")
+
+    def test_case_insensitive(self):
+        assert _is_subdomain("DOCS.EXAMPLE.COM", "example.com")

--- a/tests/test_llmstxt_unit.py
+++ b/tests/test_llmstxt_unit.py
@@ -1,16 +1,20 @@
 """Unit tests for llmstxt.py pure functions.
 
-Tests the _extract_description() function directly without needing
-a running Docker stack. Run with: python3 -m pytest tests/test_llmstxt_unit.py -v
+Tests the _extract_description() and discover_pages() functions directly
+without needing a running Docker stack.
+Run with: python3 -m pytest tests/test_llmstxt_unit.py -v
 """
 
 import os
 import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 # Add the agent-svc directory to the path so we can import llmstxt
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agent-svc"))
 
-from agent.llmstxt import _extract_description
+from agent.llmstxt import _extract_description, discover_pages
 
 
 def test_ends_at_sentence_boundary():
@@ -115,3 +119,217 @@ def test_multi_sentence_content():
     assert "opening statement" in desc
     # Should end with a sentence-ending punctuation
     assert desc.rstrip()[-1] in ".!?"
+
+
+# ── discover_pages tests ──────────────────────────────────────────
+
+
+def _mock_html_page(
+    *,
+    internal_links: list[str] | None = None,
+    external_links: list[str] | None = None,
+    non_http_links: list[str] | None = None,
+) -> str:
+    """Build an HTML page with the given link lists for testing."""
+    links_html = ""
+    for link in internal_links or []:
+        links_html += f'<a href="{link}">internal</a>\n'
+    for link in external_links or []:
+        links_html += f'<a href="{link}">external</a>\n'
+    for link in non_http_links or []:
+        links_html += f'<a href="{link}">non-http</a>\n'
+    return f"<html><body>{links_html}</body></html>"
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_extracts_internal_links():
+    """discover_pages should extract same-host links from the page HTML."""
+    html = _mock_html_page(
+        internal_links=["/page1", "/page2", "/page3"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+    assert "http://example.com/page3" in result
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_excludes_external_links():
+    """discover_pages should exclude links to external domains."""
+    html = _mock_html_page(
+        internal_links=["/page1"],
+        external_links=["https://other.com/page"],
+        non_http_links=["mailto:test@example.com"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert "http://example.com/page1" in result
+    assert "https://other.com/page" not in result
+    assert "mailto:test@example.com" not in result
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_respects_max_pages():
+    """discover_pages should limit results to max_pages."""
+    html = _mock_html_page(
+        internal_links=[f"/page{i}" for i in range(20)],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=3)
+
+    assert len(result) == 3
+    # First 3 links should be returned
+    assert result[0] == "http://example.com/page0"
+    assert result[1] == "http://example.com/page1"
+    assert result[2] == "http://example.com/page2"
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_http_error_falls_back():
+    """discover_pages should return [url] when the server returns non-200."""
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 404
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_exception_falls_back():
+    """discover_pages should return [url] when an exception occurs during fetch."""
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = Exception("Connection error")
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_empty_results_falls_back():
+    """discover_pages should return [url] when no links are found."""
+    html = "<html><body><p>No links here</p></body></html>"
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_deduplicates_links():
+    """discover_pages should not return duplicate URLs."""
+    html = _mock_html_page(
+        internal_links=["/page1", "/page1", "/page2", "/page1"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert len(result) == 2
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_strips_fragments():
+    """discover_pages should strip fragment identifiers from URLs."""
+    html = _mock_html_page(
+        internal_links=["/page1#section1", "/page1#section2", "/page2"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    # Fragment-stripped URLs should be deduped — only one /page1 entry
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+    assert "#" not in str(result)
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_max_pages_larger_than_available():
+    """When max_pages exceeds available links, all links are returned."""
+    html = _mock_html_page(
+        internal_links=["/a", "/b"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=100)
+
+    assert len(result) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -203,6 +203,8 @@ class TestCrawlRequest:
         r = CrawlRequest(url="https://example.com")
         assert r.max_pages == 10
         assert r.max_depth == 2
+        assert r.regex_on_full_url is False
+        assert r.verbose is False
 
     def test_with_webhook(self):
         from agent.models import CrawlRequest
@@ -211,6 +213,70 @@ class TestCrawlRequest:
             url="https://x.com", webhook={"url": "https://hook.example.com"}
         )
         assert r.webhook["url"] == "https://hook.example.com"
+
+    def test_with_regex_on_full_url(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[r"/section/.*"],
+        )
+        assert r.regex_on_full_url is True
+        assert r.include_paths == [r"/section/.*"]
+
+    def test_invalid_regex_raises_validation_error(self):
+        from agent.models import CrawlRequest
+
+        with pytest.raises(ValidationError) as excinfo:
+            CrawlRequest(
+                url="https://example.com",
+                regex_on_full_url=True,
+                include_paths=["[unclosed"],
+            )
+        err = str(excinfo.value)
+        assert "include_paths" in err
+        assert "unclosed" in err.lower() or "invalid" in err.lower()
+
+    def test_invalid_regex_in_exclude_paths_raises_error(self):
+        from agent.models import CrawlRequest
+
+        with pytest.raises(ValidationError) as excinfo:
+            CrawlRequest(
+                url="https://example.com",
+                regex_on_full_url=True,
+                exclude_paths=[r"[\w+", r"/valid/\d+"],
+            )
+        err = str(excinfo.value)
+        assert "exclude_paths" in err
+
+    def test_valid_regex_passes_validation(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[r"/section/\d+", r"/blog/.*"],
+            exclude_paths=[r"/admin/.*"],
+        )
+        assert r.include_paths == [r"/section/\d+", r"/blog/.*"]
+        assert r.exclude_paths == [r"/admin/.*"]
+
+    def test_empty_include_paths_with_regex_is_valid(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[],
+        )
+        assert r.include_paths == []
+
+    def test_verbose_flag(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(url="https://example.com", verbose=True)
+        assert r.verbose is True
 
 
 class TestBatchScrapeRequest:


### PR DESCRIPTION
## Summary

Enhances the CrawlStatusResponse model and GET /v2/crawl/{id} endpoint with timestamp fields, per-page metadata enrichment, and input validation.

## Changes

### Models (models.py)
- Added `created_at`, `completed_at`, `expires_at`, `duration` fields to `CrawlStatusResponse`
- Added `ge=1` and `ge=0` validation constraints to `CrawlRequest.max_pages` and `CrawlRequest.max_depth` respectively (rejects 0 and negative values)

### Job Store (store.py)
- Added `expires_at` ISO 8601 timestamp (createdAt + 24h) to job metadata on creation
- Added `_expires_iso()` helper function, imported `timedelta`

### Crawl Engine (crawler.py)
- Enriched per-page data with: `title`, `metadata` dict (title/description/source), `status_code`, `content_type`, `scraped_at`, `duration_ms`
- Added per-page scrape timing using `time.monotonic()`

### API (api.py)
- `GET /v2/crawl/{job_id}` now passes `created_at`, `completed_at`, `expires_at` from job meta
- Computes `duration` in milliseconds from created_at to completed_at

### Tests
- Added tests for CrawlStatusResponse timestamp fields
- Added tests for max_pages >= 1 validation (rejects 0)
- Added tests for max_depth >= 0 validation (rejects negative)
- Added tests for per-page metadata enrichment
- Added tests for store expires_at on creation

## Validation Contract Coverage

- VAL-CRAWL-017: Enhanced CrawlStatusResponse with createdAt, expiresAt, completedAt, duration
- VAL-CRAWL-018: Enhanced per-page metadata (title, status_code, etc.)
- VAL-CRAWL-041: Crawl progress visible during polling (existing periodic store updates)
- VAL-CRAWL-067: max_pages=0 rejected at creation (422 via Field(ge=1))
- VAL-CRAWL-068: max_depth=-1 rejected at creation (422 via Field(ge=0))

## Verification

- 115 unit tests pass, 2 skipped (Redis-dependent)
- mypy: no issues found
- ruff: all checks passed
- Pre-commit hooks all passed