### PR TITLE
feat(domain-scope-controls): implement crawlEntireDomain, allowSubdomains, allowExternalLinks scope controls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -153,3 +153,12 @@
 # Limits how many search calls a single client IP can make within the
 # window. Uses Valkey-backed INCR/EXPIRE for atomic counting.
 # AGENT_SEARCH_RATE_LIMIT=10/60s
+
+# ── Crawl Job Lifecycle ──────────────────────────────────────────
+# Maximum wall-clock duration for a single crawl job (seconds, default: 1800 = 30 min).
+# Crawls exceeding this are terminated with a TimeoutError.
+# CRAWL_MAX_DURATION_SECONDS=1800
+
+# Idle timeout for stuck/zombie crawls (seconds, default: 300 = 5 min).
+# If no page completes within this window, the crawl is terminated.
+# CRAWL_IDLE_TIMEOUT_SECONDS=300

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -294,17 +294,25 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
     store: JobStore = request.app.state.job_store
     job_id = store.create_job(kind="crawl", payload=body.model_dump())
 
+    # Resolve limit vs max_pages conflict (stricter wins, per VAL-CRAWL-089)
+    effective_max_pages = body.max_pages
+    if body.limit is not None:
+        effective_max_pages = min(body.max_pages, body.limit)
+
     from .worker import _process_crawl_async
 
     request.app.state.task_tracker.create_background_task(
         _process_crawl_async(
             job_id=job_id,
             url=body.url,
-            max_pages=body.max_pages,
+            max_pages=effective_max_pages,
             max_depth=body.max_depth,
             scraper_url=request.app.state.scraper_url,
             webhook_config=body.webhook,
             task_tracker=request.app.state.task_tracker,
+            ignore_query_parameters=body.ignore_query_parameters,
+            include_paths=body.include_paths,
+            exclude_paths=body.exclude_paths,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -8,10 +8,7 @@ from datetime import UTC
 from typing import Any
 
 import httpx
-from bs4 import BeautifulSoup
 from fastapi import APIRouter, Request, Response
-
-from common.url import extract_domain, is_same_origin
 
 from .exceptions import (
     BrowserError,
@@ -744,22 +741,33 @@ async def map_site(request: Request, body: MapRequest) -> MapResponse:
             resp = await client.get(body.url)
             if resp.status_code != 200:
                 raise UpstreamError(detail=f"Site returned HTTP {resp.status_code}")
-            soup = BeautifulSoup(resp.text, "html.parser")
-            links: list[str] = []
-            for a in soup.find_all("a", href=True):
-                href: str = a["href"]  # type: ignore[assignment,union-attr]
-                if href.startswith("/"):
-                    href = f"{extract_domain(body.url, include_scheme=True)}{href}"
-                href_start = href.startswith(body.url.rstrip("/")) or is_same_origin(
-                    body.url, href
-                )
-                if href_start and href not in links:
-                    links.append(href)
-                    if len(links) >= body.limit:
-                        break
+
+            # Use shared LinkExtractor instead of inline BeautifulSoup parsing
+            from urllib.parse import urlparse
+
+            from .link_extractor import extract_links, filter_links
+
+            all_links = extract_links(resp.text, body.url)
+
+            # Filter links by domain scope (default: same-origin only)
+            base_domain = (urlparse(body.url).hostname or "").lower()
+            filtered = filter_links(
+                all_links,
+                base_domain=base_domain,
+                allow_subdomains=body.allow_subdomains,
+                allow_external_links=body.allow_external_links,
+            )
+
+            # Apply limit (truncates AFTER filtering)
+            result = filtered[: body.limit]
+
+            # Apply search filter (case-insensitive substring match)
             if body.search:
-                links = [link for link in links if body.search.lower() in link.lower()]
-            return MapResponse(links=links)
+                result = [
+                    link for link in result if body.search.lower() in link.lower()
+                ]
+
+            return MapResponse(links=result)
     except Exception as e:
         logger.error("Map failed for %s: %s", body.url, e)
         raise UpstreamError(detail=str(e)) from e

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -316,6 +316,9 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             regex_on_full_url=body.regex_on_full_url,
             verbose=body.verbose,
             sitemap_mode=body.sitemap,
+            crawl_entire_domain=body.crawl_entire_domain,
+            allow_subdomains=body.allow_subdomains,
+            allow_external_links=body.allow_external_links,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -327,12 +327,31 @@ async def get_crawl_status(request: Request, job_id: str) -> CrawlStatusResponse
     if job is None:
         raise NotFoundError(detail="Job not found", details={"job_id": job_id})
     data = job.get("data") or {}
+
+    # Compute duration in milliseconds from created_at to completed_at
+    created_at = job.get("created_at")
+    completed_at = job.get("completed_at")
+    duration: int | None = None
+    if created_at and completed_at:
+        try:
+            from datetime import datetime as _dt
+
+            created_dt = _dt.fromisoformat(created_at)
+            completed_dt = _dt.fromisoformat(completed_at)
+            duration = int((completed_dt - created_dt).total_seconds() * 1000)
+        except (ValueError, TypeError):
+            duration = None
+
     return CrawlStatusResponse(
         status=job.get("status", "processing"),
         completed=data.get("completed", 0),
         total=data.get("total", 0),
         data=data.get("pages"),
         error=job.get("error"),
+        created_at=created_at,
+        completed_at=completed_at,
+        expires_at=job.get("expires_at"),
+        duration=duration,
     )
 
 

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -313,6 +313,8 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             ignore_query_parameters=body.ignore_query_parameters,
             include_paths=body.include_paths,
             exclude_paths=body.exclude_paths,
+            regex_on_full_url=body.regex_on_full_url,
+            verbose=body.verbose,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -315,6 +315,7 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             exclude_paths=body.exclude_paths,
             regex_on_full_url=body.regex_on_full_url,
             verbose=body.verbose,
+            sitemap_mode=body.sitemap,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -9,6 +9,7 @@ job store for status polling.
 
 from __future__ import annotations
 
+import collections.abc
 import json
 import logging
 import posixpath
@@ -61,6 +62,8 @@ class CrawlOptions:
     verbose: bool = False
     allow_subdomains: bool = False
     allow_external_links: bool = False
+    max_duration_seconds: int = 1800
+    idle_timeout_seconds: int = 300
 
 
 @dataclass
@@ -340,12 +343,23 @@ class CrawlEngine:
             await self._html_client.aclose()
             self._html_client = None
 
-    async def run(self, start_url: str, job_id: str | None = None) -> CrawlResult:
+    async def run(
+        self,
+        start_url: str,
+        job_id: str | None = None,
+        page_callback: collections.abc.Callable[
+            [str, dict], collections.abc.Awaitable[None]
+        ]
+        | None = None,
+    ) -> CrawlResult:
         """Execute a BFS crawl starting from ``start_url``.
 
         Args:
             start_url: The URL to begin crawling from.
-            job_id: Optional job ID for periodic store updates.
+            job_id: Optional job ID for periodic store updates and
+                cancellation checking.
+            page_callback: Optional async callback invoked after each
+                successful page scrape, receiving (job_id, page_dict).
 
         Returns:
             A ``CrawlResult`` with scraped pages, totals, and errors.
@@ -356,11 +370,50 @@ class CrawlEngine:
         # Seed the BFS queue
         self._queue.append((start_url, 0))
         last_store_update = time.monotonic()
+        crawl_start_time = time.monotonic()
+        last_completion_time = crawl_start_time
 
         while self._queue and len(self._pages) < self.options.max_pages:
             if self._cancel_flag:
                 logger.info("Crawl cancelled via cancel flag")
                 break
+
+            # Cooperative cancellation: check Redis for cancelled status
+            # between pages (checked before each page scrape).
+            if self.store is not None and job_id is not None:
+                job_meta = self.store.get_job(job_id)
+                if job_meta and job_meta.get("status") == "cancelled":
+                    self._cancel_flag = True
+                    logger.info("Crawl %s cancelled via Redis status check", job_id)
+                    break
+
+            # Maximum duration timeout check
+            now = time.monotonic()
+            elapsed = now - crawl_start_time
+            if elapsed > self.options.max_duration_seconds:
+                logger.warning(
+                    "Crawl %s exceeded max duration of %ds (elapsed=%.1fs)",
+                    job_id,
+                    self.options.max_duration_seconds,
+                    elapsed,
+                )
+                raise TimeoutError(
+                    f"Crawl exceeded max duration of {self.options.max_duration_seconds}s"
+                )
+
+            # Idle timeout (stuck-crawl) check
+            idle_elapsed = now - last_completion_time
+            if idle_elapsed > self.options.idle_timeout_seconds:
+                logger.warning(
+                    "Crawl %s idle for %ds (timeout=%ds) — killing zombie crawl",
+                    job_id,
+                    idle_elapsed,
+                    self.options.idle_timeout_seconds,
+                )
+                raise TimeoutError(
+                    f"Crawl idle for {idle_elapsed:.0f}s — "
+                    f"exceeded idle timeout of {self.options.idle_timeout_seconds}s"
+                )
 
             url, depth = self._queue.popleft()
             normalized = self.normalize_url(url)
@@ -466,6 +519,19 @@ class CrawlEngine:
                 "duration_ms": scrape_duration_ms,
             }
             self._pages.append(page)
+            last_completion_time = time.monotonic()
+
+            # Fire per-page webhook callback
+            if page_callback is not None and job_id is not None:
+                try:
+                    await page_callback(job_id, page)
+                except Exception:
+                    logger.warning(
+                        "Page callback failed for %s (job %s)",
+                        url,
+                        job_id,
+                        exc_info=True,
+                    )
 
             # Discover child links if within max_depth
             if depth < self.options.max_depth:

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -22,7 +22,9 @@ from urllib.parse import urlparse, urlunparse
 
 import httpx
 
-from .link_extractor import extract_links, filter_links
+from common.url import is_private_host
+
+from .link_extractor import classify_links, extract_links, filter_links
 from .scraper_client import ScraperClient
 from .sitemap_parser import SitemapParser
 from .store import JobStore
@@ -64,6 +66,7 @@ class CrawlOptions:
     sitemap_mode: str = "include"  # "include" | "skip" | "only"
     allow_subdomains: bool = False
     allow_external_links: bool = False
+    crawl_entire_domain: bool = False
     max_duration_seconds: int = 1800
     idle_timeout_seconds: int = 300
 
@@ -591,6 +594,27 @@ class CrawlEngine:
                         allow_subdomains=self.options.allow_subdomains,
                         allow_external_links=self.options.allow_external_links,
                     )
+                    # SSRF guard: always block private/internal hosts on
+                    # EXTERNAL URLs regardless of allow_external_links setting.
+                    # Internal and subdomain URLs are already vetted and are
+                    # part of the organization's own infrastructure — they
+                    # bypass the SSRF check. (VAL-SCOPE-017)
+                    classified = classify_links(child_links, url)
+                    if classified.get("external"):
+                        classified["external"] = self._filter_ssrf_blocked(
+                            classified["external"]
+                        )
+                    # Rebuild the full link list from classified buckets
+                    child_links = (
+                        classified.get("internal", [])
+                        + classified.get("subdomain", [])
+                        + classified.get("external", [])
+                    )
+                    # When crawl_entire_domain is False, only follow child paths
+                    # (deeper in the path hierarchy). When True, follow all
+                    # same-domain links including siblings and parents.
+                    if not self.options.crawl_entire_domain:
+                        child_links = self._filter_child_paths(child_links, url)
                     for child_url in child_links:
                         child_normalized = self.normalize_url(child_url)
                         if child_normalized not in self._seen:
@@ -659,6 +683,75 @@ class CrawlEngine:
     def cancel(self) -> None:
         """Signal the crawl to stop at the next opportunity."""
         self._cancel_flag = True
+
+    @staticmethod
+    def _filter_child_paths(links: list[str], current_url: str) -> list[str]:
+        """Filter links to only include child paths of the current URL.
+
+        When ``crawl_entire_domain`` is False, only follow links whose path
+        is a child (deeper) of the current page's path. Links on different
+        domains (subdomains or external) are not affected by this constraint.
+
+        Args:
+            links: List of absolute URL strings to filter.
+            current_url: The URL of the page the links were extracted from.
+
+        Returns:
+            Filtered list of URLs that are child paths (or different-domain).
+        """
+        current_path = urlparse(current_url).path.rstrip("/") + "/"
+        current_domain = (urlparse(current_url).hostname or "").lower()
+
+        result: list[str] = []
+        for link in links:
+            parsed = urlparse(link)
+            link_path = parsed.path or "/"
+            link_domain = (parsed.hostname or "").lower()
+
+            # If the link is on a different domain (including subdomain when
+            # already allowed by filter_links), skip the child-path constraint.
+            if link_domain != current_domain:
+                result.append(link)
+                continue
+
+            # On same domain: only allow child paths (deeper in hierarchy)
+            if link_path.startswith(current_path) and link_path != current_path.rstrip(
+                "/"
+            ):
+                result.append(link)
+                continue
+
+            # / page (not a child path of current)
+            logger.debug(
+                "Filtered out non-child path: %s (current=%s, crawl_entire_domain=False)",
+                link,
+                current_url,
+            )
+
+        return result
+
+    @staticmethod
+    def _filter_ssrf_blocked(links: list[str]) -> list[str]:
+        """Filter out links to private/internal hosts (SSRF guard).
+
+        Always active regardless of ``allow_external_links`` setting.
+        Uses ``common.url.is_private_host()`` which checks RFC 1918
+        private ranges, loopback, link-local, metadata IPs, and
+        internal hostname suffixes.
+
+        Args:
+            links: List of absolute URL strings to filter.
+
+        Returns:
+            List of URLs that are NOT private/internal hosts.
+        """
+        result: list[str] = []
+        for link in links:
+            if is_private_host(link):
+                logger.debug("SSRF guard blocked private host URL: %s", link)
+                continue
+            result.append(link)
+        return result
 
     def _get_filter_reason(self, url: str) -> dict | None:
         """Determine which path filter excluded a URL and why.

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -24,6 +24,7 @@ import httpx
 
 from .link_extractor import extract_links, filter_links
 from .scraper_client import ScraperClient
+from .sitemap_parser import SitemapParser
 from .store import JobStore
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class CrawlOptions:
     ignore_query_parameters: bool = False
     regex_on_full_url: bool = False
     verbose: bool = False
+    sitemap_mode: str = "include"  # "include" | "skip" | "only"
     allow_subdomains: bool = False
     allow_external_links: bool = False
     max_duration_seconds: int = 1800
@@ -367,8 +369,52 @@ class CrawlEngine:
         parsed_start = urlparse(start_url)
         base_domain = parsed_start.hostname.lower() if parsed_start.hostname else ""
 
-        # Seed the BFS queue
+        # Seed the BFS queue with start URL (DO NOT add to _seen — the main
+        # loop adds to _seen when it pops each URL. Adding here would cause
+        # the main loop's dedup check to skip the start URL.)
         self._queue.append((start_url, 0))
+        start_normalized = self.normalize_url(start_url)
+
+        # Seed with sitemap URLs if sitemap_mode is not "skip"
+        sitemap_seeded_count = 0
+        if self.options.sitemap_mode != "skip":
+            try:
+                sitemap_urls = await self._fetch_sitemap_urls(base_domain)
+            except Exception as exc:
+                logger.warning(
+                    "Sitemap fetch failed for %s: %s — falling back to HTML-only discovery",
+                    base_domain,
+                    exc,
+                )
+                sitemap_urls = []
+            if sitemap_urls:
+                # Truncate sitemap URLs to respect max_pages (reserve 1 for start URL)
+                remaining = self.options.max_pages - 1
+                if remaining > 0:
+                    sitemap_urls = sitemap_urls[:remaining]
+                sitemap_dedup: set[str] = set()
+                for sm_url in sitemap_urls:
+                    sm_normalized = self.normalize_url(sm_url)
+                    # Skip if duplicate within sitemap, or if it matches
+                    # the start URL (already in queue — will be deduped
+                    # by the main loop's seen-set).  The sitemap URL is
+                    # NOT added to self._seen here because the main loop
+                    # reads _seen to decide whether to scrape. If we added
+                    # it here, the main loop would skip it.
+                    if (
+                        sm_normalized in sitemap_dedup
+                        or sm_normalized == start_normalized
+                    ):
+                        continue
+                    sitemap_dedup.add(sm_normalized)
+                    self._queue.appendleft((sm_url, 0))
+                    sitemap_seeded_count += 1
+                logger.info(
+                    "Seeded %d sitemap URLs into crawl queue for %s",
+                    sitemap_seeded_count,
+                    base_domain,
+                )
+
         last_store_update = time.monotonic()
         crawl_start_time = time.monotonic()
         last_completion_time = crawl_start_time
@@ -534,7 +580,8 @@ class CrawlEngine:
                     )
 
             # Discover child links if within max_depth
-            if depth < self.options.max_depth:
+            # In "only" mode, sitemap URLs are the exclusive source — skip HTML link discovery
+            if depth < self.options.max_depth and self.options.sitemap_mode != "only":
                 html = await self._get_html(url)
                 if html:
                     child_links = extract_links(html, url)
@@ -575,6 +622,39 @@ class CrawlEngine:
         return normalize_url(
             url, ignore_query_parameters=self.options.ignore_query_parameters
         )
+
+    async def _fetch_sitemap_urls(self, domain: str) -> list[str]:
+        """Fetch sitemap URLs for the given domain.
+
+        Uses ``SitemapParser`` to discover and parse sitemaps from
+        robots.txt and common locations.
+
+        Args:
+            domain: The domain (hostname) to fetch sitemaps for.
+
+        Returns:
+            A list of unique, absolute URLs discovered from sitemaps.
+        """
+        try:
+            parser = SitemapParser(
+                client=self._html_client,
+                max_recursion_depth=3,
+            )
+            # Use the parser's own client management — it creates its
+            # own client if we don't pass one (but we already have one).
+            parser._client = self._html_client
+            urls = await parser.get_urls(
+                domain,
+                limit=self.options.max_pages * 2,  # generous outer limit
+            )
+            return urls
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch sitemaps for %s: %s — falling back to HTML-only discovery",
+                domain,
+                exc,
+            )
+            return []
 
     def cancel(self) -> None:
         """Signal the crawl to stop at the next opportunity."""

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -1,0 +1,450 @@
+"""CrawlEngine — BFS crawl orchestrator for GroktoCrawl.
+
+Manages a queue of (url, depth) tuples, tracks seen URLs for dedup,
+enforces ``max_pages`` and ``max_depth`` limits, uses the shared
+``LinkExtractor`` to discover child links, integrates with
+``ScraperClient`` for per-page fetching, and writes progress to the
+job store for status polling.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from .link_extractor import extract_links, filter_links
+from .scraper_client import ScraperClient
+from .store import JobStore
+
+logger = logging.getLogger(__name__)
+
+
+# ── Data types ───────────────────────────────────────────────────
+
+
+@dataclass
+class CrawlOptions:
+    """Options controlling crawl behavior.
+
+    Attributes:
+        max_pages: Maximum number of pages to scrape (hard stop).
+        max_depth: Maximum link-follow depth. Pages at max_depth are
+            scraped but their links are not followed.
+        include_paths: If set, only URLs whose path matches at least one
+            of these glob/regex patterns are scraped.
+        exclude_paths: URLs whose path matches any of these glob/regex
+            patterns are excluded (takes precedence over include).
+        ignore_query_parameters: If True, query-string variants of the
+            same base URL are collapsed to one fetch.
+        regex_on_full_url: If True, include/exclude paths are treated as
+            regex patterns (default: glob).
+        allow_subdomains: If True, follow links to subdomains.
+        allow_external_links: If True, follow links to external domains.
+    """
+
+    max_pages: int = 10
+    max_depth: int = 2
+    include_paths: list[str] | None = None
+    exclude_paths: list[str] | None = None
+    ignore_query_parameters: bool = False
+    regex_on_full_url: bool = False
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
+
+
+@dataclass
+class CrawlResult:
+    """Result of a crawl run."""
+
+    pages: list[dict] = field(default_factory=list)
+    total: int = 0
+    completed: int = 0
+    errors: list[dict] = field(default_factory=list)
+
+
+# ── Public functions ─────────────────────────────────────────────
+
+
+def _clean_path(path: str) -> str:
+    """Clean up a URL path by collapsing dot segments and normalizing.
+
+    Collapses ``/./`` and ``/../`` segments, and reduces ``/.`` at the
+    end to ``/``.
+    """
+    import posixpath
+
+    if not path:
+        return "/"
+
+    # posixpath.normpath collapses dot segments
+    cleaned = posixpath.normpath(path)
+
+    # normpath strips trailing slash, but root should remain /
+    if not cleaned:
+        return "/"
+
+    return cleaned
+
+
+def normalize_url(url: str, ignore_query_parameters: bool = False) -> str:
+    """Normalize a URL for dedup within a crawl run.
+
+    Steps:
+        1. Strip fragment identifier.
+        2. Lowercase scheme and host.
+        3. Remove default ports (80 for http, 443 for https).
+        4. Normalize trailing slash (remove for non-root paths).
+        5. Collapse ``/./`` and ``/../`` path segments.
+        6. Optionally strip query string entirely.
+        7. Sort query parameters if keeping them.
+
+    Args:
+        url: The URL to normalize.
+        ignore_query_parameters: If True, strip the query string.
+
+    Returns:
+        Normalized URL string.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname.lower() if parsed.hostname else ""
+    port = parsed.port
+    path = _clean_path(parsed.path or "/")
+
+    # Build netloc without default ports
+    netloc = hostname
+    if port is not None and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        netloc = f"{hostname}:{port}"
+
+    # Normalize trailing slash for non-root paths
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+
+    # Handle query parameters
+    if ignore_query_parameters:
+        query = ""
+    else:
+        # Sort query params for consistency
+        parsed_qs = parsed.query
+        if parsed_qs:
+            params = sorted(parsed_qs.split("&"))
+            query = "&".join(params)
+        else:
+            query = ""
+
+    normalized = urlunparse((scheme, netloc, path, parsed.params, query, ""))
+    return normalized
+
+
+async def fetch_html(url: str, timeout: float = 15.0) -> str | None:
+    """Fetch raw HTML from a URL for link extraction purposes.
+
+    This is a lightweight HTTP GET that follows redirects and returns
+    the response text. It is used by ``CrawlEngine`` to discover child
+    links from scraped pages, separate from the content scraping done
+    via ``ScraperClient``.
+
+    Args:
+        url: The URL to fetch.
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        The response text (HTML), or ``None`` if the fetch failed.
+    """
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
+            resp = await client.get(url)
+            if resp.status_code == 200:
+                return resp.text
+            logger.debug("fetch_html got status %d for %s", resp.status_code, url)
+            return None
+    except Exception as e:
+        logger.debug("fetch_html failed for %s: %s", url, e)
+        return None
+
+
+def _match_path(
+    url: str,
+    include_paths: list[str] | None,
+    exclude_paths: list[str] | None,
+    regex_on_full_url: bool = False,
+) -> bool:
+    """Check whether a URL passes include/exclude path filters.
+
+    Args:
+        url: The full URL to check.
+        include_paths: If set, URL must match at least one pattern.
+        exclude_paths: If set, URL must not match any pattern
+            (takes precedence).
+        regex_on_full_url: If True, patterns are regex; else glob.
+
+    Returns:
+        True if the URL should be crawled (passes all filters).
+    """
+    import re
+
+    target = url if regex_on_full_url else urlparse(url).path
+
+    if regex_on_full_url:
+        # Regex mode
+        if exclude_paths:
+            for pattern in exclude_paths:
+                try:
+                    if re.search(pattern, target):
+                        return False
+                except re.error:
+                    continue
+        if include_paths:
+            for pattern in include_paths:
+                try:
+                    if re.search(pattern, target):
+                        return True
+                except re.error:
+                    continue
+            return False  # include_paths set but none matched
+    else:
+        # Glob mode — convert glob patterns to regex
+        if exclude_paths:
+            for pattern in exclude_paths:
+                regex = _glob_to_regex(pattern)
+                try:
+                    if re.search(regex, target):
+                        return False
+                except re.error:
+                    continue
+        if include_paths:
+            for pattern in include_paths:
+                regex = _glob_to_regex(pattern)
+                try:
+                    if re.search(regex, target):
+                        return True
+                except re.error:
+                    continue
+            return False  # include_paths set but none matched
+
+    return True  # No include_paths constraint, or passed all
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Convert a simple glob pattern to an anchored regex pattern.
+
+    Supports ``*`` (match any chars except ``/``), ``**`` (match any
+    chars including ``/``), and ``?`` (match single char).
+
+    The returned pattern is anchored with ``^`` and ``$`` so that
+    ``re.search`` matches the full target string, not a substring.
+    """
+    i, n = 0, len(pattern)
+    inner: list[str] = []
+    while i < n:
+        c = pattern[i]
+        if c == "*" and i + 1 < n and pattern[i + 1] == "*":
+            inner.append(".*")
+            i += 2
+        elif c == "*":
+            inner.append("[^/]*")
+            i += 1
+        elif c == "?":
+            inner.append(".")
+            i += 1
+        elif c in ".^$+{}[]\\|()":
+            inner.append("\\" + c)
+            i += 1
+        else:
+            inner.append(c)
+            i += 1
+    return "^" + "".join(inner) + "$"
+
+
+# ── CrawlEngine ──────────────────────────────────────────────────
+
+
+class CrawlEngine:
+    """BFS crawl orchestrator.
+
+    Usage::
+
+        engine = CrawlEngine(scraper_client, options=CrawlOptions(max_pages=5))
+        result = await engine.run("https://example.com", job_id="...")
+    """
+
+    def __init__(
+        self,
+        scraper_client: ScraperClient,
+        store: JobStore | None = None,
+        options: CrawlOptions | None = None,
+    ):
+        self.scraper = scraper_client
+        self.store = store
+        self.options = options or CrawlOptions()
+        self._seen: set[str] = set()
+        self._queue: deque[tuple[str, int]] = deque()
+        self._pages: list[dict] = []
+        self._errors: list[dict] = []
+        self._cancel_flag: bool = False
+        self._update_interval: float = 1.0
+        self._html_client: httpx.AsyncClient | None = None
+
+    async def _get_html(self, url: str) -> str | None:
+        """Get HTML for a URL, using an internal persistent client."""
+        if self._html_client is None:
+            self._html_client = httpx.AsyncClient(follow_redirects=True, timeout=15.0)
+        try:
+            resp = await self._html_client.get(url)
+            if resp.status_code == 200:
+                return resp.text
+            return None
+        except Exception:
+            return None
+
+    async def close(self) -> None:
+        """Close the internal HTTP client."""
+        if self._html_client is not None:
+            await self._html_client.aclose()
+            self._html_client = None
+
+    async def run(self, start_url: str, job_id: str | None = None) -> CrawlResult:
+        """Execute a BFS crawl starting from ``start_url``.
+
+        Args:
+            start_url: The URL to begin crawling from.
+            job_id: Optional job ID for periodic store updates.
+
+        Returns:
+            A ``CrawlResult`` with scraped pages, totals, and errors.
+        """
+        parsed_start = urlparse(start_url)
+        base_domain = parsed_start.hostname.lower() if parsed_start.hostname else ""
+
+        # Seed the BFS queue
+        self._queue.append((start_url, 0))
+        last_store_update = time.monotonic()
+
+        while self._queue and len(self._pages) < self.options.max_pages:
+            if self._cancel_flag:
+                logger.info("Crawl cancelled via cancel flag")
+                break
+
+            url, depth = self._queue.popleft()
+            normalized = self.normalize_url(url)
+
+            # Dedup check
+            if normalized in self._seen:
+                logger.debug("Skipping already-seen URL: %s", url)
+                continue
+
+            # Max depth check: pages at max_depth are scraped but not
+            # followed; pages beyond max_depth are skipped entirely.
+            if depth > self.options.max_depth:
+                logger.debug("Skipping URL beyond max_depth: %s (depth=%d)", url, depth)
+                continue
+
+            # Mark as seen immediately to prevent re-enqueue
+            self._seen.add(normalized)
+
+            # Path filter check
+            if not _match_path(
+                url,
+                self.options.include_paths,
+                self.options.exclude_paths,
+                self.options.regex_on_full_url,
+            ):
+                logger.debug("Skipping URL excluded by path filter: %s", url)
+                continue
+
+            # Scrape the page
+            result = await self.scraper.scrape(url)
+
+            if not result.get("success"):
+                error_msg = result.get("error", "Unknown scrape error")
+                self._errors.append({"url": url, "error": error_msg})
+                logger.warning("Scrape failed for %s: %s", url, error_msg)
+
+                # Start URL failure — return error immediately
+                if depth == 0:
+                    logger.error("Start URL scrape failed: %s", error_msg)
+                    result_obj = CrawlResult(
+                        pages=[],
+                        total=0,
+                        completed=0,
+                        errors=self._errors,
+                    )
+                    await self.close()
+                    return result_obj
+                continue
+
+            # Record successful page
+            data = result.get("data", {})
+            page = {
+                "url": url,
+                "markdown": data.get("markdown", ""),
+            }
+            self._pages.append(page)
+
+            # Discover child links if within max_depth
+            if depth < self.options.max_depth:
+                html = await self._get_html(url)
+                if html:
+                    child_links = extract_links(html, url)
+                    child_links = filter_links(
+                        child_links,
+                        base_domain=base_domain,
+                        allow_subdomains=self.options.allow_subdomains,
+                        allow_external_links=self.options.allow_external_links,
+                    )
+                    for child_url in child_links:
+                        child_normalized = self.normalize_url(child_url)
+                        if child_normalized not in self._seen:
+                            self._queue.append((child_url, depth + 1))
+
+            # Periodic job store update
+            if self.store is not None and job_id is not None:
+                now = time.monotonic()
+                if now - last_store_update >= self._update_interval:
+                    self._update_store(job_id)
+                    last_store_update = now
+
+        # Final store update
+        if self.store is not None and job_id is not None:
+            self._update_store(job_id)
+
+        await self.close()
+
+        return CrawlResult(
+            pages=self._pages,
+            total=len(self._pages) + len(self._queue),
+            completed=len(self._pages),
+            errors=self._errors,
+        )
+
+    def normalize_url(self, url: str) -> str:
+        """Normalize a URL using this engine's options."""
+        return normalize_url(
+            url, ignore_query_parameters=self.options.ignore_query_parameters
+        )
+
+    def cancel(self) -> None:
+        """Signal the crawl to stop at the next opportunity."""
+        self._cancel_flag = True
+
+    def _update_store(self, job_id: str) -> None:
+        """Write current progress to the job store."""
+        if self.store is None:
+            return
+        try:
+            payload = {
+                "completed": len(self._pages),
+                "total": len(self._pages) + len(self._queue),
+                "pages": self._pages,
+                "errors": self._errors,
+            }
+            self.store.complete_job(job_id, payload)
+        except Exception:
+            logger.warning("Failed to update job store", exc_info=True)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -9,7 +9,10 @@ job store for status polling.
 
 from __future__ import annotations
 
+import json
 import logging
+import posixpath
+import re
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -76,8 +79,6 @@ def _clean_path(path: str) -> str:
     Collapses ``/./`` and ``/../`` segments, and reduces ``/.`` at the
     end to ``/``.
     """
-    import posixpath
-
     if not path:
         return "/"
 
@@ -188,8 +189,6 @@ def _match_path(
     Returns:
         True if the URL should be crawled (passes all filters).
     """
-    import re
-
     target = url if regex_on_full_url else urlparse(url).path
 
     if regex_on_full_url:
@@ -435,7 +434,13 @@ class CrawlEngine:
         self._cancel_flag = True
 
     def _update_store(self, job_id: str) -> None:
-        """Write current progress to the job store."""
+        """Write current progress to the job data key (not meta).
+
+        Updates only the ``data`` key in Valkey so the job's ``meta``
+        status (``processing``) remains unchanged during the crawl.
+        The caller's final ``store.complete_job()`` call sets both the
+        final data and the ``completed`` status.
+        """
         if self.store is None:
             return
         try:
@@ -445,6 +450,11 @@ class CrawlEngine:
                 "pages": self._pages,
                 "errors": self._errors,
             }
-            self.store.complete_job(job_id, payload)
+            # Write data key directly without changing meta status
+            self.store.redis.set(
+                f"job:{job_id}:data",
+                json.dumps(payload),
+                ex=86400,
+            )
         except Exception:
             logger.warning("Failed to update job store", exc_info=True)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -16,6 +16,7 @@ import re
 import time
 from collections import deque
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from urllib.parse import urlparse, urlunparse
 
 import httpx
@@ -400,8 +401,10 @@ class CrawlEngine:
                 logger.debug("Skipping URL excluded by path filter: %s", url)
                 continue
 
-            # Scrape the page
+            # Scrape the page with timing
+            scrape_start = time.monotonic()
             result = await self.scraper.scrape(url)
+            scrape_duration_ms = int((time.monotonic() - scrape_start) * 1000)
 
             if not result.get("success"):
                 error_msg = result.get("error", "Unknown scrape error")
@@ -421,11 +424,46 @@ class CrawlEngine:
                     return result_obj
                 continue
 
-            # Record successful page
+            # Record successful page with enriched metadata
             data = result.get("data", {})
+            metadata = data.get("metadata") or {}
+            og = metadata.get("og") or {}
+            meta = metadata.get("meta") or {}
+            title = (
+                og.get("title")
+                or meta.get("title")
+                or data.get("title")
+                or metadata.get("title")
+                or ""
+            )
+            description = (
+                og.get("description")
+                or meta.get("description")
+                or metadata.get("description")
+                or ""
+            )
+            source = data.get("source", "unknown")
+            status_code = metadata.get("statusCode") or data.get("status_code") or 200
+            content_type = (
+                metadata.get("content-type")
+                or metadata.get("contentType")
+                or "text/html"
+            )
+            scraped_at = datetime.now(UTC).isoformat()
+
             page = {
                 "url": url,
                 "markdown": data.get("markdown", ""),
+                "metadata": {
+                    "title": title,
+                    "description": description,
+                    "source": source,
+                },
+                "title": title,
+                "status_code": status_code,
+                "content_type": content_type,
+                "scraped_at": scraped_at,
+                "duration_ms": scrape_duration_ms,
             }
             self._pages.append(page)
 

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -46,6 +46,7 @@ class CrawlOptions:
             same base URL are collapsed to one fetch.
         regex_on_full_url: If True, include/exclude paths are treated as
             regex patterns (default: glob).
+        verbose: If True, track filtered-out URLs with reasons.
         allow_subdomains: If True, follow links to subdomains.
         allow_external_links: If True, follow links to external domains.
     """
@@ -56,6 +57,7 @@ class CrawlOptions:
     exclude_paths: list[str] | None = None
     ignore_query_parameters: bool = False
     regex_on_full_url: bool = False
+    verbose: bool = False
     allow_subdomains: bool = False
     allow_external_links: bool = False
 
@@ -68,6 +70,7 @@ class CrawlResult:
     total: int = 0
     completed: int = 0
     errors: list[dict] = field(default_factory=list)
+    filtered_out: list[dict] = field(default_factory=list)
 
 
 # ── Public functions ─────────────────────────────────────────────
@@ -231,6 +234,32 @@ def _match_path(
     return True  # No include_paths constraint, or passed all
 
 
+def _matches_pattern(
+    target: str, pattern: str, regex_on_full_url: bool = False
+) -> bool:
+    """Check whether ``target`` matches a single path pattern.
+
+    Args:
+        target: The string (path or full URL) to check.
+        pattern: The glob or regex pattern to match against.
+        regex_on_full_url: If True, ``pattern`` is a regex; else glob.
+
+    Returns:
+        True if the target matches the pattern.
+    """
+    if regex_on_full_url:
+        try:
+            return bool(re.search(pattern, target))
+        except re.error:
+            return False
+    else:
+        regex = _glob_to_regex(pattern)
+        try:
+            return bool(re.search(regex, target))
+        except re.error:
+            return False
+
+
 def _glob_to_regex(pattern: str) -> str:
     """Convert a simple glob pattern to an anchored regex pattern.
 
@@ -287,6 +316,7 @@ class CrawlEngine:
         self._queue: deque[tuple[str, int]] = deque()
         self._pages: list[dict] = []
         self._errors: list[dict] = []
+        self._filtered_out: list[dict] = []
         self._cancel_flag: bool = False
         self._update_interval: float = 1.0
         self._html_client: httpx.AsyncClient | None = None
@@ -348,13 +378,25 @@ class CrawlEngine:
             # Mark as seen immediately to prevent re-enqueue
             self._seen.add(normalized)
 
-            # Path filter check
+            # Determine the URL for path filtering.
+            # When ignore_query_parameters is True, strip query params
+            # before matching so that patterns match against the path
+            # only (VAL-SCOPE-073).
+            filter_url = (
+                urlparse(url)._replace(query="").geturl()
+                if self.options.ignore_query_parameters
+                else url
+            )
             if not _match_path(
-                url,
+                filter_url,
                 self.options.include_paths,
                 self.options.exclude_paths,
                 self.options.regex_on_full_url,
             ):
+                if self.options.verbose:
+                    filter_reason = self._get_filter_reason(filter_url)
+                    if filter_reason:
+                        self._filtered_out.append(filter_reason)
                 logger.debug("Skipping URL excluded by path filter: %s", url)
                 continue
 
@@ -421,6 +463,7 @@ class CrawlEngine:
             total=len(self._pages) + len(self._queue),
             completed=len(self._pages),
             errors=self._errors,
+            filtered_out=self._filtered_out,
         )
 
     def normalize_url(self, url: str) -> str:
@@ -432,6 +475,47 @@ class CrawlEngine:
     def cancel(self) -> None:
         """Signal the crawl to stop at the next opportunity."""
         self._cancel_flag = True
+
+    def _get_filter_reason(self, url: str) -> dict | None:
+        """Determine which path filter excluded a URL and why.
+
+        Only called when ``verbose`` is True and the URL has already
+        been determined to NOT pass ``_match_path()``.
+
+        Returns:
+            A dict with ``url``, ``reason``, and ``pattern`` keys, or
+            ``None`` if no filter reason could be determined.
+        """
+        target = url if self.options.regex_on_full_url else urlparse(url).path
+
+        # Check exclude_paths first (they bypass include_paths)
+        if self.options.exclude_paths:
+            for pattern in self.options.exclude_paths:
+                if _matches_pattern(target, pattern, self.options.regex_on_full_url):
+                    return {
+                        "url": url,
+                        "reason": "exclude_paths",
+                        "pattern": pattern,
+                    }
+
+        # Check include_paths
+        if self.options.include_paths:
+            for pattern in self.options.include_paths:
+                if _matches_pattern(target, pattern, self.options.regex_on_full_url):
+                    # Would match include, so not excluded by include
+                    return {
+                        "url": url,
+                        "reason": "include_paths",
+                        "pattern": None,
+                    }
+            # No include_paths matched
+            return {
+                "url": url,
+                "reason": "include_paths",
+                "pattern": None,
+            }
+
+        return None
 
     def _update_store(self, job_id: str) -> None:
         """Write current progress to the job data key (not meta).

--- a/agent-svc/agent/link_extractor.py
+++ b/agent-svc/agent/link_extractor.py
@@ -1,0 +1,230 @@
+"""Shared LinkExtractor module for extracting and filtering links from HTML.
+
+Provides ``extract_links()``, ``filter_links()``, and ``classify_links()``
+functions used by the crawl engine, ``/v2/map`` endpoint, and
+``llmstxt.py``.
+
+All functions are stateless — they accept inputs and return results
+without any stored state.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+def extract_links(html: str, base_url: str) -> list[str]:
+    """Extract and normalize all ``<a href>`` links from HTML.
+
+    Args:
+        html: Raw HTML content to parse.
+        base_url: The page URL used to resolve relative links. A
+            ``<base>`` tag in the HTML overrides this for relative
+            resolution but not for domain classification.
+
+    Returns:
+        List of absolute, fragment-stripped, deduplicated URLs with
+        ``http`` or ``https`` schemes. URLs are in discovery order
+        (first occurrence wins for duplicates).
+
+    Features:
+        - Resolves relative URLs against ``base_url`` (or ``<base>`` tag
+          if present in the HTML)
+        - Strips fragment identifiers (``#section``)
+        - Filters out non-http/https schemes (``mailto:``, ``tel:``,
+          ``javascript:``, etc.)
+        - Deduplicates URLs within the same page
+        - Handles malformed HTML gracefully (returns empty list instead
+          of raising exceptions)
+    """
+    if not html or not base_url:
+        return []
+
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception:
+        logger.warning("Failed to parse HTML from %s", base_url)
+        return []
+
+    # Determine effective base URL for relative resolution.
+    # <base> tag overrides the page URL.
+    effective_base: str = base_url
+    base_tag = soup.find("base", href=True)
+    if base_tag is not None and hasattr(base_tag, "get"):
+        href_val = base_tag.get("href")
+        if href_val:
+            effective_base = str(href_val)
+
+    seen: set[str] = set()
+    result: list[str] = []
+
+    try:
+        for a_tag in soup.find_all("a", href=True):
+            if not hasattr(a_tag, "get"):
+                continue
+            href_val = a_tag.get("href")
+            if href_val is None:
+                continue
+            href = _resolve_href_value(str(href_val))
+            if not href:
+                continue
+
+            # Resolve relative URLs against the effective base
+            try:
+                full_url = urljoin(effective_base, href)
+            except Exception:
+                continue
+
+            # Parse the resolved URL
+            try:
+                parsed = urlparse(full_url)
+            except Exception:
+                continue
+
+            # Filter out non-http/https schemes
+            scheme = parsed.scheme.lower()
+            if scheme and scheme not in ("http", "https"):
+                continue
+
+            # Strip fragment identifier
+            clean_url = _strip_fragment(full_url)
+
+            # Deduplicate within this page
+            if clean_url in seen:
+                continue
+            seen.add(clean_url)
+
+            result.append(clean_url)
+
+    except Exception:
+        logger.warning("Error extracting links from %s", base_url, exc_info=True)
+
+    return result
+
+
+def filter_links(
+    links: list[str],
+    *,
+    base_domain: str | None = None,
+    allow_subdomains: bool = False,
+    allow_external_links: bool = False,
+) -> list[str]:
+    """Filter a list of URLs by domain classification.
+
+    Args:
+        links: List of absolute URL strings (as returned by ``extract_links()``).
+        base_domain: The hostname of the base domain (e.g., ``"example.com"``).
+            If ``None``, only URLs that parse to a valid netloc are kept.
+        allow_subdomains: If ``True``, URLs on subdomains of the base domain
+            are included (e.g., ``docs.example.com`` when base is ``example.com``).
+        allow_external_links: If ``True``, URLs on entirely different domains
+            are included.
+
+    Returns:
+        Filtered list of URL strings matching the configured scope.
+    """
+    result: list[str] = []
+
+    for url in links:
+        parsed = urlparse(url)
+        hostname = parsed.hostname.lower() if parsed.hostname else ""
+
+        if not hostname:
+            # Shouldn't happen with absolute URLs, but be safe
+            result.append(url)
+            continue
+
+        if base_domain is None:
+            result.append(url)
+            continue
+
+        base = base_domain.lower()
+
+        if hostname == base:
+            # Internal (same domain) — always included
+            result.append(url)
+        elif _is_subdomain(hostname, base) and allow_subdomains:
+            result.append(url)
+        elif (
+            not _is_subdomain(hostname, base)
+            and hostname != base
+            and allow_external_links
+        ):
+            result.append(url)
+        # subdomain without allow_subdomains → skip
+        # external without allow_external_links → skip
+
+    return result
+
+
+def classify_links(links: list[str], base_url: str) -> dict[str, list[str]]:
+    """Classify a list of URLs by domain relationship to the base URL.
+
+    Args:
+        links: List of absolute URL strings.
+        base_url: The base URL used to determine the origin domain.
+
+    Returns:
+        Dict with keys ``"internal"``, ``"subdomain"``, and ``"external"``,
+        each containing a list of URL strings.
+    """
+    parsed_base = urlparse(base_url)
+    base_hostname = parsed_base.hostname.lower() if parsed_base.hostname else ""
+
+    result: dict[str, list[str]] = {
+        "internal": [],
+        "subdomain": [],
+        "external": [],
+    }
+
+    for url in links:
+        parsed = urlparse(url)
+        hostname = parsed.hostname.lower() if parsed.hostname else ""
+
+        if not hostname:
+            result["internal"].append(url)
+        elif hostname == base_hostname:
+            result["internal"].append(url)
+        elif _is_subdomain(hostname, base_hostname):
+            result["subdomain"].append(url)
+        else:
+            result["external"].append(url)
+
+    return result
+
+
+# ── Internal helpers ───────────────────────────────────────────────
+
+
+def _strip_fragment(url: str) -> str:
+    """Strip the fragment identifier from a URL, preserving the rest."""
+    try:
+        idx = url.index("#")
+        return url[:idx]
+    except ValueError:
+        return url
+
+
+def _is_subdomain(hostname: str, base: str) -> bool:
+    """Check whether ``hostname`` is a subdomain of ``base``.
+
+    ``blog.example.com`` is a subdomain of ``example.com``.
+    ``example.com`` is NOT a subdomain of ``example.com``.
+    ``other.com`` is NOT a subdomain of ``example.com``.
+    Comparison is case-insensitive.
+    """
+    hostname_lower = hostname.lower()
+    base_lower = base.lower()
+    if hostname_lower == base_lower:
+        return False
+    return hostname_lower.endswith("." + base_lower)
+
+
+def _resolve_href_value(href: str) -> str:
+    """Normalize an href attribute value to a string."""
+    return href.strip()

--- a/agent-svc/agent/llmstxt.py
+++ b/agent-svc/agent/llmstxt.py
@@ -7,12 +7,12 @@ the site's key pages.
 
 import logging
 import re
-from urllib.parse import urljoin
 
 import httpx
-from bs4 import BeautifulSoup
 
 from common.url import extract_domain
+
+from .link_extractor import extract_links, filter_links
 
 logger = logging.getLogger(__name__)
 
@@ -124,10 +124,11 @@ def _extract_description(text: str, max_chars: int = 300) -> str:
 
 
 async def discover_pages(url: str, max_pages: int = 50) -> list[str]:
-    """Discover page URLs on a site by fetching the homepage and finding same-domain links."""
-    discovered: list[str] = []
-    seen = set()
+    """Discover page URLs on a site by fetching the homepage and finding same-domain links.
 
+    Uses the shared LinkExtractor module for HTML link extraction and filtering,
+    replacing the previous inline BeautifulSoup parsing.
+    """
     try:
         async with httpx.AsyncClient(follow_redirects=True, timeout=15) as client:
             resp = await client.get(url)
@@ -135,29 +136,23 @@ async def discover_pages(url: str, max_pages: int = 50) -> list[str]:
                 logger.warning("Failed to fetch %s: %d", url, resp.status_code)
                 return [url]  # fallback: just return the input URL
 
-            soup = BeautifulSoup(resp.text, "html.parser")
-            from urllib.parse import urlparse
+            # Use the shared LinkExtractor for link extraction and filtering.
+            # Pass the domain-only base URL to match previous urljoin(base_url, href)
+            # behavior where base_url was the scheme+domain without path.
+            site_base = extract_domain(url, include_scheme=True)
+            all_links = extract_links(resp.text, site_base)
 
-            base_netloc = urlparse(url).netloc.lower()
-            base_url = extract_domain(url, include_scheme=True)
-            for a in soup.find_all("a", href=True):
-                href = a["href"].strip()  # type: ignore[union-attr]
-                full_url = urljoin(base_url, href)
+            # Filter to same-host only (backward compatible — external links excluded)
+            base_domain = extract_domain(url)
+            filtered = filter_links(
+                all_links,
+                base_domain=base_domain,
+                allow_subdomains=False,
+                allow_external_links=False,
+            )
 
-                # Skip external links, anchors, mailto, etc.
-                full_parsed = urlparse(full_url)
-                if full_parsed.netloc and full_parsed.netloc.lower() != base_netloc:
-                    continue
-                if not full_parsed.scheme.startswith("http"):
-                    continue
-                if full_url in seen:
-                    continue
-
-                seen.add(full_url)
-                discovered.append(full_url)
-
-                if len(discovered) >= max_pages:
-                    break
+            # Apply max_pages limit (LinkExtractor returns links in discovery order)
+            discovered = filtered[:max_pages]
 
     except Exception as e:
         logger.warning("Page discovery failed for %s: %s", url, e)

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -90,8 +90,12 @@ class AgentCancelResponse(BaseModel):
 
 class CrawlRequest(BaseModel):
     url: str
-    max_pages: int = 10
-    max_depth: int = 2
+    max_pages: int = Field(
+        default=10, ge=1, description="Maximum pages to scrape, must be >= 1"
+    )
+    max_depth: int = Field(
+        default=2, ge=0, description="Maximum link-follow depth, must be >= 0"
+    )
     limit: int | None = None
     ignore_sitemap: bool = False
     ignore_query_parameters: bool = False
@@ -149,6 +153,10 @@ class CrawlStatusResponse(BaseModel):
     credits_used: int | None = None
     data: list[dict[str, Any]] | None = None
     error: str | None = None
+    created_at: str | None = None
+    completed_at: str | None = None
+    expires_at: str | None = None
+    duration: int | None = None
 
 
 class BatchScrapeRequest(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -3,7 +3,7 @@
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ErrorDetail(BaseModel):
@@ -97,6 +97,8 @@ class CrawlRequest(BaseModel):
     ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
+    regex_on_full_url: bool = False
+    verbose: bool = False
     webhook: dict[str, Any] | None = None
 
     @field_validator("url")
@@ -111,6 +113,27 @@ class CrawlRequest(BaseModel):
         if not parsed.netloc:
             raise ValueError("URL must have a network location (host)")
         return value
+
+    @model_validator(mode="after")
+    def validate_regex_patterns(self) -> "CrawlRequest":
+        """When regex_on_full_url is True, validate that all path
+        patterns are valid Python regular expressions."""
+        if not self.regex_on_full_url:
+            return self
+        import re as _re
+
+        for field_name in ("include_paths", "exclude_paths"):
+            patterns = getattr(self, field_name)
+            if not patterns:
+                continue
+            for i, pattern in enumerate(patterns):
+                try:
+                    _re.compile(pattern)
+                except _re.error as exc:
+                    raise ValueError(
+                        f"Invalid regex in {field_name}[{i}]: '{pattern}' — {exc}"
+                    ) from exc
+        return self
 
 
 class CrawlCreateResponse(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -4,6 +4,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic.alias_generators import to_camel
 
 
 class ErrorDetail(BaseModel):
@@ -89,6 +90,8 @@ class AgentCancelResponse(BaseModel):
 
 
 class CrawlRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
     url: str
     max_pages: int = Field(
         default=10, ge=1, description="Maximum pages to scrape, must be >= 1"

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -147,6 +147,8 @@ class MapRequest(BaseModel):
     url: str
     limit: int = 100
     search: str | None = None
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
 
 
 class MapResponse(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -111,6 +111,9 @@ class CrawlRequest(BaseModel):
     regex_on_full_url: bool = False
     verbose: bool = False
     webhook: dict[str, Any] | None = None
+    crawl_entire_domain: bool = False
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
 
     @field_validator("url")
     @classmethod

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -101,6 +101,10 @@ class CrawlRequest(BaseModel):
     )
     limit: int | None = None
     ignore_sitemap: bool = False
+    sitemap: str = Field(
+        default="include",
+        description="Sitemap mode: 'include' (default), 'skip', or 'only'",
+    )
     ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
@@ -140,6 +144,24 @@ class CrawlRequest(BaseModel):
                     raise ValueError(
                         f"Invalid regex in {field_name}[{i}]: '{pattern}' — {exc}"
                     ) from exc
+        return self
+
+    @model_validator(mode="after")
+    def resolve_sitemap_mode(self) -> "CrawlRequest":
+        """Backward compatibility: ignore_sitemap=true → sitemap='skip'.
+
+        Also validates that sitemap is one of the allowed values.
+        """
+        # Backward compatibility: ignore_sitemap overrides sitemap field
+        if self.ignore_sitemap:
+            self.sitemap = "skip"
+
+        # Validate sitemap value
+        allowed = ("include", "skip", "only")
+        if self.sitemap not in allowed:
+            raise ValueError(
+                f"Invalid sitemap mode '{self.sitemap}'. Must be one of: {', '.join(allowed)}"
+            )
         return self
 
 

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -1,8 +1,9 @@
 """Pydantic models matching the Firecrawl v2 agent API contract."""
 
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ErrorDetail(BaseModel):
@@ -91,10 +92,25 @@ class CrawlRequest(BaseModel):
     url: str
     max_pages: int = 10
     max_depth: int = 2
+    limit: int | None = None
     ignore_sitemap: bool = False
+    ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
     webhook: dict[str, Any] | None = None
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        """Validate that url is a well-formed HTTP/HTTPS URL."""
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            raise ValueError("URL must have a scheme (http:// or https://)")
+        if parsed.scheme.lower() not in ("http", "https"):
+            raise ValueError(f"URL scheme must be http or https, got '{parsed.scheme}'")
+        if not parsed.netloc:
+            raise ValueError("URL must have a network location (host)")
+        return value
 
 
 class CrawlCreateResponse(BaseModel):

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -200,7 +200,7 @@ async def _run_multi_query_discover_and_scrape(
             *search_tasks, return_exceptions=True
         )
         for i, (query, result_tuple) in enumerate(  # type: ignore[misc]
-            zip(queries_to_run, search_results_list), start=1
+            zip(queries_to_run, search_results_list, strict=False), start=1
         ):
             logger.info("  [%d/%d] Searching: %s", i, len(queries_to_run), query)
             if isinstance(result_tuple, Exception):

--- a/agent-svc/agent/scraper_client.py
+++ b/agent-svc/agent/scraper_client.py
@@ -1,5 +1,6 @@
 """HTTP client to the scraper service."""
 
+import contextlib
 import logging
 import time
 
@@ -116,10 +117,8 @@ class ScraperClient:
                 pending, return_when=_asyncio.FIRST_COMPLETED
             )
             for t in done:
-                try:
+                with contextlib.suppress(Exception):
                     t.result()
-                except Exception:
-                    pass
 
         # Cancel remaining tasks
         for t in pending:

--- a/agent-svc/agent/settings.py
+++ b/agent-svc/agent/settings.py
@@ -26,6 +26,12 @@ class AgentSettings(BaseModel):
         default=5, alias="AGENT_MAX_SEARCHES_PER_REQUEST"
     )
     search_rate_limit: str = Field(default="10/60s", alias="AGENT_SEARCH_RATE_LIMIT")
+    crawl_max_duration_seconds: int = Field(
+        default=1800, alias="CRAWL_MAX_DURATION_SECONDS"
+    )
+    crawl_idle_timeout_seconds: int = Field(
+        default=300, alias="CRAWL_IDLE_TIMEOUT_SECONDS"
+    )
 
 
 @functools.cache

--- a/agent-svc/agent/sitemap_parser.py
+++ b/agent-svc/agent/sitemap_parser.py
@@ -1,0 +1,505 @@
+"""SitemapParser — fetches and parses XML sitemaps for GroktoCrawl.
+
+Discovers sitemap URLs from robots.txt ``Sitemap:`` directives and
+common locations (``/sitemap.xml``, ``/sitemap_index.xml``). Parses
+XML sitemaps (``<urlset>``) and sitemap index files (``<sitemapindex>``)
+recursively, handles gzipped content, and degrades gracefully on errors.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+from collections.abc import Sequence
+from urllib.parse import urlparse
+from xml.etree import ElementTree
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Default sitemap locations to try when robots.txt has no Sitemap directive.
+_COMMON_SITEMAP_PATHS = [
+    "/sitemap.xml",
+    "/sitemap_index.xml",
+]
+
+# Maximum recursion depth for sitemap index files.
+_MAX_RECURSION_DEPTH = 3
+
+# HTTP client timeout for sitemap fetches.
+_REQUEST_TIMEOUT = 15.0
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+
+class SitemapParser:
+    """Fetch and parse XML sitemaps for a domain.
+
+    Usage::
+
+        parser = SitemapParser()
+        urls = await parser.get_urls("example.com", limit=100)
+    """
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient | None = None,
+        common_sitemap_paths: Sequence[str] | None = None,
+        max_recursion_depth: int = _MAX_RECURSION_DEPTH,
+    ):
+        """Initialize the parser.
+
+        Args:
+            client: An optional ``httpx.AsyncClient`` to reuse. If
+                ``None``, a new client is created (and closed after
+                ``get_urls`` returns).
+            common_sitemap_paths: List of paths to check when robots.txt
+                has no ``Sitemap:`` directive. Defaults to
+                ``["/sitemap.xml", "/sitemap_index.xml"]``.
+            max_recursion_depth: Maximum depth for following nested
+                sitemap index files.
+        """
+        self._client = client
+        self._common_paths = (
+            list(common_sitemap_paths)
+            if common_sitemap_paths is not None
+            else list(_COMMON_SITEMAP_PATHS)
+        )
+        self._max_depth = max_recursion_depth
+        self._owned_client = client is None
+
+    async def get_urls(
+        self,
+        domain: str,
+        limit: int | None = None,
+    ) -> list[str]:
+        """Get all URLs from sitemaps for the given domain.
+
+        Discovers sitemap URLs from robots.txt (``Sitemap:`` directives)
+        and falls back to common locations. Parses XML sitemaps and
+        sitemap index files recursively.
+
+        Args:
+            domain: The domain to fetch sitemaps for (e.g.,
+                ``"example.com"``). Should not include a scheme.
+            limit: Maximum number of URLs to return. If ``None``, all
+                discovered URLs are returned.
+
+        Returns:
+            A list of unique, absolute URLs from the sitemap(s).
+        """
+        client = await self._ensure_client()
+        try:
+            sitemap_urls = await self._discover_sitemap_urls(domain, client)
+            if not sitemap_urls:
+                logger.info("No sitemap URLs found for %s, trying common paths", domain)
+                sitemap_urls = await self._try_common_paths(domain, client)
+
+            if not sitemap_urls:
+                logger.warning("No sitemap found for %s at any location", domain)
+                return []
+
+            # Parse all discovered sitemap URLs
+            all_urls: list[str] = []
+            seen: set[str] = set()
+
+            for sitemap_url in sitemap_urls:
+                if len(all_urls) >= (limit or float("inf")):
+                    break
+                parsed = await self._parse_sitemap(
+                    sitemap_url, client, depth=0, seen=seen
+                )
+                for url in parsed:
+                    if len(all_urls) >= (limit or float("inf")):
+                        break
+                    normalized = self._normalize_sitemap_url(url)
+                    if normalized and normalized not in seen:
+                        seen.add(normalized)
+                        all_urls.append(normalized)
+
+            return all_urls
+        finally:
+            if self._owned_client:
+                await client.aclose()
+
+    async def parse_sitemap_url(
+        self, sitemap_url: str, domain: str | None = None
+    ) -> list[str]:
+        """Parse a single sitemap URL and return its URLs.
+
+        This is useful when the caller already knows the sitemap URL
+        (e.g., from a robots.txt directive parsed by the politeness
+        module).
+
+        Args:
+            sitemap_url: The full URL of the sitemap to parse.
+            domain: Optional domain hint for logging. If not provided,
+                extracted from ``sitemap_url``.
+
+        Returns:
+            A list of unique, absolute URLs from the sitemap.
+        """
+        client = await self._ensure_client()
+        try:
+            seen: set[str] = set()
+            urls = await self._parse_sitemap(sitemap_url, client, depth=0, seen=seen)
+            result: list[str] = []
+            for url in urls:
+                normalized = self._normalize_sitemap_url(url)
+                if normalized and normalized not in result:
+                    result.append(normalized)
+            return result
+        finally:
+            if self._owned_client:
+                await client.aclose()
+
+    # ── Internal helpers ─────────────────────────────────────────
+
+    async def _ensure_client(self) -> httpx.AsyncClient:
+        """Get or create an HTTP client."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                follow_redirects=True, timeout=_REQUEST_TIMEOUT
+            )
+            self._owned_client = True
+        return self._client
+
+    async def _discover_sitemap_urls(
+        self, domain: str, client: httpx.AsyncClient
+    ) -> list[str]:
+        """Discover sitemap URLs from robots.txt ``Sitemap:`` directives.
+
+        Args:
+            domain: The domain to check.
+            client: The HTTP client to use.
+
+        Returns:
+            A list of sitemap URLs from robots.txt, or empty list if
+            robots.txt has no ``Sitemap:`` directive or is unreachable.
+        """
+        robots_url = f"https://{domain}/robots.txt"
+        try:
+            resp = await client.get(robots_url)
+            if resp.status_code != 200:
+                logger.debug(
+                    "robots.txt returned %d for %s, trying common paths",
+                    resp.status_code,
+                    domain,
+                )
+                return []
+            # Decompress gzipped robots.txt if needed
+            content = await self._decompress_content(resp)
+            if not content:
+                return []
+
+            # Extract Sitemap directives
+            sitemap_urls: list[str] = []
+            for line in content.splitlines():
+                if line.lower().startswith("sitemap:"):
+                    sitemap_urls.append(line.split(":", 1)[1].strip())
+
+            logger.info(
+                "Found %d sitemap URL(s) in robots.txt for %s",
+                len(sitemap_urls),
+                domain,
+            )
+            return sitemap_urls
+        except httpx.RequestError as exc:
+            logger.warning("Failed to fetch robots.txt for %s: %s", domain, exc)
+            return []
+        except Exception as exc:
+            logger.warning("Error parsing robots.txt for %s: %s", domain, exc)
+            return []
+
+    async def _try_common_paths(
+        self, domain: str, client: httpx.AsyncClient
+    ) -> list[str]:
+        """Try common sitemap paths as a fallback.
+
+        Args:
+            domain: The domain to check.
+            client: The HTTP client to use.
+
+        Returns:
+            A list of sitemap URLs that returned a successful response.
+        """
+        found: list[str] = []
+        for path in self._common_paths:
+            url = f"https://{domain}{path}"
+            try:
+                resp = await client.get(url)
+                if resp.status_code == 200:
+                    content_type = resp.headers.get("content-type", "").lower()
+                    # Accept XML or text content, or gzipped content
+                    if (
+                        "xml" in content_type
+                        or "text" in content_type
+                        or "gzip" in content_type
+                        or "octet-stream" in content_type
+                        or path.endswith(".gz")
+                        or not content_type
+                    ):
+                        logger.info("Found sitemap at %s", url)
+                        found.append(url)
+                    else:
+                        logger.debug(
+                            "Skipping %s (content-type: %s)", url, content_type
+                        )
+                else:
+                    logger.debug(
+                        "Common path %s returned %d for %s",
+                        url,
+                        resp.status_code,
+                        domain,
+                    )
+            except httpx.RequestError as exc:
+                logger.debug(
+                    "Failed to fetch common path %s for %s: %s",
+                    path,
+                    domain,
+                    exc,
+                )
+        return found
+
+    async def _parse_sitemap(
+        self,
+        sitemap_url: str,
+        client: httpx.AsyncClient,
+        depth: int,
+        seen: set[str],
+    ) -> list[str]:
+        """Parse a single sitemap URL and return discovered URLs.
+
+        Handles both ``<urlset>`` (leaf sitemap) and ``<sitemapindex>``
+        (index file) XML formats, as well as gzipped content and plain
+        text sitemaps.
+
+        Args:
+            sitemap_url: The URL of the sitemap to fetch.
+            client: The HTTP client.
+            depth: Current recursion depth (for nested indexes).
+            seen: Set of already-seen sitemap URLs to avoid re-parsing.
+
+        Returns:
+            A list of discovered page URLs.
+        """
+        if depth > self._max_depth:
+            logger.warning("Max recursion depth reached for %s", sitemap_url)
+            return []
+
+        # Avoid re-parsing the same sitemap URL
+        sitemap_normalized = self._normalize_sitemap_url(sitemap_url)
+        if sitemap_normalized and sitemap_normalized in seen:
+            logger.debug("Sitemap already parsed: %s", sitemap_url)
+            return []
+        if sitemap_normalized:
+            seen.add(sitemap_normalized)
+
+        # Fetch the sitemap
+        try:
+            resp = await client.get(sitemap_url)
+        except httpx.RequestError as exc:
+            logger.warning("Failed to fetch sitemap %s: %s", sitemap_url, exc)
+            return []
+
+        if resp.status_code >= 500:
+            logger.warning(
+                "Sitemap %s returned HTTP %d (server error)",
+                sitemap_url,
+                resp.status_code,
+            )
+            return []
+        if resp.status_code == 404:
+            logger.warning("Sitemap %s returned 404 (not found)", sitemap_url)
+            return []
+
+        if resp.status_code != 200:
+            logger.warning(
+                "Sitemap %s returned HTTP %d, skipping",
+                sitemap_url,
+                resp.status_code,
+            )
+            return []
+
+        # Decompress if needed
+        content = await self._decompress_content(resp)
+        if not content:
+            return []
+
+        # Check if it's a plain text sitemap (not XML)
+        is_text_sitemap = sitemap_url.endswith(".txt") or (
+            not content.strip().startswith("<")
+        )
+        if is_text_sitemap and not content.strip().startswith("<"):
+            logger.warning(
+                "Text sitemap detected at %s (unsupported) — "
+                "falling back to HTML-only discovery",
+                sitemap_url,
+            )
+            return []
+
+        return await self._parse_xml_content(content, sitemap_url, client, depth, seen)
+
+    async def _parse_xml_content(
+        self,
+        content: str,
+        sitemap_url: str,
+        client: httpx.AsyncClient,
+        depth: int,
+        seen: set[str],
+    ) -> list[str]:
+        """Parse XML sitemap content and extract URLs.
+
+        Handles both ``<urlset>`` (leaf sitemap) and ``<sitemapindex>``
+        (index) XML formats.
+
+        Args:
+            content: The XML content as a string.
+            sitemap_url: The sitemap URL (for logging).
+            client: The HTTP client.
+            depth: Current recursion depth.
+            seen: Set of already-seen sitemap/sitemap URLs.
+
+        Returns:
+            A list of discovered page URLs.
+        """
+        try:
+            root = ElementTree.fromstring(content)
+        except ElementTree.ParseError as exc:
+            logger.warning(
+                "Malformed XML in sitemap %s: %s — falling back to HTML-only discovery",
+                sitemap_url,
+                exc,
+            )
+            return []
+
+        # Determine the local tag name (handles namespace-prefixed tags)
+        def _local_tag(element) -> str:
+            tag = element.tag
+            if "}" in tag:
+                return tag.split("}", 1)[1]
+            return tag
+
+        root_tag = _local_tag(root)
+
+        if root_tag == "sitemapindex":
+            return await self._parse_sitemap_index(
+                root, client, depth, seen, _local_tag
+            )
+        elif root_tag == "urlset":
+            return self._parse_urlset(root, _local_tag)
+        else:
+            logger.warning(
+                "Unknown sitemap root element <%s> in %s",
+                root_tag,
+                sitemap_url,
+            )
+            return []
+
+    def _parse_urlset(self, root: ElementTree.Element, local_tag_fn) -> list[str]:
+        """Extract URLs from a ``<urlset>`` element.
+
+        Args:
+            root: The ``<urlset>`` XML element.
+            local_tag_fn: Function to get the local tag name.
+
+        Returns:
+            A list of ``<loc>`` values.
+        """
+        urls: list[str] = []
+        for url_elem in root:
+            for child in url_elem:
+                if local_tag_fn(child) == "loc" and child.text:
+                    url = child.text.strip()
+                    if url.startswith(("http://", "https://")):
+                        urls.append(url)
+        return urls
+
+    async def _parse_sitemap_index(
+        self,
+        root: ElementTree.Element,
+        client: httpx.AsyncClient,
+        depth: int,
+        seen: set[str],
+        local_tag_fn,
+    ) -> list[str]:
+        """Recursively parse a sitemap index file.
+
+        Args:
+            root: The ``<sitemapindex>`` XML element.
+            client: The HTTP client.
+            depth: Current recursion depth.
+            seen: Set of already-seen sitemap/sitemap URLs.
+            local_tag_fn: Function to get the local tag name.
+
+        Returns:
+            A list of aggregated page URLs from all child sitemaps.
+        """
+        child_sitemaps: list[str] = []
+        for sitemap_elem in root:
+            for child in sitemap_elem:
+                if local_tag_fn(child) == "loc" and child.text:
+                    child_sitemaps.append(child.text.strip())
+
+        all_urls: list[str] = []
+        for child_url in child_sitemaps:
+            if depth + 1 > self._max_depth:
+                logger.warning(
+                    "Max recursion depth reached for child sitemap %s",
+                    child_url,
+                )
+                continue
+            child_urls = await self._parse_sitemap(child_url, client, depth + 1, seen)
+            all_urls.extend(child_urls)
+        return all_urls
+
+    @staticmethod
+    async def _decompress_content(resp: httpx.Response) -> str | None:
+        """Decompress gzipped response content if needed.
+
+        Handles ``Content-Encoding: gzip`` and ``.gz`` extension.
+
+        Args:
+            resp: The HTTP response.
+
+        Returns:
+            Decoded string content, or ``None`` if decompression fails.
+        """
+        content_encoding = resp.headers.get("content-encoding", "").lower()
+        raw = resp.content
+
+        if content_encoding == "gzip" or raw[:2] == b"\x1f\x8b":
+            try:
+                raw = gzip.decompress(raw)
+            except (gzip.BadGzipFile, OSError) as exc:
+                logger.warning("Failed to decompress gzip content: %s", exc)
+                return None
+
+        # Try UTF-8 first, then fall back to common encodings
+        for encoding in ("utf-8", "utf-8-sig", "latin-1", "iso-8859-1"):
+            try:
+                return raw.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+
+        logger.warning("Could not decode sitemap content as text")
+        return None
+
+    @staticmethod
+    def _normalize_sitemap_url(url: str) -> str | None:
+        """Normalize a sitemap URL (strip fragments, basic cleanup).
+
+        Args:
+            url: The URL to normalize.
+
+        Returns:
+            Normalized URL, or ``None`` if the URL is not HTTP(S).
+        """
+        if not url or not url.startswith(("http://", "https://")):
+            return None
+        parsed = urlparse(url)
+        # Strip fragment
+        normalized = parsed._replace(fragment="").geturl()
+        return normalized

--- a/agent-svc/agent/store.py
+++ b/agent-svc/agent/store.py
@@ -6,13 +6,18 @@ Uses the same valkey connection for both the API and the worker.
 
 import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from redis import Redis
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _expires_iso() -> str:
+    """Return ISO 8601 timestamp for 24 hours from now."""
+    return (datetime.now(UTC) + timedelta(hours=24)).isoformat()
 
 
 def _default_ttl() -> int:
@@ -39,6 +44,7 @@ class JobStore:
             "kind": kind,
             "status": "processing",
             "created_at": _now_iso(),
+            "expires_at": _expires_iso(),
             "payload": payload or {},
         }
         self.redis.set(f"job:{job_id}:meta", json.dumps(meta), ex=_default_ttl())

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -113,6 +113,7 @@ async def _process_crawl_async(
     exclude_paths: list[str] | None = None,
     regex_on_full_url: bool = False,
     verbose: bool = False,
+    sitemap_mode: str = "include",
 ) -> None:
     """Process a crawl job with full lifecycle support.
 
@@ -158,6 +159,7 @@ async def _process_crawl_async(
             exclude_paths=exclude_paths,
             regex_on_full_url=regex_on_full_url,
             verbose=verbose,
+            sitemap_mode=sitemap_mode,
             max_duration_seconds=settings.crawl_max_duration_seconds,
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -114,13 +114,40 @@ async def _process_crawl_async(
     regex_on_full_url: bool = False,
     verbose: bool = False,
 ) -> None:
+    """Process a crawl job with full lifecycle support.
+
+    Lifecycle webhooks (when configured):
+        - ``crawl.started``: fired before the crawl begins
+        - ``crawl.page``: fired after each individual page is scraped
+        - ``crawl.completed``: fired on terminal states (completed, cancelled)
+        - ``crawl.failed``: fired on unexpected exception
+
+    Cancellation is cooperative: DELETE /v2/crawl/{id} sets the job meta
+    status to ``cancelled`` in Redis; the engine checks this between
+    page scrapes and stops early. The job store is NOT overwritten when
+    the engine detects cancellation (``cancel_job()`` already set it).
+    """
     settings = _get_worker_settings()
     store = JobStore(
         f"redis://{settings.valkey_host}:{settings.valkey_port}/{settings.valkey_db}"
     )
     scraper = ScraperClient(scraper_url)
+    start = time.monotonic()
+    job_type = "crawl"
 
-    async def work_fn() -> dict[str, Any]:
+    METRICS.counter("jobs_submitted_total", "Total jobs submitted", ["type"]).inc(
+        {"type": job_type}
+    )
+
+    try:
+        # ── Fire crawl.started webhook ────────────────────────
+        await deliver_webhook(
+            webhook_config,
+            "crawl.started",
+            job_id,
+            {"url": url, "max_pages": max_pages, "max_depth": max_depth},
+        )
+
         from .crawler import CrawlEngine, CrawlOptions
 
         options = CrawlOptions(
@@ -131,9 +158,16 @@ async def _process_crawl_async(
             exclude_paths=exclude_paths,
             regex_on_full_url=regex_on_full_url,
             verbose=verbose,
+            max_duration_seconds=settings.crawl_max_duration_seconds,
+            idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )
         engine = CrawlEngine(scraper, store=store, options=options)
-        result = await engine.run(url, job_id=job_id)
+
+        # Per-page webhook callback
+        async def _page_callback(_job_id: str, page: dict[str, Any]) -> None:
+            await deliver_webhook(webhook_config, "crawl.page", _job_id, page)
+
+        result = await engine.run(url, job_id=job_id, page_callback=_page_callback)
 
         # Fire-and-forget indexing for each page
         for page in result.pages:
@@ -141,20 +175,10 @@ async def _process_crawl_async(
             markdown = page.get("markdown", "")
             if task_tracker is not None:
                 task_tracker.create_background_task(
-                    _index_page_async(
-                        page_url,
-                        "",
-                        markdown[:2000],
-                    )
+                    _index_page_async(page_url, "", markdown[:2000])
                 )
             else:
-                asyncio.create_task(
-                    _index_page_async(
-                        page_url,
-                        "",
-                        markdown[:2000],
-                    )
-                )
+                asyncio.create_task(_index_page_async(page_url, "", markdown[:2000]))
 
         payload: dict[str, Any] = {
             "completed": result.completed,
@@ -164,11 +188,47 @@ async def _process_crawl_async(
         }
         if verbose:
             payload["filtered_out"] = result.filtered_out
-        return payload
 
-    await _run_job_with_observability(
-        job_id, "crawl", store, webhook_config, work_fn, scraper.close
-    )
+        # ── Check if job was cancelled via DELETE ─────────────
+        job_meta = store.get_job(job_id)
+        was_cancelled = job_meta is not None and job_meta.get("status") == "cancelled"
+
+        if was_cancelled:
+            # Store is already marked cancelled by cancel_job();
+            # do NOT overwrite with complete_job().
+            logger.info("Crawl %s was cancelled — preserving cancelled status", job_id)
+            await deliver_webhook(
+                webhook_config,
+                "crawl.completed",
+                job_id,
+                {**payload, "status": "cancelled"},
+            )
+        else:
+            store.complete_job(job_id, payload)
+            await deliver_webhook(webhook_config, "crawl.completed", job_id, payload)
+
+        elapsed = time.monotonic() - start
+        METRICS.histogram(
+            "job_duration_seconds", "Job processing duration", ["type", "status"]
+        ).observe({"type": job_type, "status": "completed"}, elapsed)
+        METRICS.counter("jobs_completed_total", "Total completed jobs", ["type"]).inc(
+            {"type": job_type}
+        )
+        logger.info("Crawl job %s completed in %.2fs", job_id, elapsed)
+
+    except Exception as e:
+        logger.exception("Crawl job %s failed", job_id)
+        store.fail_job(job_id, str(e))
+        await deliver_webhook(webhook_config, "crawl.failed", job_id, {"error": str(e)})
+        elapsed = time.monotonic() - start
+        METRICS.histogram(
+            "job_duration_seconds", "Job processing duration", ["type", "status"]
+        ).observe({"type": job_type, "status": "failed"}, elapsed)
+        METRICS.counter("jobs_failed_total", "Total failed jobs", ["type"]).inc(
+            {"type": job_type}
+        )
+    finally:
+        await scraper.close()
 
 
 async def _process_batch_scrape_async(

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -111,6 +111,8 @@ async def _process_crawl_async(
     ignore_query_parameters: bool = False,
     include_paths: list[str] | None = None,
     exclude_paths: list[str] | None = None,
+    regex_on_full_url: bool = False,
+    verbose: bool = False,
 ) -> None:
     settings = _get_worker_settings()
     store = JobStore(
@@ -127,6 +129,8 @@ async def _process_crawl_async(
             ignore_query_parameters=ignore_query_parameters,
             include_paths=include_paths,
             exclude_paths=exclude_paths,
+            regex_on_full_url=regex_on_full_url,
+            verbose=verbose,
         )
         engine = CrawlEngine(scraper, store=store, options=options)
         result = await engine.run(url, job_id=job_id)
@@ -152,12 +156,14 @@ async def _process_crawl_async(
                     )
                 )
 
-        payload = {
+        payload: dict[str, Any] = {
             "completed": result.completed,
             "total": result.total,
             "pages": result.pages,
             "errors": result.errors,
         }
+        if verbose:
+            payload["filtered_out"] = result.filtered_out
         return payload
 
     await _run_job_with_observability(

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -208,12 +208,30 @@ async def _process_crawl_async(
             await deliver_webhook(webhook_config, "crawl.completed", job_id, payload)
 
         elapsed = time.monotonic() - start
+
+        # ── Existing job-type-agnostic metrics (keep for backward compat) ──
         METRICS.histogram(
             "job_duration_seconds", "Job processing duration", ["type", "status"]
         ).observe({"type": job_type, "status": "completed"}, elapsed)
         METRICS.counter("jobs_completed_total", "Total completed jobs", ["type"]).inc(
             {"type": job_type}
         )
+
+        # ── Crawl-specific metrics ──────────────────────────────────────────
+        crawl_status = "cancelled" if was_cancelled else "completed"
+        METRICS.counter(
+            "groktocrawl_crawl_jobs_total", "Total crawl jobs by status", ["status"]
+        ).inc({"status": crawl_status})
+        METRICS.histogram(
+            "groktocrawl_crawl_duration_seconds",
+            "Crawl job duration in seconds",
+            ["status"],
+        ).observe({"status": crawl_status}, elapsed)
+        METRICS.counter(
+            "groktocrawl_crawl_pages_scraped_total",
+            "Total pages scraped by crawl jobs",
+        ).inc(value=float(result.completed))
+
         logger.info("Crawl job %s completed in %.2fs", job_id, elapsed)
 
     except Exception as e:
@@ -221,12 +239,24 @@ async def _process_crawl_async(
         store.fail_job(job_id, str(e))
         await deliver_webhook(webhook_config, "crawl.failed", job_id, {"error": str(e)})
         elapsed = time.monotonic() - start
+
+        # ── Existing job-type-agnostic metrics ─────────────────────────────
         METRICS.histogram(
             "job_duration_seconds", "Job processing duration", ["type", "status"]
         ).observe({"type": job_type, "status": "failed"}, elapsed)
         METRICS.counter("jobs_failed_total", "Total failed jobs", ["type"]).inc(
             {"type": job_type}
         )
+
+        # ── Crawl-specific metrics ─────────────────────────────────────────
+        METRICS.counter(
+            "groktocrawl_crawl_jobs_total", "Total crawl jobs by status", ["status"]
+        ).inc({"status": "failed"})
+        METRICS.histogram(
+            "groktocrawl_crawl_duration_seconds",
+            "Crawl job duration in seconds",
+            ["status"],
+        ).observe({"status": "failed"}, elapsed)
     finally:
         await scraper.close()
 

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -108,6 +108,9 @@ async def _process_crawl_async(
     scraper_url: str,
     webhook_config: dict[str, Any] | None = None,
     task_tracker: Any = None,
+    ignore_query_parameters: bool = False,
+    include_paths: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
 ) -> None:
     settings = _get_worker_settings()
     store = JobStore(
@@ -116,25 +119,45 @@ async def _process_crawl_async(
     scraper = ScraperClient(scraper_url)
 
     async def work_fn() -> dict[str, Any]:
-        result = await scraper.scrape(url)
-        pages = []
-        if result.get("success"):
-            data = result["data"]
-            pages.append({"url": url, "markdown": data.get("markdown", "")})
-            # Extract title from metadata if available
-            metadata = data.get("metadata") or {}
-            og = metadata.get("og") or {}
-            meta = metadata.get("meta") or {}
-            title = og.get("title") or meta.get("title") or data.get("title", "")
+        from .crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(
+            max_pages=max_pages,
+            max_depth=max_depth,
+            ignore_query_parameters=ignore_query_parameters,
+            include_paths=include_paths,
+            exclude_paths=exclude_paths,
+        )
+        engine = CrawlEngine(scraper, store=store, options=options)
+        result = await engine.run(url, job_id=job_id)
+
+        # Fire-and-forget indexing for each page
+        for page in result.pages:
+            page_url = page.get("url", "")
+            markdown = page.get("markdown", "")
             if task_tracker is not None:
                 task_tracker.create_background_task(
-                    _index_page_async(url, title, data.get("markdown", "")[:2000])
+                    _index_page_async(
+                        page_url,
+                        "",
+                        markdown[:2000],
+                    )
                 )
             else:
                 asyncio.create_task(
-                    _index_page_async(url, title, data.get("markdown", "")[:2000])
+                    _index_page_async(
+                        page_url,
+                        "",
+                        markdown[:2000],
+                    )
                 )
-        payload = {"completed": len(pages), "total": 1, "pages": pages}
+
+        payload = {
+            "completed": result.completed,
+            "total": result.total,
+            "pages": result.pages,
+            "errors": result.errors,
+        }
         return payload
 
     await _run_job_with_observability(

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -114,6 +114,9 @@ async def _process_crawl_async(
     regex_on_full_url: bool = False,
     verbose: bool = False,
     sitemap_mode: str = "include",
+    crawl_entire_domain: bool = False,
+    allow_subdomains: bool = False,
+    allow_external_links: bool = False,
 ) -> None:
     """Process a crawl job with full lifecycle support.
 
@@ -160,6 +163,9 @@ async def _process_crawl_async(
             regex_on_full_url=regex_on_full_url,
             verbose=verbose,
             sitemap_mode=sitemap_mode,
+            allow_subdomains=allow_subdomains,
+            allow_external_links=allow_external_links,
+            crawl_entire_domain=crawl_entire_domain,
             max_duration_seconds=settings.crawl_max_duration_seconds,
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )

--- a/docs/adr/0038-crawl-engine.md
+++ b/docs/adr/0038-crawl-engine.md
@@ -1,0 +1,233 @@
+# ADR-0038: Crawl Engine — BFS Orchestrator with Shared Link Extraction
+
+**Status:** accepted
+
+**Deciders:** @magnus919
+
+**Date:** 2026-06-19
+
+## Context
+
+GroktoCrawl's original `/v2/crawl` endpoint scraped only the start URL and returned it as a single-page result — it was a stub with no recursive link following. The mission called for a full recursive crawl engine matching Firecrawl's `/v2/crawl` feature set.
+
+Three distinct code paths independently extracted links from HTML pages:
+
+- The **stub crawl worker** (`_process_crawl_async` in `worker.py`) — no link extraction at all initially
+- The **`/v2/map` endpoint** — inline BeautifulSoup parsing directly in the route handler
+- The **`llmstxt.py` `discover_pages()` function** — its own link extraction logic
+
+Each used different HTML parsing approaches, had different edge-case handling (malformed HTML, `<base>` tag resolution, fragment stripping), and maintained its own URL dedup logic. This divergence meant bug fixes and improvements to link extraction had to be applied in three places.
+
+The crawl engine itself needed decisions across several dimensions:
+
+1. **Traversal strategy** — breadth-first (BFS) vs depth-first (DFS) for ordering page discovery
+2. **Link extraction ownership** — one shared module vs per-consumer extraction
+3. **Deduplication approach** — within-run seen sets, canonical URL resolution, content hash comparison
+4. **Concurrency model** — sequential vs parallel page scraping, coordination across workers
+5. **Path filtering** — how include/exclude patterns work with glob vs regex semantics
+6. **Sitemap integration** — how sitemap-discovered URLs interact with BFS discovery
+
+## Decision Drivers
+
+1. **Firecrawl API compatibility** — the output shape (BFS-order data, status response fields, path filter patterns) must match what Firecrawl users expect
+2. **No separate worker container** — crawl jobs are processed inline via `asyncio.create_task()` in the API process, matching the existing job architecture (ADR-0000 precedent)
+3. **Deterministic ordering** — users polling `GET /v2/crawl/{id}` expect pages to appear in a predictable order with the start URL first
+4. **Consistency across features** — `/v2/map`, `/v2/crawl`, and `/v2/generate-llmstxt` should discover the same links from the same HTML
+5. **Low latency for small crawls** — sub-second overhead for `max_pages=1` crawls (the common case)
+6. **Self-hosted simplicity** — avoid external dependencies where possible; Valkey is already in the stack
+
+## Considered Options
+
+### Traversal Strategy — BFS vs DFS
+
+**Option A: BFS (breadth-first search).** Use a FIFO deque. Start URL at depth 0 is scraped first, then all depth-1 pages, then depth-2, and so on.
+
+**Option B: DFS (depth-first search).** Use a stack (LIFO). The crawl follows one branch to its deepest page before backtracking.
+
+| Criterion | BFS | DFS |
+|-----------|-----|-----|
+| Start URL appears first | Yes | No |
+| Predictable page ordering | Yes | Depends on discovery order |
+| Memory usage for deep sites | Higher (queue holds all siblings) | Lower (stack holds one branch) |
+| User expectation (Firecrawl compat) | Matches | Does not match |
+| Early results visible in polling | Better (depth-1 pages appear quickly) | Worse (deep pages appear first) |
+
+**Chosen: BFS** — Firecrawl returns pages in BFS order, and users polling for progress expect to see shallow pages first. The start URL is always at index 0, making validation trivial. Memory overhead is acceptable for our concurrency model (max_pages caps the queue).
+
+### Link Extraction — Shared vs Per-Consumer
+
+**Option A: Shared `LinkExtractor` module.** A single stateless module with `extract_links()` and `filter_links()` used by all three consumers.
+
+**Option B: Per-consumer extraction.** Each consumer (crawl, map, llmstxt) maintains its own link extraction logic.
+
+| Criterion | Shared | Per-Consumer |
+|-----------|--------|--------------|
+| Bug-fix surface | One place | Three places |
+| Edge-case consistency | Guaranteed | Divergent over time |
+| Test surface | One test suite | Three test suites |
+| Consumer coupling | Tighter | Looser |
+| Adding a new consumer | Import the module | Rewrite extraction |
+
+**Chosen: Shared `LinkExtractor`** — The extraction logic is complex enough (relative URL resolution, `<base>` tag handling, fragment stripping, non-HTTP scheme filtering, dedup, malformed HTML tolerance) that maintaining three copies would create a constant tax of inconsistent behavior. The shared module is stateless (pure functions), making it testable in isolation and safe to call from concurrent contexts.
+
+### Deduplication Strategy
+
+**Option A: URL-level only.** Track a `set[str]` of normalized URLs within a crawl run. Normalization handles fragments, trailing slashes, default ports, and query parameter sorting. Optional `ignoreQueryParameters` mode strips query strings entirely.
+
+**Option B: URL + canonical tag.** After scraping, extract `<link rel="canonical">` from HTML. If the canonical URL differs from the fetched URL, replace the page reference and check against the seen set.
+
+**Option C: URL + canonical + content hash.** Compute a SHA-256 hash of the extracted markdown text. If two pages produce the same content hash, skip the duplicate.
+
+**Chosen: Option A (URL-level) for core, with canonical and content hash as layered extensions planned for Milestone 4.** URL-level dedup is sufficient for the core crawl loop and avoids the complexity of parsing scraped HTML a second time (content hash) or making additional scraper calls (canonical). The seen-set is an in-memory Python set, O(1) lookup, no Valkey round-trips. Content hash dedup requires storing hashes per crawl run and adds latency for the hashing operation.
+
+### Concurrency Model
+
+**Option A: Sequential.** Process one page at a time in the BFS loop. Simple, no coordination needed.
+
+**Option B: `asyncio.Semaphore` worker pool.** A fixed-size pool of concurrent scrape tasks coordinated by `asyncio.Semaphore(N)`. Workers pop from the shared BFS queue.
+
+**Option C: Valkey-backed distributed semaphore.** Similar to Option B but using a Valkey (Redis) distributed semaphore for multi-instance coordination.
+
+**Chosen: Option A (sequential) for initial implementation, with Option B planned for Milestone 3.** The initial crawl engine processes pages synchronously within the BFS loop, matching the existing `_process_batch_scrape_async` pattern. Sequential processing is sufficient for the common case (small crawls, low concurrency requirements). The architecture supports adding `asyncio.Semaphore` later without changing the BFS queue or dedup structures. Valkey coordination (Option C) is deferred until multi-instance deployments are demonstrated.
+
+### Path Filtering — Glob vs Regex
+
+**Option A: Glob only.** Use Unix glob-style patterns (`*`, `**`, `?`). Familiar to most users, fewer escaping edge cases.
+
+**Option B: Regex only.** Use Python regular expressions. More expressive but requires users to understand regex syntax.
+
+**Option C: Both, controlled by `regexOnFullUrl` flag.** Default to glob (backward-compatible with Firecrawl defaults), switch to regex when the flag is set.
+
+**Chosen: Option C (both).** Firecrawl supports both glob and regex patterns for `includePaths` and `excludePaths`. The `regexOnFullUrl` flag controls which mode is used. In glob mode, special regex characters (`.`, `+`, `?`, etc.) are escaped to prevent accidental false matches. In regex mode, patterns are passed directly to `re.search()` and can match against the full URL (including query parameters) when enabled.
+
+### Sitemap Integration
+
+**Option A: Ignore sitemaps entirely.** Only discover pages via BFS link following from the start URL.
+
+**Option B: Sitemap as seed only.** Fetch sitemap URLs, deduplicate them against the BFS seen-set, and insert them at the front of the queue. Pages from sitemaps are subject to the same path filtering and max_pages limits as BFS-discovered pages.
+
+**Option C: Three sitemap modes (include/skip/only).** An explicit `sitemap` field with three values:
+- `include` (default): sitemap URLs seeded into BFS queue, combined with HTML link discovery
+- `skip`: no sitemap fetch, HTML-only discovery
+- `only`: exclusively sitemap URLs, no HTML link extraction
+
+**Chosen: Option C (three modes).** This matches Firecrawl's sitemap behavior and gives users explicit control. The sitemap parser (`SitemapParser`) is a separate module that handles XML sitemap parsing, nested sitemap index recursion, robots.txt sitemap directive processing, and fallback to common locations (`/sitemap.xml`, `/sitemap_index.xml`). The `ignoreSitemap` boolean field is preserved as a backward-compatible alias for `sitemap: "skip"`.
+
+## Decision
+
+**BFS traversal, shared `LinkExtractor`, URL-level dedup, sequential concurrency (with planned Semaphore), glob+regex path filtering, and three-mode sitemap integration.**
+
+## Consequences
+
+### Positive
+
+- **Predictable BFS order.** The start URL is always first, depth-1 pages appear next, and polling users see progress in a natural top-down order.
+- **Single source of truth for link extraction.** All link discovery (crawl, map, llmstxt) routes through the same `extract_links()` function, ensuring consistent handling of `<base>` tags, fragments, relative URLs, non-HTTP schemes, and malformed HTML.
+- **Low per-crawl overhead.** The sequential loop with an in-memory seen set avoids Valkey round-trips for dedup and coordination. Small crawls (1-3 pages) complete in under a second.
+- **Path filtering is both powerful and familiar.** Glob patterns work the way users expect (`*` matches path segments, `**` matches across segments), while regex mode provides an escape hatch for complex patterns.
+- **Sitemap integration without behavioral surprises.** Sitemap-discovered URLs are deduplicated against BFS-discovered URLs, counted toward `max_pages`, and subject to the same path filters.
+
+### Negative
+
+- **Sequential scraping is slow for large crawls.** Without concurrency, crawl wall-clock time is the sum of all individual page scrape times. Milestone 3 (asyncio.Semaphore) is a required follow-up for production use cases.
+- **No canonical-tag dedup in core.** Pages with different URLs but identical content (e.g., `/product` and `/product?ref=home`) are both scraped unless `ignoreQueryParameters` is set. Content hash dedup requires a separate pass.
+- **Distributed coordination is deferred.** Multi-instance deployments must coordinate via Valkey job status (cooperative cancellation) rather than a distributed semaphore. Concurrent instances of the same crawl are not supported.
+- **SitemapParser is a separate module dependency.** The crawl engine must import and coordinate with `SitemapParser`, adding module coupling. The parser's fallback logic (robots.txt → common locations) can mask misconfigured sites.
+
+### Neutral
+
+- **The `normalize_url()` function centralizes dedup logic.** Changes to normalization rules (e.g., adding trailing-slash policy) apply everywhere automatically.
+- **Path filter evaluation order is fixed:** exclude checks run first, then include checks. This is documented and tested. Changing the order in the future would be a breaking change.
+- **Module boundaries follow existing patterns** (ADR-0036, ADR-0037): `crawler.py` (orchestrator), `link_extractor.py` (shared extraction), `sitemap_parser.py` (XML parsing), with dedup and cache logic inlined where appropriate.
+
+## Module Architecture
+
+```
+agent-svc/agent/
+  crawler.py           — CrawlEngine BFS loop, normalize_url, path filtering,
+                         queue management, seen-set dedup, store updates
+  link_extractor.py    — extract_links(), filter_links(), classify_links()
+                         (shared with /v2/map and llmstxt.py)
+  sitemap_parser.py    — SitemapParser: fetch XML sitemaps, handle nested
+                         index files, fallback to common locations
+  dedup.py             — DedupManager: multi-layer URL normalization,
+                         canonical tag extraction, content hash comparison
+  crawl_cache.py       — CrawlCache: Valkey-backed response cache with
+                         maxAge/minAge semantics
+  worker.py            — _process_crawl_async(): orchestrates CrawlEngine +
+                         job store + webhooks + metrics
+  store.py             — JobStore: Valkey CRUD for job lifecycle
+  scraper_client.py    — ScraperClient: HTTP client to scraper-svc
+  webhook.py           — Webhook delivery: crawl.started, crawl.page,
+                         crawl.completed, crawl.failed
+  metrics.py           — Prometheus metrics: crawl jobs, pages, duration
+```
+
+## Data Flow
+
+```
+POST /v2/crawl { url, max_pages, max_depth, include_paths, ... }
+  │
+  ▼
+api.py: create_crawl()
+  ├── Validate CrawlRequest (Pydantic)
+  ├── store.create_job(kind="crawl", status="processing")
+  ├── task_tracker.create_background_task(_process_crawl_async(...))
+  └── return { id, success: true }
+       │
+       ▼
+worker.py: _process_crawl_async()
+  ├── Fire crawl.started webhook
+  ├── CrawlEngine.run(start_url, job_id)
+  │   ├── [sitemap mode != skip]
+  │   │   └── SitemapParser.get_urls(domain) → seed queue
+  │   ├── BFS loop: deque.pop() → process (url, depth)
+  │   │   ├── normalize_url(url) → _seen check → skip if duplicate
+  │   │   ├── depth > max_depth? → skip
+  │   │   ├── _match_path(url, include_paths, exclude_paths)? → skip
+  │   │   ├── scraper.scrape(url, scrape_options)
+  │   │   ├── Record page in result with metadata
+  │   │   ├── [depth < max_depth]:
+  │   │   │   ├── fetch_html(url) → raw HTML
+  │   │   │   ├── LinkExtractor.extract_links(html, base_url)
+  │   │   │   ├── LinkExtractor.filter_links(links, base_domain, ...)
+  │   │   │   └── Enqueue unique child URLs at depth+1
+  │   │   ├── Fire crawl.page webhook per page
+  │   │   ├── Periodic store update for polling
+  │   │   └── Check cancellation flag
+  │   └── Stop: max_pages reached, queue empty, or cancelled
+  ├── store.complete_job() or cancel_job()
+  ├── Fire crawl.completed webhook
+  └── Record Prometheus metrics
+```
+
+## Path Filter Precedence Rules
+
+1. **URL-level checks are positional** — exclude_paths is checked before include_paths (short-circuit: if a URL matches any exclude pattern, it is immediately rejected)
+2. **Exclude always wins over include** — a URL matching both exclude and include patterns is excluded
+3. **Missing include_paths means "include all"** — when include_paths is `None`, all non-excluded URLs pass
+4. **Empty include_paths (`[]`) means "include nothing"** — an explicit empty list is treated as blocking all paths that aren't explicitly included (implementation detail: the list is treated as a constraint, not a no-op)
+5. **Mode selector (`regexOnFullUrl`)** — `false` (default): patterns are globs matched against URL path only; `true`: patterns are regexes matched against full URL
+6. **Target selection depends on mode and flags** — in glob mode, matching is against the parsed path component; in regex mode, when `regexOnFullUrl` is true, matching is against the full URL including query parameters
+7. **Path filters apply to every URL including the start URL** — if the start URL does not pass filters, the crawl returns 0 pages
+8. **Filter evaluation happens before scraper dispatch** — filtered URLs do not consume scraper budget and do not count toward max_pages
+
+## Dedup Normalization Pipeline
+
+The `normalize_url()` function applies these transformations in order:
+
+1. **Lowercase scheme and host** — `HTTP://Example.COM/Path` → `http://example.com/Path`
+2. **Remove default ports** — `http://example.com:80/` → `http://example.com/`; `https://example.com:443/` → `https://example.com/`
+3. **Strip fragment** — `/page#section` → `/page`
+4. **Collapse dot segments** — `/./` removed, `/../` resolved via `posixpath.normpath()`
+5. **Normalize trailing slash** — non-root paths ending in `/` have the slash removed
+6. **Sort query parameters** — `?b=2&a=1` → `?a=1&b=2` (only when `ignoreQueryParameters` is false)
+7. **Strip query strings** — when `ignoreQueryParameters` is true, `?ref=abc` is removed entirely
+
+## Links
+
+- Milestone 1 implementation: `agent-svc/agent/crawler.py`, `agent-svc/agent/link_extractor.py`
+- Milestone 3 (concurrency): Planned `asyncio.Semaphore` worker pool in `crawler.py`
+- Milestone 4 (content dedup): Planned canonical tag and content hash dedup in `dedup.py`
+- Milestone 2 (sitemap): Planned `SitemapParser` in `agent-svc/agent/sitemap_parser.py`
+- Refines ADR-0012: Webhook delivery pattern reused for crawl lifecycle webhooks

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,5 +56,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0035 | [Graceful Shutdown for Fire-and-Forget Tasks](0035-graceful-shutdown.md) | accepted |
 | 0036 | [Split Scraper fetch.py into Focused Modules](0036-split-scraper-fetch-modules.md) | proposed |
 | 0037 | [Split Semantic Service app.py into Focused Modules](0037-split-semantic-svc-app-modules.md) | proposed |
+| 0038 | [Crawl Engine — BFS Orchestrator with Shared Link Extraction](0038-crawl-engine.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/firecrawl-crawl-feature-research.md
+++ b/firecrawl-crawl-feature-research.md
@@ -1,0 +1,404 @@
+# Firecrawl Crawl API — Comprehensive Feature Research
+
+Generated 2026-06-19 from Firecrawl docs, blog guides, API reference, and glossary.
+
+Sources consulted:
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-post
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-get
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-delete
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-get-errors
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-active
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-params-preview
+- https://docs.firecrawl.dev/api-reference/endpoint/scrape (for scrapeOptions reference)
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-started
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-page
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-completed
+- https://www.firecrawl.dev/blog/mastering-the-crawl-endpoint-in-firecrawl
+- https://www.firecrawl.dev/glossary/web-crawling-apis/deduplicate-crawl-pages-rag
+
+---
+
+## 1. INITIATION / CONFIGURATION
+
+### `url` (string, required)
+The base URL to start crawling from.
+**GroktoCrawl:** ✅ HAS — `CrawlRequest.url`
+
+### `prompt` (string)
+Natural language description of what to crawl. Firecrawl translates this into the crawl parameters (includePaths, excludePaths, maxDiscoveryDepth, etc.). Explicitly-set parameters override the NL-derived equivalents.
+**GroktoCrawl:** ❌ MISSING — No NL→param translation for crawl.
+
+### `webhook` (object)
+A webhook specification object with `url`, `events`, and optional `metadata`.
+Firecrawl sends three event types for crawls:
+- `crawl.started` — job started
+- `crawl.page` — each page scraped (with the page data)
+- `crawl.completed` — job finished (empty data; results via GET)
+
+All webhooks include `X-Firecrawl-Signature` header (HMAC-SHA256).
+**GroktoCrawl:** ⚠️ PARTIAL — Has `webhook` field in CrawlRequest and `deliver_webhook()` function with HMAC signing, but only fires on "completed"/"failed". No per-page webhooks, no "started" event. No `events` filter or `metadata` echo.
+
+### POST `/v2/crawl/params-preview`
+NL prompt → params preview endpoint. Takes `url` + `prompt`, returns derived parameters (includePaths, excludePaths, maxDepth, crawlEntireDomain, allowExternalLinks, allowSubdomains, ignoreRobotsTxt, robotsUserAgent, deduplicateSimilarURLs, delay, limit, etc.).
+**GroktoCrawl:** ❌ MISSING — No params-preview endpoint.
+
+---
+
+## 2. DISCOVERY & SCOPE
+
+### `sitemap` (enum: "include" | "skip" | "only", default: "include")
+- `"include"` — use sitemap alongside HTML link discovery
+- `"skip"` — ignore sitemap, only follow HTML links
+- `"only"` — only crawl URLs from sitemap (+ start URL), no HTML link discovery
+**GroktoCrawl:** ❌ MISSING — `CrawlRequest` has `ignore_sitemap: bool` which only covers the binary skip/include case but isn't actually implemented in the worker. No "only" mode.
+
+### `maxDiscoveryDepth` (integer)
+Maximum depth from root. Root page = depth 0, its direct links = depth 1, etc. Pages at max depth are still scraped but their links are not followed. Sitemap-discovered pages count as depth 0.
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlRequest.max_depth` field exists but worker doesn't actually do any link discovery at all (only scrapes the starting URL).
+
+### `limit` (integer, default: 10000)
+Maximum number of pages to crawl. Firecrawl pre-checks credits against limit before starting; returns 402 if insufficient.
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlRequest.max_pages` (default: 10) but worker ignores it (single page only).
+
+### `includePaths` (string[])
+URL pathname regex patterns to include in the crawl. Only matching paths are included. The starting URL is also checked — if it doesn't match, crawl may return 0 pages.
+**GroktoCrawl:** ✅ HAS (in model) — Not yet implemented in worker.
+
+### `excludePaths` (string[])
+URL pathname regex patterns that exclude matching URLs from the crawl.
+**GroktoCrawl:** ✅ HAS (in model) — Not yet implemented in worker.
+
+### `regexOnFullURL` (boolean, default: false)
+When true, includePaths/excludePaths regex patterns match against the full URL (including query parameters), not just pathname.
+**GroktoCrawl:** ❌ MISSING
+
+### `crawlEntireDomain` (boolean, default: false)
+- `false`: Only crawls deeper (child) URLs. `/features/x` → `/features/x/tips` ✅ but won't follow `/pricing` or `/`.
+- `true`: Follows any internal links including siblings and parents.
+**GroktoCrawl:** ❌ MISSING
+
+### `allowExternalLinks` (boolean, default: false)
+Allow following links to external domains.
+**GroktoCrawl:** ❌ MISSING
+
+### `allowSubdomains` (boolean, default: false)
+Allow following links to subdomains of the main domain.
+**GroktoCrawl:** ❌ MISSING
+
+### `ignoreQueryParameters` (boolean, default: false)
+Do not re-scrape the same path with different query parameters. This is URL-level deduplication: `?ref=abc` and `?ref=xyz` collapse to one fetch.
+**GroktoCrawl:** ❌ MISSING
+
+### Deduplication Strategy (automatic, not a parameter)
+Per Firecrawl glossary, they do multi-layer dedup:
+1. **URL normalization** (pre-fetch): trailing slashes, tracking params, protocol variants
+2. **Canonical tag check** (post-fetch): `<link rel="canonical">`
+3. **Exact content hash** (post-fetch): on extracted text, not raw HTML
+4. **Near-duplicate filtering** (optional): embedding similarity for syndicated/template-heavy content
+
+Firecrawl handles URL-level dedup automatically within a crawl run. `ignoreQueryParameters` reduces the volume needing downstream content dedup.
+**GroktoCrawl:** ❌ MISSING — No dedup at any layer (only fetches one URL).
+
+---
+
+## 3. RATE LIMITING & CONCURRENCY
+
+### `delay` (number, seconds)
+Delay between scrapes. Setting this forces `maxConcurrency` to 1. Different from `waitFor` (which is per-page render time in ms).
+**GroktoCrawl:** ❌ MISSING
+
+### `maxConcurrency` (integer)
+Maximum number of concurrent scrapes for this crawl. If not specified, uses team's account-level concurrency limit.
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 4. robots.txt
+
+### `ignoreRobotsTxt` (boolean, default: false)
+Ignore website's robots.txt rules. **Enterprise only.**
+**GroktoCrawl:** ❌ MISSING
+
+### `robotsUserAgent` (string)
+Custom User-Agent for robots.txt evaluation. **Enterprise only.**
+**GroktoCrawl:** ❌ MISSING
+
+Note: The errors endpoint (`GET /v2/crawl/{id}/errors`) returns a `robotsBlocked` list of URLs skipped due to robots.txt.
+
+---
+
+## 5. SCRAPE OPTIONS (via `scrapeOptions` object)
+
+Firecrawl's crawl `scrapeOptions` mirrors the `/v2/scrape` endpoint options exactly. They apply to every page in the crawl.
+
+### Formats
+Array of format strings or format objects:
+- `"markdown"` — clean markdown (default)
+- `"html"` — cleaned HTML
+- `"rawHtml"` — raw HTML
+- `"links"` — array of links found on page
+- `"images"` — images metadata
+- `"screenshot"` — temporary PNG URL (expires 24h)
+- `"json"` — structured extraction with LLM (takes `{ type: "json", schema: {...} }`)
+- `"summary"` — LLM summary
+- `"changeTracking"` — compares against previous scrape
+- `"branding"` — logo, colors, fonts, typography, spacing, components
+- `"product"` — title, variants, price, availability, images
+- `"audio"` — audio extraction
+- `"video"` — video extraction
+- `"question"` — ask a question about the page
+- `"highlights"` — content highlights
+
+**GroktoCrawl:** ❌ MISSING — No `scrapeOptions` passthrough in CrawlRequest model at all. The worker hardcodes `scraper.scrape(url)` with no format control.
+
+### `onlyMainContent` (boolean, default: true)
+Return only main page content, excluding headers/navs/footers. Deterministic HTML-level filter, no LLM.
+**GroktoCrawl:** ❌ MISSING
+
+### `onlyCleanContent` (boolean, default: false)
+**Beta.** LLM-based pass over generated markdown to remove residual boilerplate that `onlyMainContent` can miss (cookie banners, ads, social widgets, breadcrumbs, newsletter signups, comments, related-article lists). Preserves headings, lists, tables, code blocks, images, inline links. Skipped when markdown exceeds the cleaning model's token limit. Not supported on zero-data-retention requests.
+**GroktoCrawl:** ❌ MISSING
+
+### `includeTags` (string[])
+Tags/classes/IDs to include in output.
+**GroktoCrawl:** ❌ MISSING
+
+### `excludeTags` (string[])
+Tags/classes/IDs to exclude from output.
+**GroktoCrawl:** ❌ MISSING
+
+### `maxAge` (integer, default: 172800000 ms = 2 days)
+Cache control: return cached version if younger than this. Can speed up scrapes by ~500%.
+**GroktoCrawl:** ❌ MISSING — No caching layer.
+
+### `minAge` (integer)
+Cache-only mode: only checks cache, never triggers fresh scrape. Minimum age of cached data. If no match, returns 404 `SCRAPE_NO_CACHED_DATA`. Set to 1 to accept any cached data.
+**GroktoCrawl:** ❌ MISSING
+
+### `headers` (object)
+Custom headers sent with the scrape request (cookies, user-agent, etc.).
+**GroktoCrawl:** ❌ MISSING
+
+### `waitFor` (integer, default: 0)
+Milliseconds to wait before fetching content, in addition to Firecrawl's smart wait.
+**GroktoCrawl:** ❌ MISSING
+
+### `mobile` (boolean, default: false)
+Emulate mobile device scraping. Useful for responsive pages and mobile screenshots.
+**GroktoCrawl:** ❌ MISSING
+
+### `skipTlsVerification` (boolean, default: true)
+Skip TLS certificate verification.
+**GroktoCrawl:** ❌ MISSING (scraper-svc may have this internally, but not configurable from crawl API)
+
+### `timeout` (integer, default: 60000 ms, min: 1000, max: 300000)
+Per-page request timeout.
+**GroktoCrawl:** ❌ MISSING (per-page timeout not configurable)
+
+### `parsers` (object[])
+Controls file processing. When `"pdf"` is included (default), PDFs are extracted to markdown (1 credit per page). Empty array returns PDF as base64 (flat 1 credit).
+**GroktoCrawl:** ❌ MISSING
+
+### `actions` (object[])
+Browser actions to perform before grabbing content:
+- `wait` (by duration ms)
+- `waitFor` (wait for element selector)
+- `screenshot` (full page or element)
+- `click` (by selector)
+- `write` (type text)
+- `press` (press a key)
+- `scroll` (scroll to element or by pixels)
+- `scrape` (scrape current state)
+- `executeJavascript` (run JS)
+- `generatePDF` (generate PDF of current state)
+
+**GroktoCrawl:** ❌ MISSING — Browser actions exist on the separate `/v2/browser` endpoint but not as scrape options.
+
+### `location` (object: { country, languages })
+Location settings for proxy selection and language/timezone emulation. Defaults to `"US"`.
+**GroktoCrawl:** ❌ MISSING
+
+### `removeBase64Images` (boolean, default: true)
+Remove base64-encoded images from markdown output. Alt text preserved with placeholder.
+**GroktoCrawl:** ❌ MISSING
+
+### `blockAds` (boolean, default: true)
+Enable ad blocking and cookie popup blocking.
+**GroktoCrawl:** ❌ MISSING
+
+### `proxy` (enum: "basic" | "enhanced" | "auto", default: "auto")
+- `basic`: Fast, for sites with minimal anti-bot
+- `enhanced`: For advanced anti-bot sites. Costs up to 5 credits/request.
+- `auto`: Tries basic first, falls back to enhanced on failure. Only bills enhanced credits if fallback used.
+**GroktoCrawl:** ❌ MISSING
+
+### `storeInCache` (boolean, default: true)
+Whether to store the page in Firecrawl's cache. Set to false for data protection concerns. Some params (actions, headers) force this to false.
+**GroktoCrawl:** ❌ MISSING
+
+### `lockdown` (boolean, default: false)
+Cache-only mode: never makes outbound request. On cache miss, returns 404 `SCRAPE_LOCKDOWN_CACHE_MISS`. URL is never logged on miss. Treated as zero data retention. Default `maxAge` extended to 2 years. Billed at 5 credits on hit, 1 on miss. Designed for compliance/air-gapped environments.
+**GroktoCrawl:** ❌ MISSING
+
+### `redactPII` (boolean | object, default: false)
+Redact PII from returned markdown. Pass `true` for defaults, or an object to tune mode, entities, and replacement style.
+**GroktoCrawl:** ❌ MISSING
+
+### `profile` (object: { name, saveChanges })
+Enable persistent browser storage across scrape and interact sessions. Sessions with the same profile name share browser state (cookies, localStorage, session data).
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 6. RESULTS & STATUS
+
+### `POST /v2/crawl` — Create
+Response: `{ success: true, id: string, url: string }`
+**GroktoCrawl:** ✅ HAS — `CrawlCreateResponse { success, id }`. Missing the `url` field in response.
+
+### `GET /v2/crawl/{id}` — Status
+Response fields:
+- `status` (string): "scraping" | "completed" | "failed"
+- `total` (int): total pages attempted
+- `completed` (int): pages successfully scraped
+- `creditsUsed` (int): credits consumed
+- `expiresAt` (datetime): when results expire
+- `createdAt` (datetime): when job started
+- `completedAt` (datetime): when job finished (terminal states only)
+- `duration` (number): elapsed seconds
+- `next` (string | null): URL for next 10MB chunk if response > 10MB
+- `data` (array): scraped page documents, each with markdown, html, rawHtml, links, screenshot, metadata
+
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlStatusResponse` has `status`, `completed`, `total`, `credits_used`, `data`, `error`. Missing: `expiresAt`, `createdAt`, `completedAt`, `duration`, `next` (pagination), full per-page metadata shape.
+
+### `DELETE /v2/crawl/{id}` — Cancel
+Response: `{ status: "cancelled" }`
+**GroktoCrawl:** ✅ HAS — Returns `{ success: true }` via `AgentCancelResponse`. Slightly different response shape but functionally equivalent.
+
+### `GET /v2/crawl/{id}/errors` — Errors
+Response:
+- `errors[]`: array of `{ id, timestamp, url, error }`
+- `robotsBlocked[]`: array of URL strings blocked by robots.txt
+
+**GroktoCrawl:** ❌ MISSING
+
+### `GET /v2/crawl/active` — Active crawls
+Lists all active crawls for the authenticated team with full options.
+**GroktoCrawl:** ⚠️ PARTIAL — Has `GET /v2/activity` which lists all active jobs across all types. No crawl-specific filtering, and no per-job options display.
+
+### Webhook Events (3 for crawl)
+- `crawl.started` — `{ type, id, webhookId, data: [], metadata: {} }`
+- `crawl.page` — `{ success, type, id, webhookId, data: [pageDoc], error: string | null, metadata: {} }` — fires per page as scraped
+- `crawl.completed` — `{ success, type, id, webhookId, data: [], metadata: {} }`
+
+All include HMAC signature via `X-Firecrawl-Signature` header (uses specific webhook secret, not the API token).
+**GroktoCrawl:** ❌ MISSING — Only fires one webhook on completion/failure. No per-page events, no started event, no webhookId for dedup, no metadata echo.
+
+### SDK Delivery Modes
+- `crawl()` — synchronous, blocks until done
+- `start_crawl()` + `get_crawl_status()` — async polling
+- `AsyncFirecrawl.watcher()` — WebSocket streaming (with HTTP polling fallback)
+- Webhooks — HTTP POST push
+
+**GroktoCrawl:** ⚠️ PARTIAL — Has sync create + poll (store-based). No WebSocket streaming. No SDK-level watcher.
+
+---
+
+## 7. ADVANCED / SECURITY
+
+### `zeroDataRetention` (boolean, default: false)
+If true, enables zero data retention for this crawl. Must contact Firecrawl to enable.
+**GroktoCrawl:** ❌ MISSING
+
+### Prompt-to-Params Translation (NL → Crawl Config)
+The `prompt` field in crawl POST is translated via LLM into crawl parameters. The `/v2/crawl/params-preview` endpoint exposes this translation. Different prompts produce different includePaths, maxDepth, etc.
+**GroktoCrawl:** ❌ MISSING
+
+### Credit Pre-check
+Before starting a crawl, Firecrawl checks that your remaining credits can cover the `limit`. If not, returns `402 Payment Required`.
+**GroktoCrawl:** ❌ MISSING — No credit system.
+
+### `deduplicateSimilarURLs` (in params-preview output)
+A parameter surfaced in params-preview that controls URL dedup similarity. Not directly documented as a crawl POST parameter but appears in the preview output.
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 8. ENDPOINT SUMMARY (Full Firecrawl Crawl Surface)
+
+| Method | Path | GroktoCrawl Status |
+|--------|------|-------------------|
+| POST | `/v2/crawl` | ✅ EXISTS (minimal impl) |
+| GET | `/v2/crawl/{id}` | ✅ EXISTS (partial fields) |
+| DELETE | `/v2/crawl/{id}` | ✅ EXISTS |
+| GET | `/v2/crawl/{id}/errors` | ❌ MISSING |
+| GET | `/v2/crawl/active` | ⚠️ PARTIAL (generic activity endpoint) |
+| POST | `/v2/crawl/params-preview` | ❌ MISSING |
+
+## 9. GROKTOCRAWL CRITICAL GAPS SUMMARY
+
+The current GroktoCrawl crawl implementation is fundamentally a **single-page scrape with a crawl-shaped API shell**:
+
+1. **No link discovery** — the worker only scrapes the starting URL. `max_pages`, `max_depth`, `include_paths`, `exclude_paths`, `ignore_sitemap` fields exist in the model but are never used in processing.
+
+2. **No scrapeOptions passthrough** — all format control, content filtering, JS rendering, proxy selection, caching, PII redaction, ad blocking, and browser actions are missing.
+
+3. **No concurrency** — no `delay`, `maxConcurrency`, or parallel scraping infrastructure.
+
+4. **No deduplication** — no URL normalization, canonical checking, content hashing, or near-duplicate filtering.
+
+5. **Missing endpoints** — `/errors`, `/params-preview`, crawl-specific `/active`.
+
+6. **Minimal webhooks** — only completion/failure, no per-page events, no started event, no webhookId for dedup.
+
+7. **No caching** — no `maxAge`/`minAge`/`storeInCache`/`lockdown` infrastructure.
+
+8. **No NL→params translation** — no `prompt` field or params-preview.
+
+9. **Response shape gaps** — missing `expiresAt`, `createdAt`, `completedAt`, `duration`, `next` (pagination), full per-page metadata.
+
+10. **Missing Firecrawl API fields** — `crawlEntireDomain`, `allowExternalLinks`, `allowSubdomains`, `ignoreQueryParameters`, `regexOnFullURL`, `sitemap` modes (enum not bool), `scrapeOptions`, `zeroDataRetention`, full webhook shape.
+
+## 10. PRIORITY IMPLEMENTATION ORDER (RECOMMENDATION)
+
+### Tier 1 — Core crawl functionality (MVP)
+1. Link discovery engine (HTML link extraction, sitemap parsing)
+2. Depth-first / breadth-first traversal with `maxDepth` / `maxDiscoveryDepth`
+3. `limit` enforcement (stop at `maxPages`)
+4. `includePaths` / `excludePaths` filtering with regex
+5. URL-level dedup within a crawl run
+6. `ignoreQueryParameters` for query-string collapse
+
+### Tier 2 — Scope and discovery
+7. `sitemap` modes (include/skip/only) with proper sitemap parsing
+8. `crawlEntireDomain` (sibling/parent URL following)
+9. `allowSubdomains`
+10. `allowExternalLinks` (with safety guard)
+11. `regexOnFullURL`
+
+### Tier 3 — Scrape options passthrough
+12. `scrapeOptions` model with all format/content/rendering fields
+13. Pass scrapeOptions through to scraper-svc
+14. `onlyMainContent`, `includeTags`, `excludeTags`
+15. `waitFor`, `timeout`, `mobile`, `headers`
+
+### Tier 4 — Concurrency and rate limiting
+16. `maxConcurrency` with asyncio semaphore or task pool
+17. `delay` (between-request pacing)
+18. Parallel scraping infrastructure
+
+### Tier 5 — Caching and advanced features
+19. Response caching layer (`maxAge`/`minAge`)
+20. Content dedup (canonical check, content hash)
+21. `robots.txt` parsing and enforcement
+22. `GET /v2/crawl/{id}/errors` endpoint
+23. `GET /v2/crawl/active` (or enhance existing activity)
+
+### Tier 6 — Full parity
+24. NL→params translation (`prompt` field + `/v2/crawl/params-preview`)
+25. Per-page webhooks (`crawl.page` events)
+26. WebSocket streaming (`watcher()` equivalent)
+27. `lockdown`, `redactPII`, `profile`, `zeroDataRetention`
+28. Advanced scrapeOptions (`actions`, `location`, `proxy`, `blockAds`, `parsers`, `removeBase64Images`)
+29. Response shape parity (all fields: `expiresAt`, `createdAt`, `completedAt`, `duration`, `next`, full metadata, per-page `links`/`screenshot`/`html`/`rawHtml`)
+30. Credit system with pre-check

--- a/groktocrawl
+++ b/groktocrawl
@@ -540,6 +540,8 @@ class Client:
         max_depth: int = 2,
         include_paths: list[str] | None = None,
         exclude_paths: list[str] | None = None,
+        max_pages: int | None = None,
+        ignore_query_parameters: bool = False,
         **extra: Any,
     ) -> dict[str, Any]:
         data: dict[str, Any] = {
@@ -547,10 +549,14 @@ class Client:
             "limit": limit,
             "maxDepth": max_depth,
         }
+        if max_pages is not None:
+            data["maxPages"] = max_pages
         if include_paths:
             data["includePaths"] = include_paths
         if exclude_paths:
             data["excludePaths"] = exclude_paths
+        if ignore_query_parameters:
+            data["ignoreQueryParameters"] = True
         data.update(extra)
         return self._request("POST", "/crawl", json_data=data)
 
@@ -848,6 +854,8 @@ def cmd_crawl(client: Client, args: argparse.Namespace) -> None:
             max_depth=args.max_depth,
             include_paths=args.include_paths,
             exclude_paths=args.exclude_paths,
+            max_pages=args.max_pages,
+            ignore_query_parameters=args.ignore_query_parameters,
         )
     except ApiError as e:
         die(str(e))
@@ -866,14 +874,20 @@ def cmd_crawl(client: Client, args: argparse.Namespace) -> None:
         return
 
     log(f"Crawl job {job_id} — polling...")
+    poll_errors = 0
+    max_poll_errors = 3
     while True:
         time.sleep(POLL_INTERVAL)
         try:
             status = client.crawl_status(job_id)
         except ApiError as e:
-            warn(f"Status check failed: {e}")
+            poll_errors += 1
+            if poll_errors >= max_poll_errors:
+                die(f"Lost connection to server while polling crawl status: {e}")
+            warn(f"Status check failed ({poll_errors}/{max_poll_errors}): {e}")
             continue
 
+        poll_errors = 0  # reset on success
         s = status.get("status", "unknown")
         if s in ("completed", "finished"):
             pages = status.get("data", status.get("pages", []))
@@ -969,7 +983,7 @@ def cmd_agent(client: Client, args: argparse.Namespace) -> None:
                             print(f"  {src}")
                 return
             elif s == "failed":
-                err_msg = status.get('error', 'unknown')
+                err_msg = status.get("error", "unknown")
                 print(f"\nError: Agent failed — {err_msg}", flush=True)
                 sys.exit(1)
             else:
@@ -1754,6 +1768,12 @@ def make_parser() -> argparse.ArgumentParser:
         "--limit", "-l", type=int, default=50, help="Max pages to crawl (default: 50)"
     )
     p_crawl.add_argument(
+        "--max-pages",
+        type=int,
+        default=None,
+        help="Maximum pages to crawl (overrides --limit if both provided; the API uses the stricter value)",
+    )
+    p_crawl.add_argument(
         "--max-depth", "-d", type=int, default=2, help="Max crawl depth (default: 2)"
     )
     p_crawl.add_argument(
@@ -1761,6 +1781,12 @@ def make_parser() -> argparse.ArgumentParser:
     )
     p_crawl.add_argument(
         "--exclude-paths", nargs="+", help="URL path patterns to exclude"
+    )
+    p_crawl.add_argument(
+        "--ignore-query-params",
+        dest="ignore_query_parameters",
+        action="store_true",
+        help="Treat URLs with different query parameters as the same page",
     )
     p_crawl.add_argument(
         "--no-poll", action="store_true", help="Don't poll for completion"

--- a/groktocrawl
+++ b/groktocrawl
@@ -547,16 +547,16 @@ class Client:
         data: dict[str, Any] = {
             "url": url,
             "limit": limit,
-            "maxDepth": max_depth,
+            "max_depth": max_depth,
         }
         if max_pages is not None:
-            data["maxPages"] = max_pages
+            data["max_pages"] = max_pages
         if include_paths:
-            data["includePaths"] = include_paths
+            data["include_paths"] = include_paths
         if exclude_paths:
-            data["excludePaths"] = exclude_paths
+            data["exclude_paths"] = exclude_paths
         if ignore_query_parameters:
-            data["ignoreQueryParameters"] = True
+            data["ignore_query_parameters"] = True
         data.update(extra)
         return self._request("POST", "/crawl", json_data=data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ skip-magic-trailing-comma = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 addopts = "--cov=agent-svc/agent --cov=scraper-svc/scraper --cov=browser-svc/browser_svc --cov=parse-svc/parse_svc --cov=portal-svc/portal --cov=semantic-svc --cov-report=term-missing --cov-fail-under=20 --durations=10 -n auto"
 
 [tool.mypy]

--- a/scraper-svc/scraper/adapters/base.py
+++ b/scraper-svc/scraper/adapters/base.py
@@ -94,7 +94,7 @@ class AdapterContext:
         try:
             return await asyncio.wait_for(coro, timeout=timeout)
         except TimeoutError:
-            raise AdapterTimeoutError(f"Timed out after {timeout}s")
+            raise AdapterTimeoutError(f"Timed out after {timeout}s") from None
 
 
 # ── Adapter base class ───────────────────────────────────────────

--- a/scraper-svc/scraper/adapters/bluesky.py
+++ b/scraper-svc/scraper/adapters/bluesky.py
@@ -11,6 +11,7 @@ Public endpoint: https://public.api.bsky.app
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
 from urllib.parse import urlparse
@@ -79,10 +80,7 @@ async def _fetch_post_thread(did: str, rkey: str) -> dict | None:
     response, or ``None`` on failure.
     """
     at_uri = f"at://{did}/app.bsky.feed.post/{rkey}"
-    url = (
-        f"{PUBLIC_API_URL}/xrpc/app.bsky.feed.getPostThread"
-        f"?uri={at_uri}&depth=1"
-    )
+    url = f"{PUBLIC_API_URL}/xrpc/app.bsky.feed.getPostThread?uri={at_uri}&depth=1"
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             resp = await client.get(url)
@@ -241,10 +239,10 @@ def _format_thread(thread: dict) -> tuple[str, dict]:
     """
     post = thread.get("post", {})
     author = post.get("author", {})
-    record = post.get("record", {})
+    post.get("record", {})
 
     # Root post text
-    root_text = _extract_post_text(post)
+    _extract_post_text(post)
     timestamp = _format_timestamp(post)
 
     # Counts come from the post view, not the record
@@ -267,17 +265,22 @@ def _format_thread(thread: dict) -> tuple[str, dict]:
             images = embed.get("images", [])
             if not images and "image" in embed:
                 images = [embed["image"]]
-            embed_markdown = "\n" + "\n".join(
-                f"![{img.get('alt', 'Image')}]({img.get('image', {}).get('ref', {}).get('$link', '') or img.get('ref', '')})"
-                for img in images
-            ) + "\n" if images else ""
+            embed_markdown = (
+                "\n"
+                + "\n".join(
+                    f"![{img.get('alt', 'Image')}]({img.get('image', {}).get('ref', {}).get('$link', '') or img.get('ref', '')})"
+                    for img in images
+                )
+                + "\n"
+                if images
+                else ""
+            )
         elif "record" in embed_type:
             quoted = embed.get("record", {})
             quoted_author = quoted.get("author", {})
             quoted_text = _extract_post_text(quoted)
             embed_markdown = (
-                f"\n> **@{quoted_author.get('handle', 'unknown')}**\n"
-                f"> {quoted_text}\n"
+                f"\n> **@{quoted_author.get('handle', 'unknown')}**\n> {quoted_text}\n"
             )
 
     # Build metadata
@@ -312,9 +315,7 @@ def _format_thread(thread: dict) -> tuple[str, dict]:
 # ── Browser fallback ─────────────────────────────────────────────
 
 
-async def _fetch_via_browser(
-    url: str, ctx: AdapterContext
-) -> tuple[str, dict] | None:
+async def _fetch_via_browser(url: str, ctx: AdapterContext) -> tuple[str, dict] | None:
     """Fallback: render Bluesky page in browser, extract text + metadata.
 
     Returns ``(markdown, metadata)`` or ``None``.
@@ -361,22 +362,19 @@ async def _fetch_via_browser(
                 f"{browser_svc_url}/browsers/{session_id}/execute",
                 json={
                     "action": "executeScript",
-                    "script": (
-                        "JSON.stringify({"
-                        "title: document.title,"
-                        "})"
-                    ),
+                    "script": ("JSON.stringify({title: document.title,})"),
                 },
             )
             metadata: dict = {"source": "bluesky-adapter"}
             if meta_resp.json().get("success"):
                 import json
 
-                raw = meta_resp.json().get("result", {}).get("script_result", "{}") or "{}"
-                try:
+                raw = (
+                    meta_resp.json().get("result", {}).get("script_result", "{}")
+                    or "{}"
+                )
+                with contextlib.suppress(json.JSONDecodeError):
                     metadata.update(json.loads(raw))
-                except json.JSONDecodeError:
-                    pass
 
             if not body_text:
                 return None

--- a/scraper-svc/scraper/adapters/github_social.py
+++ b/scraper-svc/scraper/adapters/github_social.py
@@ -616,8 +616,8 @@ def _render_discussion(data: dict) -> tuple[str, dict]:
     # Answer (for Q&A discussions)
     answer = data.get("answer")
     if answer and isinstance(answer, dict):
-        aa = answer.get("author", {}).get("login", "unknown")
-        ad = (answer.get("createdAt", "") or "")[:10]
+        answer.get("author", {}).get("login", "unknown")
+        (answer.get("createdAt", "") or "")[:10]
         ab = _fmt_body(answer.get("body"))
         parts.append("---\n## ✅ Answer  by @{aa}  _({ad})_\n")
         if ab:
@@ -767,7 +767,7 @@ def _render_commit(data: dict) -> tuple[str, dict]:
     committer_name = committer_obj.get(
         "name", committer_obj.get("user", {}).get("login", "")
     )
-    url = data.get("url", "")
+    data.get("url", "")
     parents = [p.get("oid", "")[:7] for p in (data.get("parents", {}).get("nodes", []))]
 
     parts.append(f"# {headline or sha}\n")

--- a/scraper-svc/scraper/cookie_store.py
+++ b/scraper-svc/scraper/cookie_store.py
@@ -7,6 +7,7 @@ Ported from browser-svc/browser_svc/app.py.
 Shares the same key prefix (cf:clearance:) and TTL (1500s).
 """
 
+import contextlib
 import json
 import logging
 import time
@@ -64,10 +65,8 @@ async def close_client():
     """Close the Valkey client connection."""
     global _redis_client
     if _redis_client is not None:
-        try:
+        with contextlib.suppress(Exception):
             await _redis_client.close()
-        except Exception:
-            pass
         _redis_client = None
 
 

--- a/scraper-svc/scraper/extract.py
+++ b/scraper-svc/scraper/extract.py
@@ -105,18 +105,20 @@ def _check_boilerplate(markdown: str) -> tuple[float, str]:
         return 0.0, "fail"
 
     lines = markdown.strip().split("\n")
-    non_empty = [l.strip() for l in lines if l.strip()]
+    non_empty = [line.strip() for line in lines if line.strip()]
 
     if not non_empty:
         return 0.0, "fail"
 
     # Count link-heavy lines
-    link_lines = sum(1 for l in non_empty if re.search(r"\[.*?\]\(.*?\)", l))
+    link_lines = sum(1 for line in non_empty if re.search(r"\[.*?\]\(.*?\)", line))
     link_ratio = link_lines / len(non_empty)
 
     # Count substantive paragraphs (multi-sentence, non-link lines)
     substantive = sum(
-        1 for l in non_empty if len(l) > 60 and not re.search(r"\[.*?\]\(.*?\)", l)
+        1
+        for line in non_empty
+        if len(line) > 60 and not re.search(r"\[.*?\]\(.*?\)", line)
     )
 
     # Score

--- a/scraper-svc/scraper/politeness.py
+++ b/scraper-svc/scraper/politeness.py
@@ -12,6 +12,7 @@ Architecture:
     before proceeding.
 """
 
+import contextlib
 import hashlib
 import logging
 import re
@@ -170,10 +171,8 @@ class PolitenessManager:
 
             # Crawl-delay
             if line.lower().startswith("crawl-delay:"):
-                try:
+                with contextlib.suppress(ValueError):
                     crawl_delay = float(line.split(":", 1)[1].strip())
-                except ValueError:
-                    pass
 
             # Sitemap
             if line.lower().startswith("sitemap:"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""pytest configuration for GroktoCrawl unit tests.
+
+Adds the project root and agent-svc to the Python path so that unit tests
+can import the agent modules directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add project root to path (for common.* imports)
+_root = Path(__file__).resolve().parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+# Add agent-svc to path (for agent.* imports)
+_agent_svc = _root / "agent-svc"
+if _agent_svc.exists() and str(_agent_svc) not in sys.path:
+    sys.path.insert(0, str(_agent_svc))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,517 @@
+"""Tests for the groktocrawl CLI — crawl subcommand flags and error handling.
+
+Covers:
+- Client.crawl() parameter mapping to API
+- cmd_crawl() handler behavior with new flags
+- JSON output formatting
+- Server-unreachable error handling
+- Help text completeness
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Load the CLI script ──────────────────────────────────────────────────────
+
+_CLI_PATH = os.path.join(os.path.dirname(__file__), "..", "groktocrawl")
+if not os.path.isfile(_CLI_PATH):
+    pytest.skip("groktocrawl CLI not found at project root", allow_module_level=True)
+
+# Load the CLI module by executing it with a namespace dict
+_cli_ns: dict = {}
+with open(_CLI_PATH, encoding="utf-8") as f:
+    _code = compile(f.read(), _CLI_PATH, "exec")
+exec(_code, _cli_ns)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    """Create a Client instance with dry_run=False for testing."""
+    client_cls = _cli_ns["Client"]
+    return client_cls(server="http://test-server:8080", dry_run=False)
+
+
+# ── Client.crawl() tests ─────────────────────────────────────────────────────
+
+
+class TestClientCrawl:
+    """Tests for Client.crawl() parameter mapping."""
+
+    def test_basic_crawl_sends_correct_data(self, client):
+        """Basic crawl sends url, limit, and maxDepth."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["url"] == "http://example.com"
+            assert json_data["limit"] == 50
+            assert json_data["maxDepth"] == 2
+            return {"success": True, "id": "crawl-1234-uuid"}
+
+        client._request = _fake_request
+        result = client.crawl(url="http://example.com")
+        assert result["id"] == "crawl-1234-uuid"
+
+    def test_crawl_sends_include_paths(self, client):
+        """include_paths is passed as includePaths."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["includePaths"] == ["/blog/*", "/docs/*"]
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            include_paths=["/blog/*", "/docs/*"],
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_exclude_paths(self, client):
+        """exclude_paths is passed as excludePaths."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["excludePaths"] == ["/admin/*"]
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            exclude_paths=["/admin/*"],
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_max_pages(self, client):
+        """max_pages is passed as maxPages."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["maxPages"] == 5
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            max_pages=5,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_max_depth(self, client):
+        """max_depth is passed as maxDepth."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["maxDepth"] == 1
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            max_depth=1,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_ignore_query_parameters(self, client):
+        """ignore_query_parameters=True sends ignoreQueryParameters."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["ignoreQueryParameters"] is True
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            ignore_query_parameters=True,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_does_not_send_ignore_query_parameters_by_default(self, client):
+        """ignore_query_parameters=False does not send the field."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert "ignoreQueryParameters" not in json_data
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            ignore_query_parameters=False,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_does_not_send_max_pages_when_none(self, client):
+        """max_pages=None does not send maxPages."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert "maxPages" not in json_data
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            max_pages=None,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_both_limit_and_max_pages(self, client):
+        """Both limit and max_pages can be sent together."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["limit"] == 50
+            assert json_data["maxPages"] == 5
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            limit=50,
+            max_pages=5,
+        )
+        assert result["id"] == "job-1"
+
+
+# ── Connection error handling ────────────────────────────────────────────────
+
+
+class TestConnectionErrorHandling:
+    """Tests that connection errors produce clean messages without tracebacks."""
+
+    def test_connection_error_is_caught_and_clean(self, client):
+        """ConnectionError in _request raises ApiError with clean message."""
+        api_error_cls = _cli_ns["ApiError"]
+        with patch.object(
+            client,
+            "_request",
+            side_effect=api_error_cls(
+                "Cannot connect to http://test-server:8080: "
+                "ConnectionRefusedError(61, 'Connection refused')\n"
+                "  Is the server running? Set --server or GROKTOCRAWL_API_URL"
+            ),
+        ):
+            with pytest.raises(api_error_cls) as exc_info:
+                client.crawl(url="http://example.com")
+            msg = str(exc_info.value)
+            assert "Cannot connect" in msg
+            assert "Is the server running" in msg
+            assert "Traceback" not in msg
+
+    def test_cmd_crawl_connection_error_exits_nonzero(self):
+        """cmd_crawl exits non-zero with clean error message on connection error."""
+        api_error_cls = _cli_ns["ApiError"]
+        cmd_crawl = _cli_ns["cmd_crawl"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 50
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = None
+        mock_args.ignore_query_parameters = False
+        mock_args.no_poll = True
+        mock_args.dry_run = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.side_effect = api_error_cls(
+            "Cannot connect to http://localhost:8080: Connection refused"
+        )
+
+        stderr = _capture_stderr(cmd_crawl, mock_client, mock_args)
+        assert "Error:" in stderr
+        assert "Cannot connect" in stderr
+        assert "Traceback" not in stderr
+
+
+# ── cmd_crawl handler tests ──────────────────────────────────────────────────
+
+
+class TestCmdCrawl:
+    """Tests for the cmd_crawl() handler function."""
+
+    def test_cmd_crawl_sends_new_flags(self):
+        """cmd_crawl passes max_pages and ignore_query_parameters to client.crawl()."""
+        cmd_crawl = _cli_ns["cmd_crawl"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 50
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = 5
+        mock_args.ignore_query_parameters = True
+        mock_args.no_poll = True
+        mock_args.dry_run = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.return_value = {"success": True, "id": "job-1"}
+
+        # With no_poll=True, cmd_crawl returns normally after printing job ID
+        cmd_crawl(mock_client, mock_args)
+
+        mock_client.crawl.assert_called_once_with(
+            url="http://example.com",
+            limit=50,
+            max_depth=2,
+            include_paths=None,
+            exclude_paths=None,
+            max_pages=5,
+            ignore_query_parameters=True,
+        )
+
+    def test_cmd_crawl_json_output(self):
+        """cmd_crawl with JSON_OUTPUT produces valid JSON."""
+        cmd_crawl = _cli_ns["cmd_crawl"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 1
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = None
+        mock_args.ignore_query_parameters = False
+        mock_args.dry_run = False
+        mock_args.no_poll = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.return_value = {"success": True, "id": "job-json-test"}
+        mock_client.crawl_status.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "data": [
+                {"url": "http://example.com/page1", "markdown": "# Page 1"},
+                {"url": "http://example.com/page2", "markdown": "# Page 2"},
+            ],
+        }
+
+        original_json = _cli_ns["JSON_OUTPUT"]
+        _cli_ns["JSON_OUTPUT"] = True
+        try:
+            stdout = _capture_stdout(cmd_crawl, mock_client, mock_args)
+        finally:
+            _cli_ns["JSON_OUTPUT"] = original_json
+
+        output = stdout.strip()
+        # Output should be valid JSON
+        parsed = json.loads(output)
+        assert parsed["job_id"] == "job-json-test"
+        assert parsed["status"] == "completed"
+        assert len(parsed["pages"]) == 2
+
+    def test_cmd_crawl_polling_error_retry_limit(self):
+        """cmd_crawl exits after max polling errors."""
+        cmd_crawl = _cli_ns["cmd_crawl"]
+        api_error_cls = _cli_ns["ApiError"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 50
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = None
+        mock_args.ignore_query_parameters = False
+        mock_args.dry_run = False
+        mock_args.no_poll = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.return_value = {"success": True, "id": "job-poll-err"}
+        # All status checks fail
+        mock_client.crawl_status.side_effect = api_error_cls(
+            "Status check failed: connection lost"
+        )
+
+        stderr = _capture_stderr(cmd_crawl, mock_client, mock_args)
+        assert "Lost connection" in stderr
+        assert "Traceback" not in stderr
+
+
+def _capture_stdout(func, *args, **kwargs):
+    """Run func and capture stdout, returning the string."""
+    from contextlib import redirect_stdout, suppress
+    from io import StringIO
+
+    buf = StringIO()
+    with redirect_stdout(buf), suppress(SystemExit):
+        func(*args, **kwargs)
+    return buf.getvalue()
+
+
+def _capture_stderr(func, *args, **kwargs):
+    """Run func and capture stderr, returning the string."""
+    from contextlib import redirect_stderr, suppress
+    from io import StringIO
+
+    buf = StringIO()
+    with redirect_stderr(buf), suppress(SystemExit):
+        func(*args, **kwargs)
+    return buf.getvalue()
+
+
+# ── Parser / help text tests ─────────────────────────────────────────────────
+
+
+class TestCrawlParser:
+    """Tests for the crawl subcommand argument parser."""
+
+    def test_help_contains_crawl_flags(self):
+        """crawl --help lists all flags including new ones."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        stdout = StringIO()
+        with pytest.raises(SystemExit):
+            with redirect_stdout(stdout):
+                parser.parse_args(["crawl", "--help"])
+        help_text = stdout.getvalue()
+
+        # Existing flags
+        assert "--limit" in help_text
+        assert "--max-depth" in help_text
+        assert "--include-paths" in help_text
+        assert "--exclude-paths" in help_text
+        assert "--no-poll" in help_text
+
+        # New flags
+        assert "--max-pages" in help_text
+        assert "--ignore-query-params" in help_text
+
+    def test_parse_crawl_args_max_pages(self):
+        """--max-pages is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com", "--max-pages", "5"])
+        assert args.max_pages == 5
+
+    def test_parse_crawl_args_max_pages_default_none(self):
+        """--max-pages defaults to None."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com"])
+        assert args.max_pages is None
+
+    def test_parse_crawl_args_ignore_query_params(self):
+        """--ignore-query-params is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(
+            ["crawl", "http://example.com", "--ignore-query-params"]
+        )
+        assert args.ignore_query_parameters is True
+
+    def test_parse_crawl_args_ignore_query_params_default(self):
+        """--ignore-query-params defaults to False."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com"])
+        assert args.ignore_query_parameters is False
+
+    def test_parse_crawl_args_include_paths(self):
+        """--include-paths parses multiple path patterns."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(
+            [
+                "crawl",
+                "http://example.com",
+                "--include-paths",
+                "/blog/*",
+                "/docs/*",
+            ]
+        )
+        assert args.include_paths == ["/blog/*", "/docs/*"]
+
+    def test_parse_crawl_args_exclude_paths(self):
+        """--exclude-paths parses multiple path patterns."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(
+            [
+                "crawl",
+                "http://example.com",
+                "--exclude-paths",
+                "/admin/*",
+            ]
+        )
+        assert args.exclude_paths == ["/admin/*"]
+
+    def test_parse_crawl_args_max_depth(self):
+        """--max-depth is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com", "--max-depth", "1"])
+        assert args.max_depth == 1
+
+    def test_parse_crawl_args_limit(self):
+        """--limit is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com", "--limit", "10"])
+        assert args.limit == 10
+
+    def test_global_help_shows_crawl(self):
+        """Top-level --help lists the crawl subcommand."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        stdout = StringIO()
+        with pytest.raises(SystemExit):
+            with redirect_stdout(stdout):
+                parser.parse_args(["--help"])
+        help_text = stdout.getvalue()
+        assert "crawl" in help_text
+
+
+# ── Subprocess integration tests ──────────────────────────────────────────────
+
+
+class TestCLISubprocess:
+    """Integration tests that run the CLI as a subprocess."""
+
+    def test_help_shows_crawl_flags(self):
+        """Running groktocrawl crawl --help shows all flags."""
+        result = subprocess.run(
+            [sys.executable, _CLI_PATH, "crawl", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        # Old flags
+        assert "--limit" in result.stdout
+        assert "--max-depth" in result.stdout
+        assert "--include-paths" in result.stdout
+        assert "--exclude-paths" in result.stdout
+        assert "--no-poll" in result.stdout
+        # New flags
+        assert "--max-pages" in result.stdout
+        assert "--ignore-query-params" in result.stdout
+
+    def test_top_level_help_shows_crawl(self):
+        """Top-level --help lists crawl command."""
+        result = subprocess.run(
+            [sys.executable, _CLI_PATH, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "crawl" in result.stdout

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -616,13 +616,17 @@ class TestCrawlEngine:
 
     @pytest.mark.asyncio
     async def test_bfs_order(self, mock_scraper):
-        """Pages appear in BFS order: start URL, then depth-1, then depth-2."""
+        """Pages appear in BFS order: start URL, then depth-1, then depth-2.
+
+        Uses crawl_entire_domain=True so that non-child sibling/parent
+        links are followed (e.g., grandchild from child-a).
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
             mock_scraper,
             store=None,
-            options=CrawlOptions(max_pages=10, max_depth=2),
+            options=CrawlOptions(max_pages=10, max_depth=2, crawl_entire_domain=True),
         )
 
         async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
@@ -930,7 +934,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_include_paths_start_url_matches(self, mock_scraper):
-        """When start URL matches include_paths, it is crawled."""
+        """When start URL matches include_paths, it is crawled.
+
+        Uses crawl_entire_domain=True to follow sibling paths under
+        /blog/ from /blog/index.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -940,6 +948,7 @@ class TestPathFiltering:
                 max_pages=10,
                 max_depth=1,
                 include_paths=["/blog/*"],
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1001,7 +1010,10 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_include_paths_regex_mode(self, mock_scraper):
-        """include_paths with regex_on_full_url=True uses regex matching."""
+        """include_paths with regex_on_full_url=True uses regex matching.
+
+        Uses crawl_entire_domain=True to allow sibling paths to be followed.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1012,6 +1024,7 @@ class TestPathFiltering:
                 max_depth=1,
                 include_paths=["/section/page-[12]"],
                 regex_on_full_url=True,
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1107,7 +1120,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_exclude_overrides_include(self, mock_scraper):
-        """exclude_paths takes precedence over include_paths."""
+        """exclude_paths takes precedence over include_paths.
+
+        Uses crawl_entire_domain=True so sibling paths like /section/page-1
+        are followed from /section/index.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1118,6 +1135,7 @@ class TestPathFiltering:
                 max_depth=1,
                 include_paths=["/section/*"],
                 exclude_paths=["/section/page-2"],
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1192,7 +1210,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_glob_double_star_matches_any_depth(self, mock_scraper):
-        """Glob ** matches across directory boundaries."""
+        """Glob ** matches across directory boundaries.
+
+        Uses crawl_entire_domain=True so sibling paths like /blog/2024
+        are followed from /blog/index.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1202,6 +1224,7 @@ class TestPathFiltering:
                 max_pages=20,
                 max_depth=3,
                 include_paths=["/blog/**"],
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1230,7 +1253,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_regex_on_full_url_with_query_params(self, mock_scraper):
-        """regex_on_full_url matches against full URL including query params."""
+        """regex_on_full_url matches against full URL including query params.
+
+        Uses crawl_entire_domain=True so sibling paths are followed from
+        /start path.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1241,6 +1268,7 @@ class TestPathFiltering:
                 max_depth=1,
                 include_paths=[r"\?ref=partner"],
                 regex_on_full_url=True,
+                crawl_entire_domain=True,
             ),
         )
 
@@ -2032,3 +2060,597 @@ class TestCrawlEngineSitemap:
         assert "http://example.com/sitemap-page1" in urls
         assert "http://example.com/sitemap-page2" in urls
         assert "http://example.com/pricing" not in urls  # HTML link, not followed
+
+
+# ── Domain Scope Controls tests ─────────────────────────────────
+
+
+class TestDomainScopeControls:
+    """Tests for crawlEntireDomain, allowSubdomains, allowExternalLinks."""
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_false_only_child_paths(self, mock_scraper):
+        """When crawlEntireDomain is False (default), only child paths are followed.
+
+        /section/page → /section/page/deeper ✅, /other ❌, / ❌
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                crawl_entire_domain=False,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page/deeper">Deeper child</a>
+                <a href="http://example.com/other">Sibling/other</a>
+                <a href="http://example.com/">Root</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page")
+
+        # Start URL + deeper child = 2 pages
+        # Sibling (/other) and root (/) should not be followed
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page" in urls
+        assert "http://example.com/section/page/deeper" in urls
+        assert "http://example.com/other" not in urls
+        assert "http://example.com/" not in urls
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_true_follows_all_same_domain(self, mock_scraper):
+        """When crawlEntireDomain is True, sibling/parent links are followed.
+
+        /section/page → /other ✅, / ✅
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page/deeper">Deeper child</a>
+                <a href="http://example.com/other">Sibling/other</a>
+                <a href="http://example.com/">Root</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page")
+
+        # Start URL + deeper child + other + root = 4 pages
+        assert result.completed == 4
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page" in urls
+        assert "http://example.com/section/page/deeper" in urls
+        assert "http://example.com/other" in urls
+        assert "http://example.com/" in urls
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_root_start_identical(self, mock_scraper):
+        """When start URL is root, crawlEntireDomain=false and true produce identical results."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        for crawl_entire in (False, True):
+            engine = CrawlEngine(
+                mock_scraper,
+                store=None,
+                options=CrawlOptions(
+                    max_pages=10,
+                    max_depth=2,
+                    crawl_entire_domain=crawl_entire,
+                ),
+            )
+
+            async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+                return MockPage.success(url, f"# Content of {url}")
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    <a href="http://example.com/about">About</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+            # Both modes should find all children (everything is a child of root)
+            urls = [p["url"] for p in result.pages]
+            assert "http://example.com/" in urls
+            assert "http://example.com/pricing" in urls
+            assert "http://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_subdomains_false_blocks_subdomains(self, mock_scraper):
+        """When allowSubdomains is False (default), subdomain links are NOT followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_subdomains=False,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://docs.example.com/doc">Docs subdomain</a>
+                <a href="http://blog.example.com/post">Blog subdomain</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing = 2 pages (subdomains blocked)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://docs.example.com/doc" not in urls
+        assert "http://blog.example.com/post" not in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_subdomains_true_follows_subdomains(self, mock_scraper):
+        """When allowSubdomains is True, subdomain links ARE followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_subdomains=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://docs.example.com/doc">Docs subdomain</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing + docs subdomain = 3 pages
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://docs.example.com/doc" in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_external_links_false_blocks_external(self, mock_scraper):
+        """When allowExternalLinks is False (default), external links are NOT followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_external_links=False,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://other.com/page">External other</a>
+                <a href="http://another.org/path">External another</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing = 2 pages (external blocked)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://other.com/page" not in urls
+        assert "http://another.org/path" not in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_external_links_true_follows_external(self, mock_scraper):
+        """When allowExternalLinks is True, external domain links ARE followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_external_links=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://other.com/page">External other</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing + external = 3 pages
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://other.com/page" in urls
+
+    @pytest.mark.asyncio
+    async def test_ssrf_guard_blocks_private_hosts(self, mock_scraper):
+        """SSRF guard blocks private host URLs regardless of allow_external_links."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_external_links=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://127.0.0.1/secret">Loopback</a>
+                <a href="http://10.0.0.1/internal">RFC 1918 10.x</a>
+                <a href="http://192.168.1.1/admin">RFC 1918 192.168.x</a>
+                <a href="http://169.254.169.254/latest/meta-data/">Metadata IP</a>
+                <a href="http://localhost:6379/valkey">Localhost</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing = 2 pages (all private hosts blocked)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://127.0.0.1/secret" not in urls
+        assert "http://10.0.0.1/internal" not in urls
+        assert "http://192.168.1.1/admin" not in urls
+        assert "http://169.254.169.254/latest/meta-data/" not in urls
+        assert "http://localhost:6379/valkey" not in urls
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_plus_allow_subdomains(self, mock_scraper):
+        """crawlEntireDomain + allowSubdomains: follow sibling/parent on subdomains too."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=20,
+                max_depth=3,
+                crawl_entire_domain=True,
+                allow_subdomains=True,
+                allow_external_links=False,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://blog.example.com/post">Blog subdomain</a>
+                <a href="http://other.com/external">External</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page")
+
+        # Start URL + pricing + blog subdomain = 3 pages
+        # External should be excluded
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://blog.example.com/post" in urls
+        assert "http://other.com/external" not in urls
+
+    @pytest.mark.asyncio
+    async def test_external_pages_respect_max_pages(self, mock_scraper):
+        """External pages count toward max_pages limit."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=3,
+                max_depth=2,
+                allow_external_links=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://other.com/page1">External 1</a>
+                <a href="http://another.org/page2">External 2</a>
+                <a href="http://third.net/page3">External 3</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # max_pages=3: start URL + pricing + 1 external = 3
+        assert result.completed <= 3
+        assert len(result.pages) <= 3
+
+
+# ── CrawlRequest scope control field validation tests ───────────
+
+
+class TestCrawlRequestScopeControlValidation:
+    """Tests for CrawlRequest scope control field validation."""
+
+    def test_crawl_entire_domain_default_false(self):
+        """crawl_entire_domain defaults to False."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.crawl_entire_domain is False
+
+    def test_crawl_entire_domain_can_be_true(self):
+        """crawl_entire_domain can be set to True."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", crawl_entire_domain=True)
+        assert req.crawl_entire_domain is True
+
+    def test_allow_subdomains_default_false(self):
+        """allow_subdomains defaults to False."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.allow_subdomains is False
+
+    def test_allow_subdomains_can_be_true(self):
+        """allow_subdomains can be set to True."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", allow_subdomains=True)
+        assert req.allow_subdomains is True
+
+    def test_allow_external_links_default_false(self):
+        """allow_external_links defaults to False."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.allow_external_links is False
+
+    def test_allow_external_links_can_be_true(self):
+        """allow_external_links can be set to True."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", allow_external_links=True)
+        assert req.allow_external_links is True
+
+    def test_crawl_entire_domain_coerces_from_string(self):
+        """crawl_entire_domain with truthy string is coerced to True (Pydantic default)."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", crawl_entire_domain="yes")
+        assert req.crawl_entire_domain is True
+
+
+# ── _filter_child_paths unit tests ──────────────────────────────
+
+
+class TestFilterChildPaths:
+    """Tests for the CrawlEngine._filter_child_paths static method."""
+
+    def test_keeps_child_paths(self):
+        """Links that are children of the current URL path are kept."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/section/page/deeper",
+            "http://example.com/section/page/child",
+            "http://example.com/section/page/deep/est",
+        ]
+        result = CrawlEngine._filter_child_paths(
+            links, "http://example.com/section/page"
+        )
+        assert len(result) == 3
+
+    def test_filters_sibling_and_parent(self):
+        """Links to sibling or parent paths are filtered out."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/section/other",  # sibling
+            "http://example.com/section",  # parent
+            "http://example.com/",  # grandparent
+            "http://example.com/section/page/deeper",  # child (kept)
+        ]
+        result = CrawlEngine._filter_child_paths(
+            links, "http://example.com/section/page"
+        )
+        assert len(result) == 1
+        assert "http://example.com/section/page/deeper" in result
+
+    def test_keeps_different_domain_links(self):
+        """Links on different domains are kept regardless of path."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://docs.example.com/other",  # subdomain
+            "http://external.com/anything",  # external
+        ]
+        result = CrawlEngine._filter_child_paths(
+            links, "http://example.com/section/page"
+        )
+        # Different domains always pass through
+        assert len(result) == 2
+
+    def test_current_url_with_trailing_slash(self):
+        """Works correctly when current_url has a trailing slash.
+
+        Both /section/child and /section/other are children of /section/.
+        """
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/section/child",  # child (kept)
+            "http://example.com/section/other",  # also child (kept)
+            "http://example.com/section",  # parent (filtered)
+        ]
+        result = CrawlEngine._filter_child_paths(links, "http://example.com/section/")
+        assert len(result) == 2
+        assert "http://example.com/section/child" in result
+        assert "http://example.com/section/other" in result
+        assert "http://example.com/section" not in result
+
+    def test_empty_links_returns_empty(self):
+        """Empty links list returns empty list."""
+        from agent.crawler import CrawlEngine
+
+        result = CrawlEngine._filter_child_paths([], "http://example.com/page")
+        assert result == []
+
+
+# ── _filter_ssrf_blocked unit tests ─────────────────────────────
+
+
+class TestFilterSsrfBlocked:
+    """Tests for the CrawlEngine._filter_ssrf_blocked static method."""
+
+    def test_allows_public_hosts(self):
+        """Public hosts are allowed through."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/page",
+            "http://google.com/search",
+            "https://github.com/repo",
+        ]
+        result = CrawlEngine._filter_ssrf_blocked(links)
+        assert len(result) == 3
+
+    def test_blocks_private_ips(self):
+        """Private IP addresses are blocked."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/page",  # allowed
+            "http://127.0.0.1/secret",  # loopback
+            "http://10.0.0.1/internal",  # RFC 1918 10.x
+            "http://192.168.1.1/admin",  # RFC 1918 192.168.x
+        ]
+        result = CrawlEngine._filter_ssrf_blocked(links)
+        assert len(result) == 1
+        assert "http://example.com/page" in result
+
+    def test_blocks_localhost_hostname(self):
+        """Localhost hostname is blocked."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://localhost:6379/valkey",
+            "http://example.com/page",
+        ]
+        result = CrawlEngine._filter_ssrf_blocked(links)
+        assert len(result) == 1
+        assert "http://example.com/page" in result
+
+    def test_empty_links(self):
+        """Empty links list returns empty list."""
+        from agent.crawler import CrawlEngine
+
+        result = CrawlEngine._filter_ssrf_blocked([])
+        assert result == []

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -270,8 +270,9 @@ def mock_scraper():
 
 @pytest.fixture
 def mock_store():
-    """Create a mock JobStore."""
+    """Create a mock JobStore with a mock Redis client."""
     store = MagicMock()
+    store.redis = MagicMock()
     store.complete_job = MagicMock()
     return store
 
@@ -728,8 +729,8 @@ class TestCrawlEngine:
         result = await engine.run("http://example.com/", job_id="test-job-123")
 
         assert result.completed == 1
-        # complete_job should have been called at least once (final update)
-        assert mock_store.complete_job.call_count >= 1
+        # redis.set should have been called at least once (final update)
+        assert mock_store.redis.set.call_count >= 1
 
     @pytest.mark.asyncio
     async def test_crawl_with_include_paths(self, mock_scraper):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,921 @@
+"""Unit tests for the CrawlEngine in agent-svc/agent/crawler.py.
+
+Covers:
+- URL normalization (fragments, trailing slash, ignore_query_parameters)
+- Path filtering (glob and regex)
+- Glob-to-regex conversion
+- CrawlEngine BFS traversal
+- max_pages and max_depth enforcement
+- URL dedup within a crawl run
+- Start URL failure handling
+- Child page error handling
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── normalize_url tests ──────────────────────────────────────────
+
+
+class TestNormalizeUrl:
+    """Tests for the ``normalize_url()`` function."""
+
+    def test_strips_fragment(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com/page#section")
+            == "https://example.com/page"
+        )
+
+    def test_lowercases_scheme(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("HTTPS://EXAMPLE.COM/PAGE") == "https://example.com/PAGE"
+
+    def test_lowercases_host(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("https://Example.COM/Page") == "https://example.com/Page"
+
+    def test_removes_default_http_port(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("http://example.com:80/page") == "http://example.com/page"
+
+    def test_removes_default_https_port(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com:443/page") == "https://example.com/page"
+        )
+
+    def test_keeps_non_default_port(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com:8080/page")
+            == "https://example.com:8080/page"
+        )
+
+    def test_normalizes_trailing_slash(self):
+        from agent.crawler import normalize_url
+
+        # Non-root paths with trailing slash -> no trailing slash
+        assert normalize_url("https://example.com/page/") == "https://example.com/page"
+        assert normalize_url("https://example.com/page") == "https://example.com/page"
+
+    def test_keeps_root_slash(self):
+        from agent.crawler import normalize_url
+
+        # Root path / should stay as /
+        assert normalize_url("https://example.com/") == "https://example.com/"
+
+    def test_normalizes_dot_path(self):
+        from agent.crawler import normalize_url
+
+        # /. should collapse to /
+        assert normalize_url("https://example.com/.") == "https://example.com/"
+        assert normalize_url("https://example.com/a/./b") == "https://example.com/a/b"
+
+    def test_ignore_query_parameters_strips_query(self):
+        from agent.crawler import normalize_url
+
+        result = normalize_url(
+            "https://example.com/page?a=1&b=2", ignore_query_parameters=True
+        )
+        assert result == "https://example.com/page"
+
+    def test_ignore_query_parameters_default_false_keeps_query(self):
+        from agent.crawler import normalize_url
+
+        result = normalize_url("https://example.com/page?a=1&b=2")
+        assert "a=1" in result
+        assert "b=2" in result
+
+    def test_sorts_query_parameters(self):
+        from agent.crawler import normalize_url
+
+        # Different order but same params -> same result
+        r1 = normalize_url("https://example.com/page?b=2&a=1")
+        r2 = normalize_url("https://example.com/page?a=1&b=2")
+        assert r1 == r2
+        assert "a=1" in r1
+        assert "b=2" in r1
+
+    def test_fragment_and_query_stripped_together(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com/page?a=1#section")
+            == "https://example.com/page?a=1"
+        )
+
+
+# ── Glob-to-regex tests ──────────────────────────────────────────
+
+
+class TestGlobToRegex:
+    """Tests for the ``_glob_to_regex()`` helper."""
+
+    def test_literal_string(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/about")
+        assert re.search(pattern, "/about")
+        assert not re.search(pattern, "/aboutus")
+
+    def test_single_star(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/section/*")
+        assert re.search(pattern, "/section/page-1")
+        assert re.search(pattern, "/section/foo")
+        assert not re.search(pattern, "/section/sub/page")
+
+    def test_double_star(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/section/**")
+        assert re.search(pattern, "/section/page-1")
+        assert re.search(pattern, "/section/sub/page")
+        assert not re.search(pattern, "/other")
+
+    def test_question_mark(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/page-?")
+        assert re.search(pattern, "/page-1")
+        assert re.search(pattern, "/page-a")
+        assert not re.search(pattern, "/page-12")
+
+    def test_special_chars_escaped(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/file.html")
+        assert re.search(pattern, "/file.html")
+        assert not re.search(pattern, "/fileXhtml")
+
+
+# ── Path matching tests ─────────────────────────────────────────
+
+
+class TestMatchPath:
+    """Tests for the ``_match_path()`` function."""
+
+    def test_no_filters_passes(self):
+        from agent.crawler import _match_path
+
+        assert _match_path("https://example.com/page", None, None) is True
+
+    def test_include_paths_matches(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-1",
+                ["/section/*"],
+                None,
+            )
+            is True
+        )
+
+    def test_include_paths_no_match(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/about",
+                ["/section/*"],
+                None,
+            )
+            is False
+        )
+
+    def test_exclude_paths_excludes(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/admin/secret",
+                None,
+                ["/admin/*"],
+            )
+            is False
+        )
+
+    def test_exclude_overrides_include(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-2",
+                ["/section/*"],
+                ["/section/page-2"],
+            )
+            is False
+        )
+
+    def test_regex_mode_on_full_url(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-1?ref=abc",
+                ["section/page-[12]"],
+                None,
+                regex_on_full_url=True,
+            )
+            is True
+        )
+
+    def test_regex_mode_no_match(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-3",
+                ["section/page-[12]"],
+                None,
+                regex_on_full_url=True,
+            )
+            is False
+        )
+
+
+# ── CrawlEngine tests ────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_scraper():
+    """Create a mock ScraperClient that returns successful results."""
+    client = MagicMock()
+    client.scrape = AsyncMock()
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_store():
+    """Create a mock JobStore."""
+    store = MagicMock()
+    store.complete_job = MagicMock()
+    return store
+
+
+class MockPage:
+    """Helper to create a mock scrape result for a given URL."""
+
+    @staticmethod
+    def success(
+        url: str, markdown: str = "# Page Content", html: str | None = None
+    ) -> dict:
+        return {
+            "success": True,
+            "data": {
+                "markdown": markdown,
+                "source": "playwright",
+                "metadata": {"title": "Test Page"},
+            },
+        }
+
+    @staticmethod
+    def failure(url: str, error: str = "Scrape failed") -> dict:
+        return {"success": False, "error": error}
+
+
+class TestCrawlEngine:
+    """Tests for the CrawlEngine BFS crawl loop."""
+
+    @pytest.mark.asyncio
+    async def test_single_page_crawl(self, mock_scraper, mock_store):
+        """A crawl with max_pages=1 returns just the start URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape.return_value = MockPage.success("http://example.com/")
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.total >= 1
+        assert len(result.pages) == 1
+        assert result.pages[0]["url"] == "http://example.com/"
+        assert result.errors == []
+
+    @pytest.mark.asyncio
+    async def test_max_pages_enforcement(self, mock_scraper):
+        """Crawl stops after max_pages pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Mock scraper to always succeed
+        mock_scraper.scrape.return_value = MockPage.success("http://example.com/page")
+        mock_scraper.scrape.side_effect = None  # reset
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=3, max_depth=2),
+        )
+
+        # We need a link-rich start page. Mock the HTML fetch too.
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="/page1">Page 1</a>
+                <a href="/page2">Page 2</a>
+                <a href="/page3">Page 3</a>
+                </body></html>
+            """
+
+            # Set up scraper to return appropriate markdown per URL
+            async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+                return MockPage.success(url, f"# Content of {url}")
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 3
+        assert len(result.pages) == 3
+        # Should have the start URL and 2 children (due to max_pages=3)
+
+    @pytest.mark.asyncio
+    async def test_max_depth_0(self, mock_scraper):
+        """max_depth=0 scrapes only the start URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=0),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="/pricing">Pricing</a>
+                <a href="/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert len(result.pages) == 1
+        assert result.pages[0]["url"] == "http://example.com/"
+
+    @pytest.mark.asyncio
+    async def test_max_depth_1(self, mock_scraper):
+        """max_depth=1 scrapes start URL and direct children."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/contact">Contact</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + 3 children = 4 pages
+        assert result.completed == 4
+        assert len(result.pages) == 4
+
+        # Verify BFS order: start URL first, then children
+        assert result.pages[0]["url"] == "http://example.com/"
+
+    @pytest.mark.asyncio
+    async def test_url_dedup(self, mock_scraper):
+        """No duplicate URLs within a single crawl run."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Start page has duplicate links to the same page
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/pricing">Pricing (again)</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/pricing#section">Pricing with fragment</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + pricing + about = 3 unique pages
+        # (pricing appears 3 times in links but should be scraped once)
+        urls = [p["url"] for p in result.pages]
+        assert len(urls) == len(set(urls)), f"Duplicate URLs found: {urls}"
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_fragment_stripped_dedup(self, mock_scraper):
+        """Links /page#a and /page#b normalize to same URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/about#section1">About 1</a>
+                <a href="http://example.com/about#section2">About 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + about = 2 pages (fragments collapsed)
+        assert result.completed == 2
+        about_pages = [p for p in result.pages if "about" in p["url"]]
+        assert len(about_pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_normalization(self, mock_scraper):
+        """/pricing and /pricing/ are treated as the same URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/pricing/">Pricing with slash</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + pricing = 2 pages (trailing slash collapsed)
+        assert result.completed == 2
+        pricing_pages = [p for p in result.pages if "pricing" in p["url"]]
+        assert len(pricing_pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_ignore_query_parameters_collapses_variants(self, mock_scraper):
+        """When ignore_query_parameters=True, query variants collapse."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                ignore_query_parameters=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page?a=1">Page a=1</a>
+                <a href="http://example.com/page?b=2">Page b=2</a>
+                <a href="http://example.com/page">Page no query</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # With ignore_query_parameters, /page?a=1, /page?b=2, /page all collapse
+        # to /page. So we should have start URL + page = 2 pages
+        assert result.completed == 2
+        page_entries = [p for p in result.pages if "page" in p["url"]]
+        assert len(page_entries) == 1
+
+    @pytest.mark.asyncio
+    async def test_child_scrape_failure_collected(self, mock_scraper):
+        """Child page scrape failures are collected, not fatal."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            if "fail" in url:
+                return MockPage.failure(url, "Connection refused")
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good">Good page</a>
+                <a href="http://example.com/fail">Failing page</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + good page = 2 successful scrapes
+        assert result.completed == 2
+        assert len(result.pages) == 2
+        # One error for the failing page
+        assert len(result.errors) == 1
+        assert "fail" in result.errors[0]["url"]
+        assert result.errors[0]["error"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_start_url_failure_returns_immediately(self, mock_scraper):
+        """Start URL failure returns error immediately."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.failure("http://example.com/", "Connection refused")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert result.pages == []
+        assert len(result.errors) == 1
+        assert result.errors[0]["url"] == "http://example.com/"
+        assert result.errors[0]["error"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_bfs_order(self, mock_scraper):
+        """Pages appear in BFS order: start URL, then depth-1, then depth-2."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Track which HTML is returned for each URL to simulate link structure
+        html_responses = {
+            "http://example.com/": """
+                <html><body>
+                <a href="http://example.com/child-a">Child A</a>
+                <a href="http://example.com/child-b">Child B</a>
+                </body></html>
+            """,
+            "http://example.com/child-a": """
+                <html><body>
+                <a href="http://example.com/grandchild">Grandchild</a>
+                </body></html>
+            """,
+            "http://example.com/child-b": """
+                <html><body>
+                <p>No links here</p>
+                </body></html>
+            """,
+        }
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.side_effect = lambda url: html_responses.get(url)
+
+            result = await engine.run("http://example.com/")
+
+        # Expected BFS order:
+        # [start, child-a, child-b, grandchild]
+        assert len(result.pages) == 4
+        assert result.pages[0]["url"] == "http://example.com/"
+        assert result.pages[1]["url"] == "http://example.com/child-a"
+        assert result.pages[2]["url"] == "http://example.com/child-b"
+        assert result.pages[3]["url"] == "http://example.com/grandchild"
+
+    @pytest.mark.asyncio
+    async def test_empty_site_no_links(self, mock_scraper):
+        """A page with no outgoing links returns only the start page."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", "No links here")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert len(result.pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_pages_larger_than_available(self, mock_scraper):
+        """When max_pages > available pages, crawl completes when queue is empty."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", "Just one page")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=100, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_job_store_updates(self, mock_scraper, mock_store):
+        """Job store is updated with progress during crawl."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+        # Use short update interval for testing
+        engine._update_interval = 0.01
+
+        result = await engine.run("http://example.com/", job_id="test-job-123")
+
+        assert result.completed == 1
+        # complete_job should have been called at least once (final update)
+        assert mock_store.complete_job.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_include_paths(self, mock_scraper):
+        """Only URLs matching include_paths are crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/section/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Section 1</a>
+                <a href="http://example.com/section/page-2">Section 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL doesn't match /section/*, so only section pages are crawled
+        # But start URL is included since include_paths only filters child discovery
+        # actually... wait, let me re-examine the logic.
+
+        # The current code checks self._should_crawl before scraping, which
+        # includes a call to _match_path. But the start URL is the first URL
+        # and should also be checked against include_paths.
+
+        # Looking at the architecture.md:
+        # "Path filters apply to all URLs including the start URL — if start URL
+        # doesn't match include_paths, crawl returns 0 pages"
+
+        # Wait, but my current implementation checks _match_path AFTER adding to seen
+        # but BEFORE scraping... Actually, looking at my crawl loop:
+
+        # 1. Pop from queue
+        # 2. Normalize
+        # 3. Check dedup - skip if seen
+        # 4. Check max_depth - skip if too deep (but depth=0 is fine)
+        # 5. Add to seen
+        # 6. Check path filters - if not match, continue
+        # 7. Scrape
+        # 8. Extract links if depth < max_depth
+
+        # So the start URL IS checked against include_paths. If it doesn't match,
+        # it's skipped. That means the start URL would need to match include_paths
+        # to be crawled.
+
+        # For this test, let's check that "/section/*" doesn't match "/about"
+        about_pages = [p for p in result.pages if "about" in p["url"]]
+        assert len(about_pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_exclude_paths(self, mock_scraper):
+        """URLs matching exclude_paths are skipped."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=["/admin/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/admin/secret">Admin</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing + about = 3 pages, admin excluded
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/admin/secret" not in urls
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_markdown_handled_gracefully(self, mock_scraper):
+        """A page with empty markdown is still included."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", markdown="")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.pages[0]["markdown"] == ""
+
+    @pytest.mark.asyncio
+    async def test_cancel_flag_stops_crawl(self, mock_scraper):
+        """Setting cancel flag stops the crawl loop."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            # Cancel after the first page is scraped
+            original_scrape = mock_scraper.scrape
+
+            async def scrape_with_cancel(url: str, force_browser: bool = False) -> dict:
+                result = await original_scrape(url, force_browser)
+                engine.cancel()
+                return result
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_with_cancel)
+
+            result = await engine.run("http://example.com/")
+
+        # Should have at least 1 page (start URL was scraped before cancel)
+        assert result.completed >= 1
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_self_referencing_links(self, mock_scraper):
+        """Self-referencing links don't cause infinite loops."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            # Page links to itself and to a child
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/">Self link</a>
+                <a href="http://example.com/.">Self link dot</a>
+                <a href="http://example.com/page1">Page 1</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should complete without infinite loop
+        # Start URL + page1 = 2 pages
+        assert result.completed == 2

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1555,6 +1555,43 @@ class TestCrawlRequestValidation:
         req = CrawlRequest(url="http://example.com")
         assert req.max_pages == 10
 
+    def test_sitemap_default_is_include(self):
+        """Default sitemap mode is 'include'."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.sitemap == "include"
+
+    def test_sitemap_skip_accepted(self):
+        """sitemap='skip' is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", sitemap="skip")
+        assert req.sitemap == "skip"
+
+    def test_sitemap_only_accepted(self):
+        """sitemap='only' is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", sitemap="only")
+        assert req.sitemap == "only"
+
+    def test_sitemap_invalid_rejected(self):
+        """Invalid sitemap mode returns validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="sitemap"):
+            CrawlRequest(url="http://example.com", sitemap="banana")
+
+    def test_ignore_sitemap_true_maps_to_skip(self):
+        """ignore_sitemap=true maps to sitemap='skip' for backward compatibility."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", ignore_sitemap=True)
+        assert req.sitemap == "skip"
+        assert req.ignore_sitemap is True
+
 
 # ── Store tests ──────────────────────────────────────────────────
 
@@ -1706,3 +1743,292 @@ class TestPerPageMetadata:
         assert page["content_type"] == "text/html"  # default
         assert page["scraped_at"] is not None
         assert isinstance(page["duration_ms"], int)
+
+
+# ── Sitemap integration tests ────────────────────────────────────
+
+
+class TestCrawlEngineSitemap:
+    """Tests for sitemap integration in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_sitemap_include_seeds_urls(self, mock_scraper):
+        """sitemap_mode='include' seeds sitemap URLs into the BFS queue."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Mock sitemap fetch to return some URLs
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+            ]
+
+            # Mock HTML fetch to simulate no HTML link discovery
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """<html><body><p>No links</p></body></html>"""
+
+                result = await engine.run("http://example.com/")
+
+        # Should have start URL + 2 sitemap URLs = 3 pages
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/sitemap-page1" in urls
+        assert "http://example.com/sitemap-page2" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_skip_no_fetch(self, mock_scraper):
+        """sitemap_mode='skip' does NOT fetch sitemaps."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="skip",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    <a href="http://example.com/about">About</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+        # Should NOT have sitemap URLs
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/sitemap-page1" not in urls
+        assert "http://example.com/sitemap-page2" not in urls
+        # Should still discover HTML links
+        assert "http://example.com/pricing" in urls
+        assert "http://example.com/about" in urls
+        # _fetch_sitemap_urls should NOT have been called
+        mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sitemap_only_exclusive(self, mock_scraper):
+        """sitemap_mode='only' crawls exclusively sitemap URLs, no HTML link discovery."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                sitemap_mode="only",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-only-page1",
+                "http://example.com/sitemap-only-page2",
+            ]
+
+            with patch.object(engine, "_get_html"):
+                result = await engine.run("http://example.com/")
+
+        # Should have start URL + 2 sitemap URLs
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/sitemap-only-page1" in urls
+        assert "http://example.com/sitemap-only-page2" in urls
+        # No extra pages from HTML link discovery
+        assert len(urls) == 3
+
+    @pytest.mark.asyncio
+    async def test_sitemap_urls_respect_max_pages(self, mock_scraper):
+        """Sitemap URLs are counted toward max_pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=2,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+                "http://example.com/sitemap-page3",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """<html><body><p>No links</p></body></html>"""
+
+                result = await engine.run("http://example.com/")
+
+        # max_pages=2 should give us exactly 2 pages
+        assert result.completed == 2
+        assert len(result.pages) == 2
+
+    @pytest.mark.asyncio
+    async def test_sitemap_dedup_against_start_url(self, mock_scraper):
+        """Sitemap URLs that match the start URL are deduplicated."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            # Sitemap contains the start URL
+            mock_fetch.return_value = [
+                "http://example.com/",
+                "http://example.com/about",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """<html><body><p>No links</p></body></html>"""
+
+                result = await engine.run("http://example.com/")
+
+        # Should have start URL + about = 2 pages (start URL deduplicated)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert len(urls) == 2
+        assert "http://example.com/" in urls
+        assert "http://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_fetch_failure_falls_back(self, mock_scraper):
+        """When sitemap fetch fails, crawl falls back to HTML-only discovery."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Simulate sitemap fetch failure
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.side_effect = Exception("Sitemap fetch failed")
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    <a href="http://example.com/about">About</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+        # Should fall back to HTML discovery
+        assert result.completed >= 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/pricing" in urls
+        assert "http://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_only_with_max_depth_zero(self, mock_scraper):
+        """sitemap='only' with max_depth=0 still scrapes sitemap URLs (they are depth 0)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=0,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+        # Should scrape start URL + sitemap URLs (all depth 0)
+        # But NOT follow HTML links (max_depth=0)
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/sitemap-page1" in urls
+        assert "http://example.com/sitemap-page2" in urls
+        assert "http://example.com/pricing" not in urls  # HTML link, not followed

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -920,3 +920,526 @@ class TestCrawlEngine:
         # Should complete without infinite loop
         # Start URL + page1 = 2 pages
         assert result.completed == 2
+
+
+# ── Path filtering tests ────────────────────────────────────────
+
+
+class TestPathFiltering:
+    """Tests for path filtering in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_include_paths_start_url_matches(self, mock_scraper):
+        """When start URL matches include_paths, it is crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/blog/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/blog/post1">Blog Post 1</a>
+                <a href="http://example.com/blog/post2">Blog Post 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/blog/index")
+
+        # Start URL matches /blog/*, children under /blog/ are included
+        assert result.completed >= 2  # start + at least one blog child
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/blog/index" in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_include_paths_start_url_no_match_returns_zero(self, mock_scraper):
+        """When start URL doesn't match include_paths, 0 pages are crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/section/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Section 1</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL / doesn't match /section/* so it's skipped
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_include_paths_regex_mode(self, mock_scraper):
+        """include_paths with regex_on_full_url=True uses regex matching."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/page-[12]"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/section/page-3">Page 3</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page-1")
+
+        # Start URL /section/page-1 should match /section/page-[12]
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" in urls
+        assert "http://example.com/section/page-3" not in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_include_paths_empty_is_identity(self, mock_scraper):
+        """Empty include_paths list means 'include all' (identity)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # All URLs should pass (identity filter)
+        assert result.completed >= 2
+
+    @pytest.mark.asyncio
+    async def test_exclude_paths_empty_is_identity(self, mock_scraper):
+        """Empty exclude_paths list means 'exclude none' (identity)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=[],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # All URLs should pass (identity filter)
+        assert result.completed >= 2
+
+    @pytest.mark.asyncio
+    async def test_exclude_overrides_include(self, mock_scraper):
+        """exclude_paths takes precedence over include_paths."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/*"],
+                exclude_paths=["/section/page-2"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/index")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" not in urls  # excluded
+        assert "http://example.com/about" not in urls  # not in include_paths
+
+    @pytest.mark.asyncio
+    async def test_exclude_all_returns_zero_pages(self, mock_scraper):
+        """exclude_paths matching everything returns 0 pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                exclude_paths=["/*"],
+            ),
+        )
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_include_nonexistent_returns_zero_pages(self, mock_scraper):
+        """include_paths that match nothing returns 0 pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/nonexistent/*"],
+            ),
+        )
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_glob_double_star_matches_any_depth(self, mock_scraper):
+        """Glob ** matches across directory boundaries."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=20,
+                max_depth=3,
+                include_paths=["/blog/**"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/blog/2024/01/post">Deep post</a>
+                <a href="http://example.com/blog/2024">Year index</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/blog/index")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/blog/index" in urls
+        # Deep paths under /blog/ should match /blog/**
+        assert "http://example.com/blog/2024" in urls
+        assert "http://example.com/blog/2024/01/post" in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_query_params(self, mock_scraper):
+        """regex_on_full_url matches against full URL including query params."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[r"\?ref=partner"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page?ref=partner">Partner link</a>
+                <a href="http://example.com/page?ref=other">Other link</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/start?ref=partner")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/page?ref=partner" in urls
+        assert "http://example.com/page?ref=other" not in urls
+
+    @pytest.mark.asyncio
+    async def test_verbose_tracks_filtered_out_urls(self, mock_scraper):
+        """Verbose mode collects URLs that were filtered out with reasons."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/*"],
+                exclude_paths=["/section/secret"],
+                verbose=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/secret">Secret</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL / doesn't match /section/* → should be filtered out
+        assert result.completed == 0
+        assert len(result.pages) == 0
+        if result.filtered_out:
+            # At least one filtered URL should be recorded
+            assert any(f["reason"] == "include_paths" for f in result.filtered_out)
+
+    @pytest.mark.asyncio
+    async def test_verbose_tracks_exclude_reason(self, mock_scraper):
+        """Verbose mode records exclude_paths as filter reason."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=["/admin/*"],
+                verbose=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/admin/secret">Admin</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed >= 2  # start URL + pricing
+        if result.filtered_out:
+            assert any(f["reason"] == "exclude_paths" for f in result.filtered_out), (
+                "Expected exclude_paths reason in filtered_out"
+            )
+
+    @pytest.mark.asyncio
+    async def test_glob_escapes_regex_special_chars(self, mock_scraper):
+        """Glob mode treats regex special chars as literals."""
+        from agent.crawler import _match_path
+
+        # In glob mode, '.' should be literal, not 'any char'
+        assert _match_path(
+            "http://example.com/file.html",
+            ["/file.html"],
+            None,
+            regex_on_full_url=False,
+        )
+        # Should NOT match fileXhtml when . is treated literally
+        assert not _match_path(
+            "http://example.com/fileXhtml",
+            ["/file.html"],
+            None,
+            regex_on_full_url=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_exclude_paths(self, mock_scraper):
+        """exclude_paths with regex_on_full_url=True uses regex matching."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=[r"/section/page-[23]"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/section/page-3">Page 3</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" not in urls
+        assert "http://example.com/section/page-3" not in urls
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_ignore_query_params(self, mock_scraper):
+        """ignoreQueryParameters strips query first, then regex applies to path.
+
+        Per VAL-SCOPE-073: when both regexOnFullURL and ignoreQueryParameters
+        are set, query string is stripped from the URL BEFORE regex matching.
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[r"/page$"],
+                regex_on_full_url=True,
+                ignore_query_parameters=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/other-page?ref=test">Other page with query</a>
+                <a href="http://example.com/pages">Pages (plural)</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/page")
+
+        # Start URL /page matches /page$ include pattern
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/page" in urls
+        # With ignore_query_parameters, /other-page?ref=test normalizes to /other-page
+        # and the filter_url (without query) matches /page$? No — /other-page doesn't end with /page
+        # So /other-page should be excluded by the path filter
+        assert "http://example.com/other-page" not in urls
+        # /pages should NOT match /page$ (because $ anchors to end)
+        assert "http://example.com/pages" not in urls

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1443,3 +1443,266 @@ class TestPathFiltering:
         assert "http://example.com/other-page" not in urls
         # /pages should NOT match /page$ (because $ anchors to end)
         assert "http://example.com/pages" not in urls
+
+
+# ── CrawlStatusResponse enhancement tests ────────────────────────
+
+
+class TestCrawlStatusResponseModel:
+    """Tests for CrawlStatusResponse model with new timestamp fields."""
+
+    def test_crawl_status_response_has_timestamp_fields(self):
+        """CrawlStatusResponse model includes created_at, completed_at, expires_at, duration."""
+        from agent.models import CrawlStatusResponse
+
+        # While processing (no completed_at, no duration)
+        resp = CrawlStatusResponse(
+            status="processing",
+            completed=0,
+            total=5,
+            created_at="2026-01-15T10:00:00+00:00",
+            expires_at="2026-01-16T10:00:00+00:00",
+        )
+        assert resp.created_at == "2026-01-15T10:00:00+00:00"
+        assert resp.expires_at == "2026-01-16T10:00:00+00:00"
+        assert resp.completed_at is None
+        assert resp.duration is None
+
+        # On completion (all four fields present)
+        resp2 = CrawlStatusResponse(
+            status="completed",
+            completed=5,
+            total=5,
+            created_at="2026-01-15T10:00:00+00:00",
+            completed_at="2026-01-15T10:00:05+00:00",
+            expires_at="2026-01-16T10:00:00+00:00",
+            duration=5000,
+        )
+        assert resp2.created_at is not None
+        assert resp2.completed_at is not None
+        assert resp2.expires_at is not None
+        assert resp2.duration == 5000
+        # Verify created_at < completed_at <= expires_at
+        assert resp2.created_at < resp2.completed_at <= resp2.expires_at
+
+    def test_crawl_status_response_defaults(self):
+        """CrawlStatusResponse defaults to processing state with no timestamp fields."""
+        from agent.models import CrawlStatusResponse
+
+        resp = CrawlStatusResponse()
+        assert resp.status == "processing"
+        assert resp.completed == 0
+        assert resp.total == 0
+        assert resp.created_at is None
+        assert resp.completed_at is None
+        assert resp.expires_at is None
+        assert resp.duration is None
+
+
+# ── CrawlRequest validation tests ────────────────────────────────
+
+
+class TestCrawlRequestValidation:
+    """Tests for CrawlRequest field validation."""
+
+    def test_max_pages_positive_accepts_valid(self):
+        """max_pages >= 1 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_pages=1)
+        assert req.max_pages == 1
+
+        req2 = CrawlRequest(url="http://example.com", max_pages=100)
+        assert req2.max_pages == 100
+
+    def test_max_pages_zero_rejected(self):
+        """max_pages=0 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_pages"):
+            CrawlRequest(url="http://example.com", max_pages=0)
+
+    def test_max_depth_non_negative_accepts_valid(self):
+        """max_depth >= 0 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_depth=0)
+        assert req.max_depth == 0
+
+        req2 = CrawlRequest(url="http://example.com", max_depth=5)
+        assert req2.max_depth == 5
+
+    def test_max_depth_negative_rejected(self):
+        """max_depth=-1 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_depth"):
+            CrawlRequest(url="http://example.com", max_depth=-1)
+
+    def test_max_depth_default_is_two(self):
+        """Default max_depth is 2."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.max_depth == 2
+
+    def test_max_pages_default_is_ten(self):
+        """Default max_pages is 10."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.max_pages == 10
+
+
+# ── Store tests ──────────────────────────────────────────────────
+
+
+class TestJobStoreExpiresAt:
+    """Tests for JobStore expires_at field."""
+
+    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    def test_create_job_includes_expires_at(self):
+        """JobStore.create_job sets expires_at in job metadata."""
+        from agent.store import JobStore
+
+        store = JobStore()
+        job_id = store.create_job(kind="crawl", payload={"url": "http://example.com"})
+        try:
+            meta_raw = store.redis.get(f"job:{job_id}:meta")
+            assert meta_raw is not None
+
+            import json
+
+            meta = json.loads(meta_raw)
+            assert "expires_at" in meta
+            assert meta["expires_at"] is not None
+            # expires_at should be a valid ISO 8601 string
+            from datetime import datetime
+
+            parsed = datetime.fromisoformat(meta["expires_at"])
+            assert parsed is not None
+
+            # expires_at should be ~24h after created_at
+            created = datetime.fromisoformat(meta["created_at"])
+            diff = parsed - created
+            assert 23 * 3600 <= diff.total_seconds() <= 25 * 3600  # ~24h window
+        finally:
+            store.redis.delete(f"job:{job_id}:meta")
+
+    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    def test_complete_job_sets_completed_at(self):
+        """JobStore.complete_job sets completed_at in metadata."""
+        from agent.store import JobStore
+
+        store = JobStore()
+        job_id = store.create_job(kind="crawl", payload={"url": "http://example.com"})
+        try:
+            store.complete_job(job_id, {"completed": 1, "total": 1})
+
+            meta_raw = store.redis.get(f"job:{job_id}:meta")
+            assert meta_raw is not None
+
+            import json
+
+            meta = json.loads(meta_raw)
+            assert "completed_at" in meta
+            assert meta["completed_at"] is not None
+            # completed_at should be a valid ISO 8601 string
+            from datetime import datetime
+
+            parsed = datetime.fromisoformat(meta["completed_at"])
+            assert parsed is not None
+            assert meta["status"] == "completed"
+        finally:
+            store.redis.delete(f"job:{job_id}:meta")
+            store.redis.delete(f"job:{job_id}:data")
+
+
+# ── Per-page metadata enrichment tests ──────────────────────────
+
+
+class TestPerPageMetadata:
+    """Tests for per-page metadata enrichment in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_page_includes_title_and_metadata(self, mock_scraper):
+        """Each page in crawl results includes title, metadata dict with title/description/source,
+        status_code, content_type, scraped_at, and duration_ms."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Mock scraper to return enriched data with metadata
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return {
+                "success": True,
+                "data": {
+                    "markdown": f"# Content of {url}",
+                    "source": "playwright",
+                    "metadata": {
+                        "title": "Test Page",
+                        "description": "A test page description",
+                        "sourceURL": url,
+                        "statusCode": 200,
+                        "content-type": "text/html",
+                    },
+                },
+            }
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=0),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert len(result.pages) == 1
+        page = result.pages[0]
+
+        # Verify metadata fields
+        assert page["url"] == "http://example.com/"
+        assert page["markdown"] == "# Content of http://example.com/"
+        assert page["title"] == "Test Page"
+        assert page["metadata"]["title"] == "Test Page"
+        assert page["metadata"]["description"] == "A test page description"
+        assert page["metadata"]["source"] == "playwright"
+        assert page["status_code"] == 200
+        assert page["content_type"] == "text/html"
+        assert page["scraped_at"] is not None
+        assert isinstance(page["duration_ms"], int)
+        assert page["duration_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_page_metadata_falls_back_gracefully(self, mock_scraper):
+        """When scraper returns minimal data, metadata fields fall back to defaults."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Minimal scraper response
+        mock_scraper.scrape = AsyncMock(
+            return_value={"success": True, "data": {"markdown": "Just text"}}
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=0),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert len(result.pages) == 1
+        page = result.pages[0]
+
+        assert page["url"] == "http://example.com/"
+        assert page["markdown"] == "Just text"
+        assert page["title"] == ""  # falls back to empty string
+        assert page["metadata"]["title"] == ""
+        assert page["metadata"]["description"] == ""
+        assert page["metadata"]["source"] == "unknown"
+        assert page["status_code"] == 200  # default
+        assert page["content_type"] == "text/html"  # default
+        assert page["scraped_at"] is not None
+        assert isinstance(page["duration_ms"], int)

--- a/tests/test_link_extractor.py
+++ b/tests/test_link_extractor.py
@@ -1,0 +1,407 @@
+"""Unit tests for the shared LinkExtractor module.
+
+Tests the ``extract_links()``, ``filter_links()``, and ``classify_links()``
+functions from ``agent-svc/agent/link_extractor.py`` without needing a
+running Docker stack.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Add agent-svc to sys.path so we can import the agent package directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agent-svc"))
+
+from agent.link_extractor import (
+    _is_subdomain,
+    _strip_fragment,
+    classify_links,
+    extract_links,
+    filter_links,
+)
+
+# ── extract_links() tests ──────────────────────────────────────────
+
+
+class TestExtractLinks:
+    """Tests for extract_links() — core link extraction."""
+
+    def test_basic_link_extraction(self):
+        """Should extract all <a href> links from simple HTML."""
+        html = """
+        <html>
+        <body>
+            <a href="/page1">Page 1</a>
+            <a href="/page2">Page 2</a>
+            <a href="/page3">Page 3</a>
+        </body>
+        </html>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 3
+        assert "https://example.com/page1" in links
+        assert "https://example.com/page2" in links
+        assert "https://example.com/page3" in links
+
+    def test_absolute_links_preserved(self):
+        """Should preserve already-absolute URLs unchanged."""
+        html = '<a href="https://other.com/page">Link</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://other.com/page" in links
+
+    def test_relative_urls_resolved(self):
+        """Should resolve relative hrefs against base_url (VAL-CRAWL-035)."""
+        html = '<a href="/about">About</a><a href="contact">Contact</a>'
+        links = extract_links(html, "https://example.com/sub/")
+        assert "https://example.com/about" in links
+        assert "https://example.com/sub/contact" in links
+
+    def test_fragment_stripped(self):
+        """Should strip fragment identifiers from extracted URLs (VAL-CRAWL-036)."""
+        html = '<a href="/about#team">Team</a><a href="/pricing#plans">Plans</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://example.com/about" in links
+        assert "https://example.com/pricing" in links
+        # No fragment-bearing URLs should be present
+        for link in links:
+            assert "#" not in link
+
+    def test_duplicates_deduplicated(self):
+        """Should deduplicate identical URLs (VAL-CRAWL-058)."""
+        html = """
+        <a href="/page">First</a>
+        <a href="/page">Second</a>
+        <a href="https://example.com/page">Third (absolute dup)</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/page"]
+
+    def test_fragment_variants_deduplicated(self):
+        """Fragment variants of same URL should resolve to same base URL."""
+        html = '<a href="/about#team">Team</a><a href="/about#history">History</a>'
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/about"]
+
+    def test_non_http_schemes_filtered(self):
+        """Should filter out mailto:, tel:, javascript:, ftp: (VAL-CRAWL-057)."""
+        html = """
+        <a href="mailto:user@example.com">Email</a>
+        <a href="tel:+1234567890">Call</a>
+        <a href="javascript:void(0)">JS</a>
+        <a href="ftp://files.example.com">FTP</a>
+        <a href="/valid-page">Valid</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/valid-page"]
+
+    def test_malformed_html_graceful(self):
+        """Malformed HTML should not crash — graceful degradation (VAL-CRAWL-056)."""
+        html = """<html><body><a href="/page1">Page1<a href="/page2">Page2"""
+        links = extract_links(html, "https://example.com")
+        assert len(links) >= 1
+
+    def test_completely_garbled_html(self):
+        """Completely garbled HTML should not crash."""
+        html = "not even close to valid html <<<<>>>> ### %% ^^^^"
+        links = extract_links(html, "https://example.com")
+        assert isinstance(links, list)
+
+    def test_empty_html(self):
+        """Empty HTML should return empty list."""
+        assert extract_links("", "https://example.com") == []
+
+    def test_none_html(self):
+        """None-like empty HTML should return empty list."""
+        assert extract_links("", "https://example.com") == []
+
+    def test_base_tag_respected(self):
+        """<base> tag should override base_url for relative resolution (VAL-CRAWL-074)."""
+        html = """
+        <html>
+        <head><base href="https://other.example.com/sub/"></head>
+        <body>
+            <a href="page">Relative to base</a>
+            <a href="/root">Root-relative</a>
+        </body>
+        </html>
+        """
+        links = extract_links(html, "https://example.com")
+        assert "https://other.example.com/sub/page" in links
+        assert "https://other.example.com/root" in links
+
+    def test_links_with_no_href_ignored(self):
+        """<a> tags without href attribute should be ignored."""
+        html = '<a>No href</a><a href="">Empty href</a><a href="/ok">OK</a>'
+        links = extract_links(html, "https://example.com")
+        assert links == ["https://example.com/ok"]
+
+    def test_trailing_whitespace_in_href(self):
+        """Href with leading/trailing whitespace should be trimmed."""
+        html = '<a href="  /page  ">Spaced</a>'
+        links = extract_links(html, "https://example.com")
+        assert links == ["https://example.com/page"]
+
+    def test_same_page_link_handled(self):
+        """A link to '#' should resolve to the base URL without fragment."""
+        html = '<a href="#">Top</a>'
+        links = extract_links(html, "https://example.com")
+        # urljoin("#", "https://example.com") returns "https://example.com"
+        assert links == ["https://example.com"]
+
+    def test_protocol_relative_url(self):
+        """Protocol-relative URLs (//example.com/path) should resolve correctly."""
+        html = '<a href="//cdn.example.com/file.js">CDN</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://cdn.example.com/file.js" in links
+
+    def test_multiple_nested_a_tags(self):
+        """Links nested in complex HTML structures should all be found."""
+        html = """
+        <div><ul><li><a href="/deep1">Deep</a></li></ul></div>
+        <p><span><a href="/deep2">Nested</a></span></p>
+        <a href="/top">Top</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 3
+        assert "https://example.com/deep1" in links
+        assert "https://example.com/deep2" in links
+        assert "https://example.com/top" in links
+
+    def test_no_links_in_html(self):
+        """HTML with no <a> tags should return empty list."""
+        html = "<html><body><p>No links here</p></body></html>"
+        assert extract_links(html, "https://example.com") == []
+
+
+# ── filter_links() tests ────────────────────────────────────────────
+
+
+class TestFilterLinks:
+    """Tests for filter_links() — scope-based filtering."""
+
+    def test_internal_links_included_by_default(self):
+        """Internal (same-domain) links should always be included."""
+        links = [
+            "https://example.com/page1",
+            "https://example.com/page2",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 2
+
+    def test_subdomain_excluded_by_default(self):
+        """Subdomain links should be excluded when allow_subdomains=False."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+    def test_subdomain_included_when_allowed(self):
+        """Subdomain links should be included when allow_subdomains=True."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+            "https://blog.example.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 3
+        assert "https://docs.example.com/page" in filtered
+
+    def test_external_excluded_by_default(self):
+        """External links should be excluded when allow_external_links=False."""
+        links = [
+            "https://example.com/page",
+            "https://other.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+    def test_external_included_when_allowed(self):
+        """External links should be included when allow_external_links=True."""
+        links = [
+            "https://example.com/page",
+            "https://other.com/page",
+            "https://another.org/path",
+        ]
+        filtered = filter_links(
+            links,
+            base_domain="example.com",
+            allow_external_links=True,
+        )
+        assert len(filtered) == 3
+        assert "https://other.com/page" in filtered
+
+    def test_subdomain_and_external_combined(self):
+        """Both subdomain and external flags should work together."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+            "https://other.com/page",
+        ]
+        filtered = filter_links(
+            links,
+            base_domain="example.com",
+            allow_subdomains=True,
+            allow_external_links=True,
+        )
+        assert len(filtered) == 3
+
+    def test_empty_links_list(self):
+        """Empty links list should return empty list."""
+        assert filter_links([], base_domain="example.com") == []
+
+    def test_no_base_domain(self):
+        """Without base_domain, all links should pass through."""
+        links = ["https://example.com/page", "https://other.com/page"]
+        filtered = filter_links(links)
+        assert len(filtered) == 2
+
+    def test_different_schemes_same_domain(self):
+        """HTTP and HTTPS on same domain should both be internal."""
+        links = [
+            "http://example.com/page1",
+            "https://example.com/page2",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 2
+
+    def test_subdomain_with_port(self):
+        """Subdomain with port should still be recognized as subdomain."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com:8080/page",
+        ]
+        # Without allow_subdomains
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+        # With allow_subdomains
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 2
+
+    def test_multi_level_subdomain(self):
+        """Multi-level subdomains should be recognized."""
+        links = ["https://deep.docs.example.com/page"]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 0
+
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 1
+
+
+# ── classify_links() tests ─────────────────────────────────────────
+
+
+class TestClassifyLinks:
+    """Tests for classify_links() — domain classification."""
+
+    def test_classify_internal(self):
+        """Same-domain URLs should be classified as internal."""
+        links = ["https://example.com/page", "https://example.com/about"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com/page" in result["internal"]
+        assert "https://example.com/about" in result["internal"]
+        assert result["subdomain"] == []
+        assert result["external"] == []
+
+    def test_classify_subdomain(self):
+        """Subdomain URLs should be classified as subdomain."""
+        links = ["https://docs.example.com/page", "https://blog.example.com/"]
+        result = classify_links(links, "https://example.com")
+        assert result["internal"] == []
+        assert "https://docs.example.com/page" in result["subdomain"]
+        assert "https://blog.example.com/" in result["subdomain"]
+        assert result["external"] == []
+
+    def test_classify_external(self):
+        """Different-domain URLs should be classified as external."""
+        links = ["https://other.com/page", "https://another.org/"]
+        result = classify_links(links, "https://example.com")
+        assert result["internal"] == []
+        assert result["subdomain"] == []
+        assert "https://other.com/page" in result["external"]
+
+    def test_classify_mixed(self):
+        """Mixed internal/subdomain/external URLs should be classified correctly."""
+        links = [
+            "https://example.com/internal",
+            "https://docs.example.com/subdomain",
+            "https://other.com/external",
+        ]
+        result = classify_links(links, "https://example.com")
+        assert len(result["internal"]) == 1
+        assert len(result["subdomain"]) == 1
+        assert len(result["external"]) == 1
+
+    def test_classify_with_port_difference(self):
+        """Port difference does not change internal classification."""
+        links = ["https://example.com:8080/page"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com:8080/page" in result["internal"]
+
+    def test_classify_with_path(self):
+        """URLs with paths are still classified by domain."""
+        links = ["https://example.com/sub/deep/page"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com/sub/deep/page" in result["internal"]
+
+    def test_classify_empty_links(self):
+        """Empty links should return all-empty categories."""
+        result = classify_links([], "https://example.com")
+        assert result == {"internal": [], "subdomain": [], "external": []}
+
+
+# ── Helper function tests ──────────────────────────────────────────
+
+
+class TestStripFragment:
+    """Tests for the _strip_fragment helper."""
+
+    def test_strips_fragment(self):
+        assert (
+            _strip_fragment("https://example.com/page#section")
+            == "https://example.com/page"
+        )
+
+    def test_no_fragment(self):
+        assert _strip_fragment("https://example.com/page") == "https://example.com/page"
+
+    def test_empty_url(self):
+        assert _strip_fragment("") == ""
+
+    def test_fragment_with_query(self):
+        assert (
+            _strip_fragment("https://example.com/page?a=1#section")
+            == "https://example.com/page?a=1"
+        )
+
+
+class TestIsSubdomain:
+    """Tests for the _is_subdomain helper."""
+
+    def test_subdomain(self):
+        assert _is_subdomain("docs.example.com", "example.com")
+
+    def test_same_domain(self):
+        assert not _is_subdomain("example.com", "example.com")
+
+    def test_different_domain(self):
+        assert not _is_subdomain("other.com", "example.com")
+
+    def test_multi_level_subdomain(self):
+        assert _is_subdomain("a.b.example.com", "example.com")
+
+    def test_not_subdomain_with_prefix(self):
+        """notexample.com is not a subdomain of example.com."""
+        assert not _is_subdomain("notexample.com", "example.com")
+
+    def test_case_insensitive(self):
+        assert _is_subdomain("DOCS.EXAMPLE.COM", "example.com")

--- a/tests/test_llmstxt_unit.py
+++ b/tests/test_llmstxt_unit.py
@@ -1,16 +1,20 @@
 """Unit tests for llmstxt.py pure functions.
 
-Tests the _extract_description() function directly without needing
-a running Docker stack. Run with: python3 -m pytest tests/test_llmstxt_unit.py -v
+Tests the _extract_description() and discover_pages() functions directly
+without needing a running Docker stack.
+Run with: python3 -m pytest tests/test_llmstxt_unit.py -v
 """
 
 import os
 import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 # Add the agent-svc directory to the path so we can import llmstxt
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agent-svc"))
 
-from agent.llmstxt import _extract_description
+from agent.llmstxt import _extract_description, discover_pages
 
 
 def test_ends_at_sentence_boundary():
@@ -115,3 +119,217 @@ def test_multi_sentence_content():
     assert "opening statement" in desc
     # Should end with a sentence-ending punctuation
     assert desc.rstrip()[-1] in ".!?"
+
+
+# ── discover_pages tests ──────────────────────────────────────────
+
+
+def _mock_html_page(
+    *,
+    internal_links: list[str] | None = None,
+    external_links: list[str] | None = None,
+    non_http_links: list[str] | None = None,
+) -> str:
+    """Build an HTML page with the given link lists for testing."""
+    links_html = ""
+    for link in internal_links or []:
+        links_html += f'<a href="{link}">internal</a>\n'
+    for link in external_links or []:
+        links_html += f'<a href="{link}">external</a>\n'
+    for link in non_http_links or []:
+        links_html += f'<a href="{link}">non-http</a>\n'
+    return f"<html><body>{links_html}</body></html>"
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_extracts_internal_links():
+    """discover_pages should extract same-host links from the page HTML."""
+    html = _mock_html_page(
+        internal_links=["/page1", "/page2", "/page3"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+    assert "http://example.com/page3" in result
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_excludes_external_links():
+    """discover_pages should exclude links to external domains."""
+    html = _mock_html_page(
+        internal_links=["/page1"],
+        external_links=["https://other.com/page"],
+        non_http_links=["mailto:test@example.com"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert "http://example.com/page1" in result
+    assert "https://other.com/page" not in result
+    assert "mailto:test@example.com" not in result
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_respects_max_pages():
+    """discover_pages should limit results to max_pages."""
+    html = _mock_html_page(
+        internal_links=[f"/page{i}" for i in range(20)],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=3)
+
+    assert len(result) == 3
+    # First 3 links should be returned
+    assert result[0] == "http://example.com/page0"
+    assert result[1] == "http://example.com/page1"
+    assert result[2] == "http://example.com/page2"
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_http_error_falls_back():
+    """discover_pages should return [url] when the server returns non-200."""
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 404
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_exception_falls_back():
+    """discover_pages should return [url] when an exception occurs during fetch."""
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = Exception("Connection error")
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_empty_results_falls_back():
+    """discover_pages should return [url] when no links are found."""
+    html = "<html><body><p>No links here</p></body></html>"
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_deduplicates_links():
+    """discover_pages should not return duplicate URLs."""
+    html = _mock_html_page(
+        internal_links=["/page1", "/page1", "/page2", "/page1"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert len(result) == 2
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_strips_fragments():
+    """discover_pages should strip fragment identifiers from URLs."""
+    html = _mock_html_page(
+        internal_links=["/page1#section1", "/page1#section2", "/page2"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    # Fragment-stripped URLs should be deduped — only one /page1 entry
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+    assert "#" not in str(result)
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_max_pages_larger_than_available():
+    """When max_pages exceeds available links, all links are returned."""
+    html = _mock_html_page(
+        internal_links=["/a", "/b"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=100)
+
+    assert len(result) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -203,6 +203,8 @@ class TestCrawlRequest:
         r = CrawlRequest(url="https://example.com")
         assert r.max_pages == 10
         assert r.max_depth == 2
+        assert r.regex_on_full_url is False
+        assert r.verbose is False
 
     def test_with_webhook(self):
         from agent.models import CrawlRequest
@@ -211,6 +213,70 @@ class TestCrawlRequest:
             url="https://x.com", webhook={"url": "https://hook.example.com"}
         )
         assert r.webhook["url"] == "https://hook.example.com"
+
+    def test_with_regex_on_full_url(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[r"/section/.*"],
+        )
+        assert r.regex_on_full_url is True
+        assert r.include_paths == [r"/section/.*"]
+
+    def test_invalid_regex_raises_validation_error(self):
+        from agent.models import CrawlRequest
+
+        with pytest.raises(ValidationError) as excinfo:
+            CrawlRequest(
+                url="https://example.com",
+                regex_on_full_url=True,
+                include_paths=["[unclosed"],
+            )
+        err = str(excinfo.value)
+        assert "include_paths" in err
+        assert "unclosed" in err.lower() or "invalid" in err.lower()
+
+    def test_invalid_regex_in_exclude_paths_raises_error(self):
+        from agent.models import CrawlRequest
+
+        with pytest.raises(ValidationError) as excinfo:
+            CrawlRequest(
+                url="https://example.com",
+                regex_on_full_url=True,
+                exclude_paths=[r"[\w+", r"/valid/\d+"],
+            )
+        err = str(excinfo.value)
+        assert "exclude_paths" in err
+
+    def test_valid_regex_passes_validation(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[r"/section/\d+", r"/blog/.*"],
+            exclude_paths=[r"/admin/.*"],
+        )
+        assert r.include_paths == [r"/section/\d+", r"/blog/.*"]
+        assert r.exclude_paths == [r"/admin/.*"]
+
+    def test_empty_include_paths_with_regex_is_valid(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[],
+        )
+        assert r.include_paths == []
+
+    def test_verbose_flag(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(url="https://example.com", verbose=True)
+        assert r.verbose is True
 
 
 class TestBatchScrapeRequest:

--- a/tests/test_sitemap_parser.py
+++ b/tests/test_sitemap_parser.py
@@ -1,0 +1,618 @@
+"""Unit tests for SitemapParser in agent-svc/agent/sitemap_parser.py.
+
+Covers:
+- Basic XML sitemap parsing (<urlset>)
+- Sitemap index file parsing (<sitemapindex>) with recursion
+- Gzipped sitemap decompression
+- Malformed XML handling
+- 404 / 5xx sitemap URL handling
+- Connection error handling
+- Common path fallback (robots.txt → /sitemap.xml)
+- robots.txt Sitemap directive discovery
+- Text sitemap detection (unsupported)
+- Empty sitemap handling
+- Non-HTTP URL filtering
+- get_urls with limit enforcement
+- Nested sitemap index depth limit
+"""
+
+from __future__ import annotations
+
+import gzip
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from agent.sitemap_parser import SitemapParser
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def xml_sitemap() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/about</loc></url>
+  <url><loc>https://example.com/pricing</loc></url>
+  <url><loc>https://example.com/blog/post-1</loc></url>
+  <url><loc>https://example.com/contact</loc></url>
+</urlset>"""
+
+
+@pytest.fixture
+def sitemap_index() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap2.xml</loc></sitemap>
+</sitemapindex>"""
+
+
+@pytest.fixture
+def child_sitemap1() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>"""
+
+
+@pytest.fixture
+def child_sitemap2() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page3</loc></url>
+  <url><loc>https://example.com/page4</loc></url>
+</urlset>"""
+
+
+@pytest.fixture
+def empty_sitemap() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</urlset>"""
+
+
+def _mock_response(
+    content: bytes | str,
+    status_code: int = 200,
+    content_type: str = "application/xml",
+    content_encoding: str | None = None,
+) -> AsyncMock:
+    """Create a mock httpx.Response."""
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    resp = AsyncMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.content = content
+    resp.headers = {"content-type": content_type}
+    if content_encoding:
+        resp.headers["content-encoding"] = content_encoding
+    return resp
+
+
+def _mock_gzipped_response(
+    xml: str,
+    status_code: int = 200,
+    content_type: str = "application/xml",
+) -> AsyncMock:
+    """Create a mock gzipped httpx.Response."""
+    compressed = gzip.compress(xml.encode("utf-8"))
+    return _mock_response(
+        compressed,
+        status_code=status_code,
+        content_type=content_type,
+        content_encoding="gzip",
+    )
+
+
+# ── Basic URL set parsing tests ─────────────────────────────────
+
+
+class TestParseUrlSet:
+    """Tests for parsing a basic <urlset> sitemap."""
+
+    @pytest.mark.asyncio
+    async def test_parse_basic_sitemap(self, xml_sitemap):
+        """A standard <urlset> sitemap is parsed correctly."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(xml_sitemap)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert len(urls) == 5
+        assert "https://example.com/" in urls
+        assert "https://example.com/about" in urls
+        assert "https://example.com/pricing" in urls
+        assert "https://example.com/blog/post-1" in urls
+        assert "https://example.com/contact" in urls
+
+    @pytest.mark.asyncio
+    async def test_parse_empty_sitemap(self, empty_sitemap):
+        """An empty <urlset> returns an empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(empty_sitemap)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_parse_malformed_xml(self):
+        """Malformed XML logs a warning and returns empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response("This is not XML at all")
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_parse_non_http_urls_filtered(self):
+        """Non-HTTP URLs in sitemaps are filtered out."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>ftp://files.example.com/file</loc></url>
+  <url><loc>mailto:admin@example.com</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>"""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(xml)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert len(urls) == 2
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+        assert "ftp://files.example.com/file" not in urls
+        assert "mailto:admin@example.com" not in urls
+
+
+# ── Sitemap index parsing tests ─────────────────────────────────
+
+
+class TestSitemapIndex:
+    """Tests for recursive sitemap index parsing."""
+
+    @pytest.mark.asyncio
+    async def test_parse_sitemap_index(
+        self, sitemap_index, child_sitemap1, child_sitemap2
+    ):
+        """A sitemap index file is recursively parsed."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "sitemap_index.xml" in url:
+                return _mock_response(sitemap_index)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            elif "sitemap2.xml" in url:
+                return _mock_response(child_sitemap2)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap_index.xml")
+
+        assert len(urls) == 4
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+        assert "https://example.com/page3" in urls
+        assert "https://example.com/page4" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_index_depth_limit(self, child_sitemap1, child_sitemap2):
+        """Deeply nested sitemap indexes are limited by max_recursion_depth."""
+        # Create index files that reference each other circularly
+        nested_index1 = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/nested2.xml</loc></sitemap>
+</sitemapindex>"""
+        nested_index2 = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+</sitemapindex>"""
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "nested1.xml" in url:
+                return _mock_response(nested_index1)
+            elif "nested2.xml" in url:
+                return _mock_response(nested_index2)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(
+            client=mock_client,
+            max_recursion_depth=1,
+        )
+        urls = await parser.parse_sitemap_url("https://example.com/nested1.xml")
+
+        # With max_recursion_depth=1, nested2.xml should be allowed
+        # but sitemap1.xml from nested2.xml should exceed depth limit
+        # Wait: depth starts at 0. When parsing nested1.xml (depth=0),
+        # it finds nested2.xml. We call _parse_sitemap(nested2.xml, depth=1).
+        # That's depth=1, which is <= max_recursion_depth=1.
+        # Then nested2.xml finds sitemap1.xml. We call _parse_sitemap(sitemap1.xml, depth=2).
+        # depth=2 > max_recursion_depth=1, so sitemap1.xml is NOT parsed.
+        # So urls should be empty.
+        assert len(urls) == 0
+
+    @pytest.mark.asyncio
+    async def test_sitemap_index_deduplication(self, child_sitemap1):
+        """Same child sitemap referenced twice is only parsed once."""
+        sitemap_index_dup = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+</sitemapindex>"""
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "sitemap_index_dup.xml" in url:
+                return _mock_response(sitemap_index_dup)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url(
+            "https://example.com/sitemap_index_dup.xml"
+        )
+
+        assert len(urls) == 2
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+
+
+# ── Gzip tests ──────────────────────────────────────────────────
+
+
+class TestGzipSitemaps:
+    """Tests for gzipped sitemaps."""
+
+    @pytest.mark.asyncio
+    async def test_gzip_content_encoding(self, xml_sitemap):
+        """Sitemaps with Content-Encoding: gzip are decompressed."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_gzipped_response(xml_sitemap)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert len(urls) == 5
+        assert "https://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_gzip_with_gz_extension(self, xml_sitemap):
+        """Sitemaps with .xml.gz extension are decompressed."""
+        compressed = gzip.compress(xml_sitemap.encode("utf-8"))
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(
+            compressed,
+            content_type="application/gzip",
+        )
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml.gz")
+
+        assert len(urls) == 5
+        assert "https://example.com/pricing" in urls
+
+
+# ── Error handling tests ────────────────────────────────────────
+
+
+class TestErrorHandling:
+    """Tests for graceful error handling."""
+
+    @pytest.mark.asyncio
+    async def test_404_returns_empty(self):
+        """A sitemap returning 404 returns an empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response("Not Found", status_code=404)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_500_returns_empty(self):
+        """A sitemap returning 500 returns an empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response("Server Error", status_code=500)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_connection_error_returns_empty(self):
+        """A connection error when fetching sitemap returns empty."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_empty(self):
+        """A timeout fetching sitemap returns empty."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.TimeoutException("Timeout after 15s")
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_text_sitemap_unsupported(self):
+        """A plain text sitemap is detected and returns empty."""
+        text_sitemap = "https://example.com/page1\nhttps://example.com/page2\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(
+            text_sitemap,
+            content_type="text/plain",
+        )
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.txt")
+
+        assert urls == []
+
+
+# ── get_urls integration tests ──────────────────────────────────
+
+
+class TestGetUrls:
+    """Tests for the full get_urls() flow."""
+
+    @pytest.mark.asyncio
+    async def test_get_urls_from_robots_txt(self, xml_sitemap):
+        """get_urls discovers sitemaps from robots.txt first."""
+        robots_txt = "User-agent: *\nSitemap: https://example.com/sitemap.xml\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+        assert "https://example.com/" in urls
+        assert "https://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_get_urls_fallback_to_common_paths(self, xml_sitemap):
+        """get_urls falls back to common paths when robots.txt has no sitemap directives."""
+        robots_txt = "User-agent: *\nDisallow: /admin/\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+        assert "https://example.com/" in urls
+
+    @pytest.mark.asyncio
+    async def test_get_urls_robots_txt_404_falls_back(self, xml_sitemap):
+        """get_urls falls back to common paths when robots.txt is 404."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response("Not Found", status_code=404)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+
+    @pytest.mark.asyncio
+    async def test_get_urls_with_limit(self, xml_sitemap):
+        """get_urls respects the limit parameter."""
+        robots_txt = "User-agent: *\nSitemap: https://example.com/sitemap.xml\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com", limit=3)
+
+        assert len(urls) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_urls_no_sitemap_returns_empty(self):
+        """get_urls returns empty list when no sitemaps are found."""
+        robots_txt = "User-agent: *\nDisallow: /\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            # Simulate 404 on all common paths
+            return _mock_response("Not Found", status_code=404)
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_get_urls_deduplicates(self, xml_sitemap):
+        """Duplicate URLs across sitemaps are deduplicated."""
+        robots_txt = (
+            "User-agent: *\n"
+            "Sitemap: https://example.com/sitemap.xml\n"
+            "Sitemap: https://example.com/sitemap2.xml\n"
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            elif "sitemap2.xml" in url:
+                return _mock_response(xml_sitemap)  # Same URLs
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5  # Deduplicated
+
+    @pytest.mark.asyncio
+    async def test_get_urls_robots_txt_unreachable_falls_back(self, xml_sitemap):
+        """get_urls falls back to common paths when robots.txt is unreachable."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                raise httpx.ConnectError("Connection refused")
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+
+    @pytest.mark.asyncio
+    async def test_multiple_robots_txt_sitemap_directives(
+        self, xml_sitemap, child_sitemap1
+    ):
+        """Multiple Sitemap directives in robots.txt are all fetched."""
+        robots_txt = (
+            "User-agent: *\n"
+            "Sitemap: https://example.com/sitemap.xml\n"
+            "Sitemap: https://example.com/extra-sitemap.xml\n"
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif url.endswith("extra-sitemap.xml"):
+                return _mock_response(child_sitemap1)
+            elif url.endswith("sitemap.xml"):
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        # 5 from sitemap.xml + 2 from extra-sitemap.xml = 7
+        assert len(urls) == 7
+
+    @pytest.mark.asyncio
+    async def test_get_urls_with_nested_index(
+        self, sitemap_index, child_sitemap1, child_sitemap2
+    ):
+        """get_urls follows nested sitemap indexes."""
+        robots_txt = "User-agent: *\nSitemap: https://example.com/sitemap_index.xml\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap_index.xml" in url:
+                return _mock_response(sitemap_index)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            elif "sitemap2.xml" in url:
+                return _mock_response(child_sitemap2)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 4
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+        assert "https://example.com/page3" in urls
+        assert "https://example.com/page4" in urls
+
+
+# ── URL normalization tests ─────────────────────────────────────
+
+
+class TestUrlNormalization:
+    """Tests for sitemap URL normalization."""
+
+    def test_normalize_strips_fragment(self):
+        """Fragments are stripped from sitemap URLs."""
+        result = SitemapParser._normalize_sitemap_url(
+            "https://example.com/page#section"
+        )
+        # Fragment is stripped by normalization
+        assert result == "https://example.com/page"
+
+    def test_normalize_rejects_non_http(self):
+        """Non-HTTP URLs return None."""
+        assert SitemapParser._normalize_sitemap_url("ftp://example.com/file") is None
+        assert SitemapParser._normalize_sitemap_url("mailto:admin@example.com") is None
+        assert SitemapParser._normalize_sitemap_url("") is None
+
+    def test_normalize_preserves_https(self):
+        """HTTPS URLs are preserved."""
+        result = SitemapParser._normalize_sitemap_url("https://example.com/page")
+        assert result == "https://example.com/page"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -31,7 +31,11 @@ class TestProcessAgentAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -75,7 +79,11 @@ class TestProcessAgentAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -118,7 +126,11 @@ class TestProcessAgentAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -146,6 +158,7 @@ class TestProcessCrawlAsync:
         from agent.worker import _process_crawl_async
 
         mock_store = MagicMock()
+        mock_store.get_job.return_value = {"status": "processing"}  # not cancelled
         mock_scraper_instance = MagicMock()
         mock_scraper_instance.scrape = AsyncMock(
             return_value={
@@ -171,7 +184,11 @@ class TestProcessCrawlAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
             patch("agent.worker._index_page_async", AsyncMock()),
@@ -194,7 +211,12 @@ class TestProcessCrawlAsync:
         assert payload["pages"][0]["url"] == "https://example.com"
         assert payload["pages"][0]["markdown"] == "# Crawled page"
 
-        mock_deliver_webhook.assert_called_once()
+        # Webhook called 3 times: crawl.started, crawl.page, crawl.completed
+        assert mock_deliver_webhook.call_count == 3
+        events = [call[0][1] for call in mock_deliver_webhook.call_args_list]
+        assert events[0] == "crawl.started"
+        assert events[1] == "crawl.page"
+        assert events[2] == "crawl.completed"
         mock_scraper_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
@@ -219,7 +241,11 @@ class TestProcessCrawlAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -232,10 +258,74 @@ class TestProcessCrawlAsync:
             )
 
         mock_store.fail_job.assert_called_once_with("crawl-fail", "Crawl error")
-        mock_deliver_webhook.assert_called_once()
-        # Verify failed event
-        assert mock_deliver_webhook.call_args[0][1] == "failed"
+        # Webhook called 2 times: crawl.started, then crawl.failed
+        assert mock_deliver_webhook.call_count == 2
+        events = [call[0][1] for call in mock_deliver_webhook.call_args_list]
+        assert events[0] == "crawl.started"
+        assert events[1] == "crawl.failed"
         # scraper.close() called in finally
+        mock_scraper_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_during_crawl(self):
+        """Verify cancellation: engine detects cancelled status, preserves it."""
+        from agent.worker import _process_crawl_async
+
+        mock_store = MagicMock()
+        # Simulate job being cancelled in Redis (as DELETE would set)
+        mock_store.get_job.return_value = {"status": "cancelled"}
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {
+                    "markdown": "# Crawled page",
+                    "metadata": {},
+                },
+            }
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch(
+                "agent.worker.load_settings",
+                return_value=MagicMock(
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
+                ),
+            ),
+            patch("agent.worker._index_page_async", AsyncMock()),
+        ):
+            await _process_crawl_async(
+                job_id="crawl-cancel",
+                url="https://example.com",
+                max_pages=10,
+                max_depth=2,
+                scraper_url="http://scraper:8001",
+            )
+
+        # complete_job should NOT be called — cancel_job already set status
+        mock_store.complete_job.assert_not_called()
+        # Webhook: crawl.started, crawl.page (for start URL), crawl.completed (cancelled)
+        assert mock_deliver_webhook.call_count >= 2
+        events = [call[0][1] for call in mock_deliver_webhook.call_args_list]
+        assert events[0] == "crawl.started"
+        # Last event should be crawl.completed (for cancelled status)
+        assert events[-1] == "crawl.completed"
+        # The cancelled status should be in the payload
+        completed_payload = mock_deliver_webhook.call_args_list[-1][0][3]
+        assert completed_payload.get("status") == "cancelled"
         mock_scraper_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
@@ -265,7 +355,11 @@ class TestProcessCrawlAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
             patch("agent.worker._index_page_async", AsyncMock()),
@@ -324,7 +418,11 @@ class TestProcessBatchScrapeAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
             patch("agent.worker._index_batch_async", mock_index_batch),
@@ -383,7 +481,11 @@ class TestProcessBatchScrapeAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -427,7 +529,11 @@ class TestProcessBatchScrapeAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -466,7 +572,11 @@ class TestProcessExtractAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -506,7 +616,11 @@ class TestProcessExtractAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -555,7 +669,11 @@ class TestProcessLlmstxtAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -592,7 +710,11 @@ class TestProcessLlmstxtAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -627,7 +749,11 @@ class TestIndexPageAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -665,7 +791,11 @@ class TestIndexPageAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -698,7 +828,11 @@ class TestIndexPageAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -747,7 +881,11 @@ class TestIndexBatchAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -779,7 +917,11 @@ class TestIndexBatchAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):


### PR DESCRIPTION

## Summary

Implements three scope control fields in CrawlEngine: `crawlEntireDomain`, `allowSubdomains`, and `allowExternalLinks`, plus SSRF guard.

## Changes

### Models (`models.py`)
- Added `crawl_entire_domain`, `allow_subdomains`, `allow_external_links` fields to `CrawlRequest` (all default `False`)

### CrawlEngine (`crawler.py`)
- Added `crawl_entire_domain` to `CrawlOptions` (default `False`)
- Implemented child-path filtering: when `crawlEntireDomain=False` (default), only follow links deeper in the path hierarchy
- When `crawlEntireDomain=True`, follow all same-domain links including siblings and parents
- Added SSRF guard via `common.url.is_private_host()` that always blocks private IPs on external URLs
- Added `_filter_child_paths()` and `_filter_ssrf_blocked()` static methods

### API/Worker wiring
- Wired scope control fields through `api.py` create_crawl to `worker.py` `_process_crawl_async` to `CrawlOptions`

### Tests
- 38 new unit tests covering all scope controls, SSRF guard, combinations
- Fixed pre-existing tests that expected all-same-domain-link-following

## Validation
- All 107 test_crawler.py tests pass, all 46 test_link_extractor.py tests pass
- mypy: no issues
- ruff: all checks passed
- graphify: knowledge graph updated
