### PR TITLE
feat(nl-to-params): implement prompt field on CrawlRequest and POST /v2/crawl/params-preview endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -153,3 +153,12 @@
 # Limits how many search calls a single client IP can make within the
 # window. Uses Valkey-backed INCR/EXPIRE for atomic counting.
 # AGENT_SEARCH_RATE_LIMIT=10/60s
+
+# ── Crawl Job Lifecycle ──────────────────────────────────────────
+# Maximum wall-clock duration for a single crawl job (seconds, default: 1800 = 30 min).
+# Crawls exceeding this are terminated with a TimeoutError.
+# CRAWL_MAX_DURATION_SECONDS=1800
+
+# Idle timeout for stuck/zombie crawls (seconds, default: 300 = 5 min).
+# If no page completes within this window, the crawl is terminated.
+# CRAWL_IDLE_TIMEOUT_SECONDS=300

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -319,6 +319,8 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             crawl_entire_domain=body.crawl_entire_domain,
             allow_subdomains=body.allow_subdomains,
             allow_external_links=body.allow_external_links,
+            max_concurrency=body.max_concurrency,
+            delay=body.delay,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -34,6 +34,8 @@ from .models import (
     BrowserExecuteResponse,
     BrowserListResponse,
     Citation,
+    CrawlActiveItem,
+    CrawlActiveResponse,
     CrawlCreateResponse,
     CrawlErrorItem,
     CrawlErrorsResponse,
@@ -352,6 +354,51 @@ async def create_crawl(
         )
     )
     return CrawlCreateResponse(id=job_id)
+
+
+@router.get("/v2/crawl/active", response_model=CrawlActiveResponse)
+async def list_active_crawls(
+    request: Request,
+    status: str = "processing",
+) -> CrawlActiveResponse:
+    """List all active crawl jobs.
+
+    Returns only jobs with ``kind: "crawl"``. By default returns jobs
+    with ``status: "processing"`` (excluding completed, failed, and
+    cancelled crawls). Filterable via the ``status`` query parameter.
+
+    Each item includes crawl-specific fields: ``url``, ``max_pages``,
+    ``max_depth``, ``completed``, ``total``, ``status``, and ``created_at``.
+
+    Returns an empty ``data`` array (HTTP 200) when no active crawls exist.
+    """
+    store: JobStore = request.app.state.job_store
+    jobs = store.list_active_jobs(kind="crawl", status=status, limit=50)
+    items: list[CrawlActiveItem] = []
+    for job in jobs:
+        payload = job.get("payload") or {}
+        url = payload.get("url") if isinstance(payload, dict) else None
+        max_pages = payload.get("max_pages") if isinstance(payload, dict) else None
+        max_depth = payload.get("max_depth") if isinstance(payload, dict) else None
+
+        # Get completed/total from data payload (set during crawl progress)
+        data = job.get("data") or {}
+        completed = data.get("completed", 0) if isinstance(data, dict) else 0
+        total = data.get("total", 0) if isinstance(data, dict) else 0
+
+        items.append(
+            CrawlActiveItem(
+                id=job["id"],
+                url=url,
+                status=job.get("status", "processing"),
+                created_at=job.get("created_at", ""),
+                completed=completed,
+                total=total,
+                max_pages=max_pages,
+                max_depth=max_depth,
+            )
+        )
+    return CrawlActiveResponse(data=items)
 
 
 @router.get("/v2/crawl/{job_id}", response_model=CrawlStatusResponse)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -294,17 +294,25 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
     store: JobStore = request.app.state.job_store
     job_id = store.create_job(kind="crawl", payload=body.model_dump())
 
+    # Resolve limit vs max_pages conflict (stricter wins, per VAL-CRAWL-089)
+    effective_max_pages = body.max_pages
+    if body.limit is not None:
+        effective_max_pages = min(body.max_pages, body.limit)
+
     from .worker import _process_crawl_async
 
     request.app.state.task_tracker.create_background_task(
         _process_crawl_async(
             job_id=job_id,
             url=body.url,
-            max_pages=body.max_pages,
+            max_pages=effective_max_pages,
             max_depth=body.max_depth,
             scraper_url=request.app.state.scraper_url,
             webhook_config=body.webhook,
             task_tracker=request.app.state.task_tracker,
+            ignore_query_parameters=body.ignore_query_parameters,
+            include_paths=body.include_paths,
+            exclude_paths=body.exclude_paths,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -35,6 +35,8 @@ from .models import (
     BrowserListResponse,
     Citation,
     CrawlCreateResponse,
+    CrawlErrorItem,
+    CrawlErrorsResponse,
     CrawlRequest,
     CrawlStatusResponse,
     ExtractCreateResponse,
@@ -397,27 +399,38 @@ async def cancel_crawl(request: Request, job_id: str) -> AgentCancelResponse:
     return AgentCancelResponse(success=True)
 
 
-@router.get("/v2/crawl/{job_id}/errors")
-async def get_crawl_errors(request: Request, job_id: str) -> dict:
+@router.get("/v2/crawl/{job_id}/errors", response_model=CrawlErrorsResponse)
+async def get_crawl_errors(request: Request, job_id: str) -> CrawlErrorsResponse:
     """Return per-URL errors and robots-blocked URLs for a crawl job.
 
-    Returns a dict with:
-        - ``errors``: list of failed URLs with error messages
-        - ``robots_blocked``: list of URLs blocked by robots.txt/politeness
-          (also present in ``errors`` with ``error_code: "ROBOTS_BLOCKED"``)
+    Returns a ``CrawlErrorsResponse`` with:
 
-    Each entry has ``url``, ``error``, and optionally ``error_code`` fields.
+    - ``errors``: list of error objects. Each has ``url``, ``error``
+      (human-readable message), ``error_type`` (machine-readable
+      category), ``error_code``, and ``timestamp``.
+    - ``robots_blocked``: subset of ``errors`` containing only URLs that
+      were blocked by robots.txt or politeness rate limiting. Each entry
+      has ``error_type: "robots_blocked"``.
+
+    Scraper failures appear in ``errors`` but NOT in ``robots_blocked``.
+    Politeness/robots.txt blocks appear in BOTH arrays.
+
+    Returns 404 for unknown job IDs. Returns empty arrays for successful
+    crawls with no errors. Errors persist until the job TTL expires (24h
+    after creation).
     """
     store: JobStore = request.app.state.job_store
     job = store.get_job(job_id)
     if job is None:
         raise NotFoundError(detail="Job not found", details={"job_id": job_id})
     data = job.get("data") or {}
-    return {
-        "success": True,
-        "errors": data.get("errors", []),
-        "robots_blocked": data.get("robots_blocked", []),
-    }
+    raw_errors: list[dict] = data.get("errors", [])
+    raw_robots_blocked: list[dict] = data.get("robots_blocked", [])
+    return CrawlErrorsResponse(
+        success=True,
+        errors=[CrawlErrorItem(**e) for e in raw_errors],
+        robots_blocked=[CrawlErrorItem(**e) for e in raw_robots_blocked],
+    )
 
 
 @router.post("/v2/batch/scrape", response_model=CrawlCreateResponse)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -54,6 +54,8 @@ from .models import (
     MonitorListResponse,
     MonitorResponse,
     MonitorUpdateRequest,
+    ParamsPreviewRequest,
+    ParamsPreviewResponse,
     ParseResponse,
     ScrapeData,
     ScrapeRequest,
@@ -316,6 +318,49 @@ async def create_crawl(
         f"{rate_remaining}/{rate_limiter.limit}"
     )
 
+    # ── NL→params: derive from prompt, merge with explicit params ──
+    include_paths = body.include_paths
+    exclude_paths = body.exclude_paths
+    max_depth = body.max_depth
+
+    if body.prompt:
+        from .nl_params import derive_crawl_params, merge_params
+
+        # Detect which fields were explicitly set by the user
+        # (exclude_unset=True only includes fields present in the request body)
+        explicitly_set = body.model_dump(exclude_unset=True)
+
+        # Explicit params that the user set (non-None values that were in the request)
+        explicit: dict[str, object] = {}
+        if "include_paths" in explicitly_set and body.include_paths is not None:
+            explicit["include_paths"] = body.include_paths
+        if "exclude_paths" in explicitly_set and body.exclude_paths is not None:
+            explicit["exclude_paths"] = body.exclude_paths
+        if "max_depth" in explicitly_set:
+            explicit["max_depth"] = body.max_depth
+
+        llm_result = await derive_crawl_params(
+            prompt=body.prompt,
+            llm_base_url=request.app.state.llm_base_url,
+            llm_api_key=request.app.state.llm_api_key,
+            llm_model=request.app.state.llm_model,
+        )
+
+        llm_error = llm_result.get("error")
+        if llm_error:
+            logger.warning("NL→params for crawl %s: %s", "pending", llm_error)
+
+        # Merge: explicit beats LLM
+        merged = merge_params(llm_result, explicit)  # type: ignore[arg-type]
+
+        # Apply merged values (only if not overridden by explicit user params)
+        if "include_paths" in merged and "include_paths" not in explicitly_set:
+            include_paths = merged["include_paths"]
+        if "exclude_paths" in merged and "exclude_paths" not in explicitly_set:
+            exclude_paths = merged["exclude_paths"]
+        if "max_depth" in merged and "max_depth" not in explicitly_set:
+            max_depth = merged["max_depth"]
+
     store: JobStore = request.app.state.job_store
     job_id = store.create_job(kind="crawl", payload=body.model_dump())
 
@@ -331,13 +376,13 @@ async def create_crawl(
             job_id=job_id,
             url=body.url,
             max_pages=effective_max_pages,
-            max_depth=body.max_depth,
+            max_depth=max_depth,
             scraper_url=request.app.state.scraper_url,
             webhook_config=body.webhook,
             task_tracker=request.app.state.task_tracker,
             ignore_query_parameters=body.ignore_query_parameters,
-            include_paths=body.include_paths,
-            exclude_paths=body.exclude_paths,
+            include_paths=include_paths,
+            exclude_paths=exclude_paths,
             regex_on_full_url=body.regex_on_full_url,
             verbose=body.verbose,
             sitemap_mode=body.sitemap,
@@ -444,6 +489,50 @@ async def cancel_crawl(request: Request, job_id: str) -> AgentCancelResponse:
             detail="Job not found or already completed", details={"job_id": job_id}
         )
     return AgentCancelResponse(success=True)
+
+
+@router.post("/v2/crawl/params-preview", response_model=ParamsPreviewResponse)
+async def params_preview(
+    request: Request, body: ParamsPreviewRequest
+) -> ParamsPreviewResponse:
+    """Preview crawl parameters derived from a natural-language prompt.
+
+    Accepts a ``url`` and ``prompt``, translates the prompt into crawl
+    parameters using the LLM, and returns the derived parameters WITHOUT
+    starting a crawl job.
+
+    The endpoint is synchronous — no job ID is created.
+
+    Returns:
+        - ``include_paths``, ``exclude_paths``, ``max_depth``,
+          ``limit``, and other derived params
+        - ``error`` if the LLM is unavailable or returns invalid JSON
+          (the caller can still proceed with default crawl params)
+    """
+    from .nl_params import derive_crawl_params
+
+    llm_base_url = request.app.state.llm_base_url
+    llm_api_key = request.app.state.llm_api_key
+    llm_model = request.app.state.llm_model
+
+    result = await derive_crawl_params(
+        prompt=body.prompt,
+        llm_base_url=llm_base_url,
+        llm_api_key=llm_api_key,
+        llm_model=llm_model,
+    )
+
+    return ParamsPreviewResponse(
+        success=("error" not in result),
+        include_paths=result.get("include_paths"),
+        exclude_paths=result.get("exclude_paths"),
+        max_depth=result.get("max_depth"),
+        limit=result.get("max_pages"),
+        ignore_robots_txt=result.get("ignore_robots_txt"),
+        robots_user_agent=result.get("robots_user_agent"),
+        deduplicate_similar_urls=result.get("deduplicate_similar_urls"),
+        error=result.get("error"),
+    )
 
 
 @router.get("/v2/crawl/{job_id}/errors", response_model=CrawlErrorsResponse)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -321,6 +321,8 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             allow_external_links=body.allow_external_links,
             max_concurrency=body.max_concurrency,
             delay=body.delay,
+            ignore_robots_txt=body.ignore_robots_txt,
+            robots_user_agent=body.robots_user_agent,
         )
     )
     return CrawlCreateResponse(id=job_id)
@@ -369,6 +371,29 @@ async def cancel_crawl(request: Request, job_id: str) -> AgentCancelResponse:
             detail="Job not found or already completed", details={"job_id": job_id}
         )
     return AgentCancelResponse(success=True)
+
+
+@router.get("/v2/crawl/{job_id}/errors")
+async def get_crawl_errors(request: Request, job_id: str) -> dict:
+    """Return per-URL errors and robots-blocked URLs for a crawl job.
+
+    Returns a dict with:
+        - ``errors``: list of failed URLs with error messages
+        - ``robots_blocked``: list of URLs blocked by robots.txt/politeness
+          (also present in ``errors`` with ``error_code: "ROBOTS_BLOCKED"``)
+
+    Each entry has ``url``, ``error``, and optionally ``error_code`` fields.
+    """
+    store: JobStore = request.app.state.job_store
+    job = store.get_job(job_id)
+    if job is None:
+        raise NotFoundError(detail="Job not found", details={"job_id": job_id})
+    data = job.get("data") or {}
+    return {
+        "success": True,
+        "errors": data.get("errors", []),
+        "robots_blocked": data.get("robots_blocked", []),
+    }
 
 
 @router.post("/v2/batch/scrape", response_model=CrawlCreateResponse)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -8,10 +8,7 @@ from datetime import UTC
 from typing import Any
 
 import httpx
-from bs4 import BeautifulSoup
 from fastapi import APIRouter, Request, Response
-
-from common.url import extract_domain, is_same_origin
 
 from .exceptions import (
     BrowserError,
@@ -744,22 +741,33 @@ async def map_site(request: Request, body: MapRequest) -> MapResponse:
             resp = await client.get(body.url)
             if resp.status_code != 200:
                 raise UpstreamError(detail=f"Site returned HTTP {resp.status_code}")
-            soup = BeautifulSoup(resp.text, "html.parser")
-            links: list[str] = []
-            for a in soup.find_all("a", href=True):
-                href: str = a["href"]  # type: ignore[assignment,union-attr]
-                if href.startswith("/"):
-                    href = f"{extract_domain(body.url, include_scheme=True)}{href}"
-                href_start = href.startswith(body.url.rstrip("/")) or is_same_origin(
-                    body.url, href
-                )
-                if href_start and href not in links:
-                    links.append(href)
-                    if len(links) >= body.limit:
-                        break
+
+            # Use shared LinkExtractor instead of inline BeautifulSoup parsing
+            from urllib.parse import urlparse
+
+            from .link_extractor import extract_links, filter_links
+
+            all_links = extract_links(resp.text, body.url)
+
+            # Filter links by domain scope (default: same-origin only)
+            base_domain = (urlparse(body.url).hostname or "").lower()
+            filtered = filter_links(
+                all_links,
+                base_domain=base_domain,
+                allow_subdomains=body.allow_subdomains,
+                allow_external_links=body.allow_external_links,
+            )
+
+            # Apply limit (truncates AFTER filtering)
+            result = filtered[: body.limit]
+
+            # Apply search filter (case-insensitive substring match)
             if body.search:
-                links = [link for link in links if body.search.lower() in link.lower()]
-            return MapResponse(links=links)
+                result = [
+                    link for link in result if body.search.lower() in link.lower()
+                ]
+
+            return MapResponse(links=result)
     except Exception as e:
         logger.error("Map failed for %s: %s", body.url, e)
         raise UpstreamError(detail=str(e)) from e

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -316,6 +316,9 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             regex_on_full_url=body.regex_on_full_url,
             verbose=body.verbose,
             sitemap_mode=body.sitemap,
+            crawl_entire_domain=body.crawl_entire_domain,
+            allow_subdomains=body.allow_subdomains,
+            allow_external_links=body.allow_external_links,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -327,12 +327,31 @@ async def get_crawl_status(request: Request, job_id: str) -> CrawlStatusResponse
     if job is None:
         raise NotFoundError(detail="Job not found", details={"job_id": job_id})
     data = job.get("data") or {}
+
+    # Compute duration in milliseconds from created_at to completed_at
+    created_at = job.get("created_at")
+    completed_at = job.get("completed_at")
+    duration: int | None = None
+    if created_at and completed_at:
+        try:
+            from datetime import datetime as _dt
+
+            created_dt = _dt.fromisoformat(created_at)
+            completed_dt = _dt.fromisoformat(completed_at)
+            duration = int((completed_dt - created_dt).total_seconds() * 1000)
+        except (ValueError, TypeError):
+            duration = None
+
     return CrawlStatusResponse(
         status=job.get("status", "processing"),
         completed=data.get("completed", 0),
         total=data.get("total", 0),
         data=data.get("pages"),
         error=job.get("error"),
+        created_at=created_at,
+        completed_at=completed_at,
+        expires_at=job.get("expires_at"),
+        duration=duration,
     )
 
 

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -344,6 +344,9 @@ async def create_crawl(
             delay=body.delay,
             ignore_robots_txt=body.ignore_robots_txt,
             robots_user_agent=body.robots_user_agent,
+            scrape_options=body.scrape_options.model_dump(mode="json", by_alias=True)
+            if body.scrape_options
+            else None,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -313,6 +313,8 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             ignore_query_parameters=body.ignore_query_parameters,
             include_paths=body.include_paths,
             exclude_paths=body.exclude_paths,
+            regex_on_full_url=body.regex_on_full_url,
+            verbose=body.verbose,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -315,6 +315,7 @@ async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateRespo
             exclude_paths=body.exclude_paths,
             regex_on_full_url=body.regex_on_full_url,
             verbose=body.verbose,
+            sitemap_mode=body.sitemap,
         )
     )
     return CrawlCreateResponse(id=job_id)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -290,7 +290,28 @@ async def cancel_agent(request: Request, job_id: str) -> AgentCancelResponse:
 
 
 @router.post("/v2/crawl", response_model=CrawlCreateResponse)
-async def create_crawl(request: Request, body: CrawlRequest) -> CrawlCreateResponse:
+async def create_crawl(
+    request: Request, body: CrawlRequest, response: Response
+) -> CrawlCreateResponse:
+    # ── Per-client rate limit check (VAL-CONC-047) ────────────
+    client_ip = _get_client_ip(request)
+    rate_limiter = request.app.state.rate_limiter
+    allowed, rate_remaining = await rate_limiter.check(f"{client_ip}:crawl")
+    if not allowed:
+        from .exceptions import RateLimitedError
+        from .metrics import METRICS
+
+        METRICS.counter("search_calls_total", "Total search calls", ["status"]).inc(
+            {"status": "rate_limited"}
+        )
+        raise RateLimitedError(
+            detail=f"Per-client rate limit exceeded ({rate_limiter.limit}/{rate_limiter.window}s)"
+        )
+
+    response.headers["X-Crawl-Rate-Remaining"] = (
+        f"{rate_remaining}/{rate_limiter.limit}"
+    )
+
     store: JobStore = request.app.state.job_store
     job_id = store.create_job(kind="crawl", payload=body.model_dump())
 

--- a/agent-svc/agent/crawl_cache.py
+++ b/agent-svc/agent/crawl_cache.py
@@ -229,9 +229,25 @@ class CrawlCache:
         cached_data = entry.get("data")
         age_ms = self.get_age_ms(url)
 
-        # ── minAge mode — serve cached regardless of age ─────────
+        # ── minAge mode — serve cached (with freshness check against maxAge) ─
         if min_age_ms is not None and min_age_ms > 0:
             if cached_data is not None:
+                # When both minAge and maxAge are set, check age against maxAge.
+                # If cache is older than maxAge, treat as stale and trigger
+                # a fresh scrape instead of returning stale data.
+                if (
+                    max_age_ms is not None
+                    and max_age_ms > 0
+                    and age_ms is not None
+                    and age_ms >= max_age_ms
+                ):
+                    logger.debug(
+                        "Cache STALE (minAge+maxAge) for %s (age=%dms, maxAge=%dms)",
+                        url,
+                        age_ms,
+                        max_age_ms,
+                    )
+                    return False, cached_data, None
                 logger.debug(
                     "Cache HIT (minAge) for %s (age=%dms, minAge=%dms)",
                     url,

--- a/agent-svc/agent/crawl_cache.py
+++ b/agent-svc/agent/crawl_cache.py
@@ -1,0 +1,273 @@
+"""Valkey-backed response cache for crawled pages with maxAge/minAge semantics.
+
+Cache keys are SHA-256 hashes of the URL. Each entry stores the full page
+data dict (the raw scrape response from ``ScraperClient``) along with a
+``cached_at`` timestamp and the ``ttl_ms`` value that was set when the entry
+was created.
+
+Key format: ``crawl:cache:{sha256(url)}``
+
+Value format (JSON)::
+
+    {
+        "url": "https://example.com/page",
+        "data": {"success": true, "data": {"markdown": "...", ...}},
+        "cached_at": "2025-01-01T00:00:00+00:00",
+        "ttl_ms": 3600000
+    }
+
+The ``CrawlCache`` is checked by the ``CrawlEngine`` before each page scrape.
+When a cache hit occurs and the entry is within ``maxAge``, the scraper call
+is skipped entirely, saving network latency. When ``minAge`` is set, the
+cache operates in cache-only mode: a cache miss returns an error rather than
+fetching fresh content.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+
+from redis import Redis
+
+logger = logging.getLogger(__name__)
+
+# Key prefix for all crawl cache entries in Valkey.
+_CACHE_KEY_PREFIX = "crawl:cache:"
+
+
+class CrawlCache:
+    """Valkey-backed response cache for crawled pages.
+
+    Each entry is stored as JSON under ``crawl:cache:{sha256(url)}`` with a
+    TTL equal to the ``maxAge`` value in seconds (minimum 1 second).
+
+    Usage::
+
+        cache = CrawlCache("redis://valkey:6379/0")
+
+        # Store a page response
+        cache.set("https://example.com", response_dict, ttl_ms=3600000)
+
+        # Check cache before scraping
+        use_cached, data, error = cache.check_cache(
+            "https://example.com",
+            max_age_ms=3600000,  # 1 hour
+            min_age_ms=60000,    # 1 minute
+        )
+        if error:
+            # Cache miss in minAge mode
+            ...
+        elif use_cached and data:
+            # Use the cached data directly
+            ...
+        else:
+            # Cache miss or stale — scrape fresh
+            ...
+    """
+
+    def __init__(self, redis_url: str = "redis://localhost:6379/0"):
+        self.redis = Redis.from_url(redis_url, decode_responses=True)
+
+    def _cache_key(self, url: str) -> str:
+        """Generate a Valkey key for a URL using its SHA-256 hash.
+
+        Returns:
+            A string like ``crawl:cache:{hex_sha256}``.
+        """
+        url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        return f"{_CACHE_KEY_PREFIX}{url_hash}"
+
+    def get(self, url: str) -> dict | None:
+        """Get the cached entry for a URL.
+
+        Returns the full cached entry dict (with ``url``, ``data``,
+        ``cached_at``, ``ttl_ms`` keys) if found, or ``None`` if the
+        URL is not cached.
+
+        The caller is responsible for checking maxAge/minAge constraints
+        using ``check_cache()`` or by inspecting the entry directly.
+        """
+        key = self._cache_key(url)
+        raw = self.redis.get(key)
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            logger.warning("Failed to decode cache entry for %s: %s", url, exc)
+            return None
+
+    def set(self, url: str, data: dict, ttl_ms: int) -> None:
+        """Store page data in the cache.
+
+        The entry's TTL is derived from ``ttl_ms`` (converted to seconds,
+        minimum 1 second). This ensures that cache entries expire
+        naturally via Valkey's key expiration mechanism.
+
+        Args:
+            url: The URL being cached.
+            data: The page data dict to store (typically the full scrape
+                response dict from ``ScraperClient``).
+            ttl_ms: Time-to-live in milliseconds for this cache entry.
+                This should typically be the ``maxAge`` value.
+        """
+        key = self._cache_key(url)
+        entry = {
+            "url": url,
+            "data": data,
+            "cached_at": datetime.now(UTC).isoformat(),
+            "ttl_ms": ttl_ms,
+        }
+        # Valkey TTL is in seconds. Ensure at least 1 second.
+        ttl_seconds = max(1, int(ttl_ms / 1000))
+        self.redis.set(key, json.dumps(entry), ex=ttl_seconds)
+
+    def get_age_ms(self, url: str) -> int | None:
+        """Get the age of a cached entry in milliseconds.
+
+        Returns the age in milliseconds (time elapsed since ``cached_at``),
+        or ``None`` if the URL is not cached or the timestamp is invalid.
+        """
+        entry = self.get(url)
+        if entry is None:
+            return None
+        cached_at_raw = entry.get("cached_at")
+        if cached_at_raw is None:
+            return None
+        try:
+            cached_dt = datetime.fromisoformat(cached_at_raw)
+            now = datetime.now(UTC)
+            elapsed = now - cached_dt
+            return int(elapsed.total_seconds() * 1000)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "Failed to parse cached_at for %s: %s — %s", url, cached_at_raw, exc
+            )
+            return None
+
+    def delete(self, url: str) -> None:
+        """Delete a cache entry for a URL.
+
+        Removes the key from Valkey immediately.
+        """
+        key = self._cache_key(url)
+        self.redis.delete(key)
+
+    def check_cache(
+        self,
+        url: str,
+        max_age_ms: int | None = None,
+        min_age_ms: int | None = None,
+    ) -> tuple[bool, dict | None, str | None]:
+        """Check the cache and determine whether to use cached data.
+
+        This is the primary entry point for the crawl engine. It evaluates
+        the cache state against the ``maxAge``/``minAge`` constraints and
+        returns a decision tuple.
+
+        Decision matrix::
+
+            maxAge=0 or None  → always fresh (bypass cache)
+            maxAge>0, no cache → cache miss (fresh scrape)
+            maxAge>0, cache hit, age < maxAge → use cached
+            maxAge>0, cache hit, age >= maxAge → stale (fresh scrape)
+            minAge>0, no cache → cache miss (ERROR)
+            minAge>0, cache hit → use cached (regardless of age)
+            Both set, no cache → cache miss (ERROR)
+            Both set, cache hit, age < maxAge → use cached
+            Both set, cache hit, age >= maxAge → stale (fresh scrape)
+
+        Args:
+            url: The URL to check in the cache.
+            max_age_ms: ``maxAge`` in milliseconds. ``0`` or ``None`` means
+                bypass cache (always scrape fresh).
+            min_age_ms: ``minAge`` in milliseconds. When set and the URL
+                is not cached, an error is returned.
+
+        Returns:
+            A tuple ``(use_cached, cached_data, error_message)``:
+
+            - ``use_cached`` (bool): ``True`` if the caller should use the
+              cached data directly without scraping.
+            - ``cached_data`` (dict | None): The cached page data dict (the
+              value of the ``data`` key in the stored entry, which is the
+              scrape response), or ``None`` if not cached.
+            - ``error_message`` (str | None): An error message if the cache
+              returns an error state (e.g., minAge cache miss), or ``None``.
+        """
+        # If neither maxAge nor minAge is set, bypass cache entirely
+        if (max_age_ms is None or max_age_ms == 0) and (
+            min_age_ms is None or min_age_ms == 0
+        ):
+            logger.debug(
+                "Cache bypass for %s (maxAge=%s, minAge=%s)",
+                url,
+                max_age_ms,
+                min_age_ms,
+            )
+            return False, None, None
+
+        entry = self.get(url)
+
+        # ── No cached entry ──────────────────────────────────────
+        if entry is None:
+            if min_age_ms is not None and min_age_ms > 0:
+                # minAge mode: cache miss is an error (VAL-SCRAPE-029)
+                err_msg = (
+                    f"Cache miss for {url} — no cached content available "
+                    f"(minAge={min_age_ms}ms)"
+                )
+                logger.debug("Cache MISS (minAge) for %s", url)
+                return False, None, err_msg
+            # Normal cache miss — caller should scrape fresh
+            logger.debug("Cache MISS for %s", url)
+            return False, None, None
+
+        cached_data = entry.get("data")
+        age_ms = self.get_age_ms(url)
+
+        # ── minAge mode — serve cached regardless of age ─────────
+        if min_age_ms is not None and min_age_ms > 0:
+            if cached_data is not None:
+                logger.debug(
+                    "Cache HIT (minAge) for %s (age=%dms, minAge=%dms)",
+                    url,
+                    age_ms or 0,
+                    min_age_ms,
+                )
+                return True, cached_data, None
+            # Entry exists but has no data — treat as miss
+            err_msg = (
+                f"Cache miss for {url} — cached entry has no data "
+                f"(minAge={min_age_ms}ms)"
+            )
+            return False, None, err_msg
+
+        # ── maxAge mode — check freshness ─────────────────────────
+        # At this point, either maxAge or minAge is set (otherwise we
+        # would have returned early above). If only minAge is set, the
+        # minAge block above already handled it. If we reach here,
+        # maxAge must be set and > 0.
+        assert max_age_ms is not None and max_age_ms > 0  # nosec — type narrowing
+        if age_ms is not None and age_ms < max_age_ms:
+            logger.debug(
+                "Cache HIT for %s (age=%dms, maxAge=%dms)",
+                url,
+                age_ms,
+                max_age_ms,
+            )
+            return True, cached_data, None
+
+        # Cache is stale — caller should scrape fresh.
+        # We still return cached_data so the caller can use it as
+        # a fallback if desired (e.g., serve stale during revalidation).
+        logger.debug(
+            "Cache STALE for %s (age=%dms, maxAge=%dms)",
+            url,
+            age_ms or -1,
+            max_age_ms,
+        )
+        return False, cached_data, None

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -65,6 +65,10 @@ class CrawlOptions:
         robots_user_agent: Custom User-Agent string for robots.txt
             evaluation. When set, robots.txt rules are evaluated against
             this User-Agent instead of the default bot UA.
+        scrape_options: Optional dict of per-page scrape options (formats,
+            only_main_content, include_tags, exclude_tags, wait_for, mobile,
+            timeout, headers, remove_base64_images). Forwarded to scraper-svc
+            on every page fetch.
     """
 
     max_pages: int = 10
@@ -84,6 +88,7 @@ class CrawlOptions:
     delay: float | None = None
     ignore_robots_txt: bool = False
     robots_user_agent: str | None = None
+    scrape_options: dict | None = None
 
 
 @dataclass
@@ -716,6 +721,7 @@ class CrawlEngine:
                         url,
                         ignore_robots_txt=self.options.ignore_robots_txt,
                         robots_user_agent=self.options.robots_user_agent,
+                        scrape_options=self.options.scrape_options,
                     ),
                     timeout=per_scrape_timeout,
                 )

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -60,6 +60,12 @@ class CrawlOptions:
             When delay is set, this is forced to 1.
         delay: Seconds to wait between successive scrapes. When set,
             forces max_concurrency to 1.
+        ignore_robots_txt: If True, bypass robots.txt enforcement. All
+            discovered URLs are scraped regardless of robots.txt Disallow
+            rules. Politeness rate limiting (crawl-delay) still applies.
+        robots_user_agent: Custom User-Agent string for robots.txt
+            evaluation. When set, robots.txt rules are evaluated against
+            this User-Agent instead of the default bot UA.
     """
 
     max_pages: int = 10
@@ -77,6 +83,8 @@ class CrawlOptions:
     idle_timeout_seconds: int = 300
     max_concurrency: int = 3
     delay: float | None = None
+    ignore_robots_txt: bool = False
+    robots_user_agent: str | None = None
 
 
 @dataclass
@@ -87,6 +95,7 @@ class CrawlResult:
     total: int = 0
     completed: int = 0
     errors: list[dict] = field(default_factory=list)
+    robots_blocked: list[dict] = field(default_factory=list)
     filtered_out: list[dict] = field(default_factory=list)
 
 
@@ -357,6 +366,7 @@ class CrawlEngine:
         self._queue: deque[tuple[str, int]] = deque()
         self._pages: list[dict] = []
         self._errors: list[dict] = []
+        self._robots_blocked: list[dict] = []
         self._filtered_out: list[dict] = []
         self._cancel_flag: bool = False
         self._update_interval: float = 1.0
@@ -545,6 +555,7 @@ class CrawlEngine:
                             total=0,
                             completed=len(self._pages),
                             errors=self._errors,
+                            robots_blocked=self._robots_blocked,
                         )
                         await self.close()
                         return result_obj
@@ -584,6 +595,7 @@ class CrawlEngine:
             total=len(self._pages) + len(self._queue),
             completed=len(self._pages),
             errors=self._errors,
+            robots_blocked=self._robots_blocked,
             filtered_out=self._filtered_out,
         )
 
@@ -693,7 +705,11 @@ class CrawlEngine:
             # Scrape the page
             scrape_start = time.monotonic()
             try:
-                result = await self.scraper.scrape(url)
+                result = await self.scraper.scrape(
+                    url,
+                    ignore_robots_txt=self.options.ignore_robots_txt,
+                    robots_user_agent=self.options.robots_user_agent,
+                )
             except Exception as exc:
                 self._errors.append({"url": url, "error": str(exc)})
                 logger.warning("Scrape exception for %s: %s", url, exc)
@@ -705,8 +721,24 @@ class CrawlEngine:
 
             if not result.get("success"):
                 error_msg = result.get("error", "Unknown scrape error")
-                self._errors.append({"url": url, "error": error_msg})
-                logger.warning("Scrape failed for %s: %s", url, error_msg)
+
+                # Detect politeness-blocked results
+                if "Blocked by politeness" in error_msg:
+                    robots_entry = {
+                        "url": url,
+                        "error": error_msg,
+                        "error_code": "ROBOTS_BLOCKED",
+                    }
+                    self._robots_blocked.append(robots_entry)
+                    self._errors.append(robots_entry)
+                    logger.info(
+                        "Politeness blocked %s (job %s): %s", url, job_id, error_msg
+                    )
+                    # Blocked start URL is not a fatal error — it's expected
+                    return
+                else:
+                    self._errors.append({"url": url, "error": error_msg})
+                    logger.warning("Scrape failed for %s: %s", url, error_msg)
 
                 # Start URL failure — raise to signal immediate stop
                 if depth == 0:
@@ -985,6 +1017,7 @@ class CrawlEngine:
                 "total": len(self._pages) + len(self._queue),
                 "pages": self._pages,
                 "errors": self._errors,
+                "robots_blocked": self._robots_blocked,
             }
             # Write data key directly without changing meta status
             self.store.redis.set(

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -9,6 +9,7 @@ job store for status polling.
 
 from __future__ import annotations
 
+import collections.abc
 import json
 import logging
 import posixpath
@@ -61,6 +62,8 @@ class CrawlOptions:
     verbose: bool = False
     allow_subdomains: bool = False
     allow_external_links: bool = False
+    max_duration_seconds: int = 1800
+    idle_timeout_seconds: int = 300
 
 
 @dataclass
@@ -340,12 +343,23 @@ class CrawlEngine:
             await self._html_client.aclose()
             self._html_client = None
 
-    async def run(self, start_url: str, job_id: str | None = None) -> CrawlResult:
+    async def run(
+        self,
+        start_url: str,
+        job_id: str | None = None,
+        page_callback: collections.abc.Callable[
+            [str, dict], collections.abc.Awaitable[None]
+        ]
+        | None = None,
+    ) -> CrawlResult:
         """Execute a BFS crawl starting from ``start_url``.
 
         Args:
             start_url: The URL to begin crawling from.
-            job_id: Optional job ID for periodic store updates.
+            job_id: Optional job ID for periodic store updates and
+                cancellation checking.
+            page_callback: Optional async callback invoked after each
+                successful page scrape, receiving (job_id, page_dict).
 
         Returns:
             A ``CrawlResult`` with scraped pages, totals, and errors.
@@ -356,11 +370,50 @@ class CrawlEngine:
         # Seed the BFS queue
         self._queue.append((start_url, 0))
         last_store_update = time.monotonic()
+        crawl_start_time = time.monotonic()
+        last_completion_time = crawl_start_time
 
         while self._queue and len(self._pages) < self.options.max_pages:
             if self._cancel_flag:
                 logger.info("Crawl cancelled via cancel flag")
                 break
+
+            # Cooperative cancellation: check Redis for cancelled status
+            # between pages (checked before each page scrape).
+            if self.store is not None and job_id is not None:
+                job_meta = self.store.get_job(job_id)
+                if job_meta and job_meta.get("status") == "cancelled":
+                    self._cancel_flag = True
+                    logger.info("Crawl %s cancelled via Redis status check", job_id)
+                    break
+
+            # Maximum duration timeout check
+            now = time.monotonic()
+            elapsed = now - crawl_start_time
+            if elapsed > self.options.max_duration_seconds:
+                logger.warning(
+                    "Crawl %s exceeded max duration of %ds (elapsed=%.1fs)",
+                    job_id,
+                    self.options.max_duration_seconds,
+                    elapsed,
+                )
+                raise TimeoutError(
+                    f"Crawl exceeded max duration of {self.options.max_duration_seconds}s"
+                )
+
+            # Idle timeout (stuck-crawl) check
+            idle_elapsed = now - last_completion_time
+            if idle_elapsed > self.options.idle_timeout_seconds:
+                logger.warning(
+                    "Crawl %s idle for %ds (timeout=%ds) — killing zombie crawl",
+                    job_id,
+                    idle_elapsed,
+                    self.options.idle_timeout_seconds,
+                )
+                raise TimeoutError(
+                    f"Crawl idle for {idle_elapsed:.0f}s — "
+                    f"exceeded idle timeout of {self.options.idle_timeout_seconds}s"
+                )
 
             url, depth = self._queue.popleft()
             normalized = self.normalize_url(url)
@@ -466,6 +519,19 @@ class CrawlEngine:
                 "duration_ms": scrape_duration_ms,
             }
             self._pages.append(page)
+            last_completion_time = time.monotonic()
+
+            # Fire per-page webhook callback
+            if page_callback is not None and job_id is not None:
+                try:
+                    await page_callback(job_id, page)
+                except Exception:
+                    logger.warning(
+                        "Page callback failed for %s (job %s)",
+                        url,
+                        job_id,
+                        exc_info=True,
+                    )
 
             # Discover child links if within max_depth
             if depth < self.options.max_depth:

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -22,7 +22,9 @@ from urllib.parse import urlparse, urlunparse
 
 import httpx
 
-from .link_extractor import extract_links, filter_links
+from common.url import is_private_host
+
+from .link_extractor import classify_links, extract_links, filter_links
 from .scraper_client import ScraperClient
 from .sitemap_parser import SitemapParser
 from .store import JobStore
@@ -64,6 +66,7 @@ class CrawlOptions:
     sitemap_mode: str = "include"  # "include" | "skip" | "only"
     allow_subdomains: bool = False
     allow_external_links: bool = False
+    crawl_entire_domain: bool = False
     max_duration_seconds: int = 1800
     idle_timeout_seconds: int = 300
 
@@ -591,6 +594,27 @@ class CrawlEngine:
                         allow_subdomains=self.options.allow_subdomains,
                         allow_external_links=self.options.allow_external_links,
                     )
+                    # SSRF guard: always block private/internal hosts on
+                    # EXTERNAL URLs regardless of allow_external_links setting.
+                    # Internal and subdomain URLs are already vetted and are
+                    # part of the organization's own infrastructure — they
+                    # bypass the SSRF check. (VAL-SCOPE-017)
+                    classified = classify_links(child_links, url)
+                    if classified.get("external"):
+                        classified["external"] = self._filter_ssrf_blocked(
+                            classified["external"]
+                        )
+                    # Rebuild the full link list from classified buckets
+                    child_links = (
+                        classified.get("internal", [])
+                        + classified.get("subdomain", [])
+                        + classified.get("external", [])
+                    )
+                    # When crawl_entire_domain is False, only follow child paths
+                    # (deeper in the path hierarchy). When True, follow all
+                    # same-domain links including siblings and parents.
+                    if not self.options.crawl_entire_domain:
+                        child_links = self._filter_child_paths(child_links, url)
                     for child_url in child_links:
                         child_normalized = self.normalize_url(child_url)
                         if child_normalized not in self._seen:
@@ -659,6 +683,75 @@ class CrawlEngine:
     def cancel(self) -> None:
         """Signal the crawl to stop at the next opportunity."""
         self._cancel_flag = True
+
+    @staticmethod
+    def _filter_child_paths(links: list[str], current_url: str) -> list[str]:
+        """Filter links to only include child paths of the current URL.
+
+        When ``crawl_entire_domain`` is False, only follow links whose path
+        is a child (deeper) of the current page's path. Links on different
+        domains (subdomains or external) are not affected by this constraint.
+
+        Args:
+            links: List of absolute URL strings to filter.
+            current_url: The URL of the page the links were extracted from.
+
+        Returns:
+            Filtered list of URLs that are child paths (or different-domain).
+        """
+        current_path = urlparse(current_url).path.rstrip("/") + "/"
+        current_domain = (urlparse(current_url).hostname or "").lower()
+
+        result: list[str] = []
+        for link in links:
+            parsed = urlparse(link)
+            link_path = parsed.path or "/"
+            link_domain = (parsed.hostname or "").lower()
+
+            # If the link is on a different domain (including subdomain when
+            # already allowed by filter_links), skip the child-path constraint.
+            if link_domain != current_domain:
+                result.append(link)
+                continue
+
+            # On same domain: only allow child paths (deeper in hierarchy)
+            if link_path.startswith(current_path) and link_path != current_path.rstrip(
+                "/"
+            ):
+                result.append(link)
+                continue
+
+            # / page (not a child path of current)
+            logger.debug(
+                "Filtered out non-child path: %s (current=%s, crawl_entire_domain=False)",
+                link,
+                current_url,
+            )
+
+        return result
+
+    @staticmethod
+    def _filter_ssrf_blocked(links: list[str]) -> list[str]:
+        """Filter out links to private/internal hosts (SSRF guard).
+
+        Always active regardless of ``allow_external_links`` setting.
+        Uses ``common.url.is_private_host()`` which checks RFC 1918
+        private ranges, loopback, link-local, metadata IPs, and
+        internal hostname suffixes.
+
+        Args:
+            links: List of absolute URL strings to filter.
+
+        Returns:
+            List of URLs that are NOT private/internal hosts.
+        """
+        result: list[str] = []
+        for link in links:
+            if is_private_host(link):
+                logger.debug("SSRF guard blocked private host URL: %s", link)
+                continue
+            result.append(link)
+        return result
 
     def _get_filter_reason(self, url: str) -> dict | None:
         """Determine which path filter excluded a URL and why.

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -24,6 +24,7 @@ import httpx
 
 from .link_extractor import extract_links, filter_links
 from .scraper_client import ScraperClient
+from .sitemap_parser import SitemapParser
 from .store import JobStore
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class CrawlOptions:
     ignore_query_parameters: bool = False
     regex_on_full_url: bool = False
     verbose: bool = False
+    sitemap_mode: str = "include"  # "include" | "skip" | "only"
     allow_subdomains: bool = False
     allow_external_links: bool = False
     max_duration_seconds: int = 1800
@@ -367,8 +369,52 @@ class CrawlEngine:
         parsed_start = urlparse(start_url)
         base_domain = parsed_start.hostname.lower() if parsed_start.hostname else ""
 
-        # Seed the BFS queue
+        # Seed the BFS queue with start URL (DO NOT add to _seen — the main
+        # loop adds to _seen when it pops each URL. Adding here would cause
+        # the main loop's dedup check to skip the start URL.)
         self._queue.append((start_url, 0))
+        start_normalized = self.normalize_url(start_url)
+
+        # Seed with sitemap URLs if sitemap_mode is not "skip"
+        sitemap_seeded_count = 0
+        if self.options.sitemap_mode != "skip":
+            try:
+                sitemap_urls = await self._fetch_sitemap_urls(base_domain)
+            except Exception as exc:
+                logger.warning(
+                    "Sitemap fetch failed for %s: %s — falling back to HTML-only discovery",
+                    base_domain,
+                    exc,
+                )
+                sitemap_urls = []
+            if sitemap_urls:
+                # Truncate sitemap URLs to respect max_pages (reserve 1 for start URL)
+                remaining = self.options.max_pages - 1
+                if remaining > 0:
+                    sitemap_urls = sitemap_urls[:remaining]
+                sitemap_dedup: set[str] = set()
+                for sm_url in sitemap_urls:
+                    sm_normalized = self.normalize_url(sm_url)
+                    # Skip if duplicate within sitemap, or if it matches
+                    # the start URL (already in queue — will be deduped
+                    # by the main loop's seen-set).  The sitemap URL is
+                    # NOT added to self._seen here because the main loop
+                    # reads _seen to decide whether to scrape. If we added
+                    # it here, the main loop would skip it.
+                    if (
+                        sm_normalized in sitemap_dedup
+                        or sm_normalized == start_normalized
+                    ):
+                        continue
+                    sitemap_dedup.add(sm_normalized)
+                    self._queue.appendleft((sm_url, 0))
+                    sitemap_seeded_count += 1
+                logger.info(
+                    "Seeded %d sitemap URLs into crawl queue for %s",
+                    sitemap_seeded_count,
+                    base_domain,
+                )
+
         last_store_update = time.monotonic()
         crawl_start_time = time.monotonic()
         last_completion_time = crawl_start_time
@@ -534,7 +580,8 @@ class CrawlEngine:
                     )
 
             # Discover child links if within max_depth
-            if depth < self.options.max_depth:
+            # In "only" mode, sitemap URLs are the exclusive source — skip HTML link discovery
+            if depth < self.options.max_depth and self.options.sitemap_mode != "only":
                 html = await self._get_html(url)
                 if html:
                     child_links = extract_links(html, url)
@@ -575,6 +622,39 @@ class CrawlEngine:
         return normalize_url(
             url, ignore_query_parameters=self.options.ignore_query_parameters
         )
+
+    async def _fetch_sitemap_urls(self, domain: str) -> list[str]:
+        """Fetch sitemap URLs for the given domain.
+
+        Uses ``SitemapParser`` to discover and parse sitemaps from
+        robots.txt and common locations.
+
+        Args:
+            domain: The domain (hostname) to fetch sitemaps for.
+
+        Returns:
+            A list of unique, absolute URLs discovered from sitemaps.
+        """
+        try:
+            parser = SitemapParser(
+                client=self._html_client,
+                max_recursion_depth=3,
+            )
+            # Use the parser's own client management — it creates its
+            # own client if we don't pass one (but we already have one).
+            parser._client = self._html_client
+            urls = await parser.get_urls(
+                domain,
+                limit=self.options.max_pages * 2,  # generous outer limit
+            )
+            return urls
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch sitemaps for %s: %s — falling back to HTML-only discovery",
+                domain,
+                exc,
+            )
+            return []
 
     def cancel(self) -> None:
         """Signal the crawl to stop at the next opportunity."""

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -1,0 +1,450 @@
+"""CrawlEngine — BFS crawl orchestrator for GroktoCrawl.
+
+Manages a queue of (url, depth) tuples, tracks seen URLs for dedup,
+enforces ``max_pages`` and ``max_depth`` limits, uses the shared
+``LinkExtractor`` to discover child links, integrates with
+``ScraperClient`` for per-page fetching, and writes progress to the
+job store for status polling.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from .link_extractor import extract_links, filter_links
+from .scraper_client import ScraperClient
+from .store import JobStore
+
+logger = logging.getLogger(__name__)
+
+
+# ── Data types ───────────────────────────────────────────────────
+
+
+@dataclass
+class CrawlOptions:
+    """Options controlling crawl behavior.
+
+    Attributes:
+        max_pages: Maximum number of pages to scrape (hard stop).
+        max_depth: Maximum link-follow depth. Pages at max_depth are
+            scraped but their links are not followed.
+        include_paths: If set, only URLs whose path matches at least one
+            of these glob/regex patterns are scraped.
+        exclude_paths: URLs whose path matches any of these glob/regex
+            patterns are excluded (takes precedence over include).
+        ignore_query_parameters: If True, query-string variants of the
+            same base URL are collapsed to one fetch.
+        regex_on_full_url: If True, include/exclude paths are treated as
+            regex patterns (default: glob).
+        allow_subdomains: If True, follow links to subdomains.
+        allow_external_links: If True, follow links to external domains.
+    """
+
+    max_pages: int = 10
+    max_depth: int = 2
+    include_paths: list[str] | None = None
+    exclude_paths: list[str] | None = None
+    ignore_query_parameters: bool = False
+    regex_on_full_url: bool = False
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
+
+
+@dataclass
+class CrawlResult:
+    """Result of a crawl run."""
+
+    pages: list[dict] = field(default_factory=list)
+    total: int = 0
+    completed: int = 0
+    errors: list[dict] = field(default_factory=list)
+
+
+# ── Public functions ─────────────────────────────────────────────
+
+
+def _clean_path(path: str) -> str:
+    """Clean up a URL path by collapsing dot segments and normalizing.
+
+    Collapses ``/./`` and ``/../`` segments, and reduces ``/.`` at the
+    end to ``/``.
+    """
+    import posixpath
+
+    if not path:
+        return "/"
+
+    # posixpath.normpath collapses dot segments
+    cleaned = posixpath.normpath(path)
+
+    # normpath strips trailing slash, but root should remain /
+    if not cleaned:
+        return "/"
+
+    return cleaned
+
+
+def normalize_url(url: str, ignore_query_parameters: bool = False) -> str:
+    """Normalize a URL for dedup within a crawl run.
+
+    Steps:
+        1. Strip fragment identifier.
+        2. Lowercase scheme and host.
+        3. Remove default ports (80 for http, 443 for https).
+        4. Normalize trailing slash (remove for non-root paths).
+        5. Collapse ``/./`` and ``/../`` path segments.
+        6. Optionally strip query string entirely.
+        7. Sort query parameters if keeping them.
+
+    Args:
+        url: The URL to normalize.
+        ignore_query_parameters: If True, strip the query string.
+
+    Returns:
+        Normalized URL string.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname.lower() if parsed.hostname else ""
+    port = parsed.port
+    path = _clean_path(parsed.path or "/")
+
+    # Build netloc without default ports
+    netloc = hostname
+    if port is not None and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        netloc = f"{hostname}:{port}"
+
+    # Normalize trailing slash for non-root paths
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+
+    # Handle query parameters
+    if ignore_query_parameters:
+        query = ""
+    else:
+        # Sort query params for consistency
+        parsed_qs = parsed.query
+        if parsed_qs:
+            params = sorted(parsed_qs.split("&"))
+            query = "&".join(params)
+        else:
+            query = ""
+
+    normalized = urlunparse((scheme, netloc, path, parsed.params, query, ""))
+    return normalized
+
+
+async def fetch_html(url: str, timeout: float = 15.0) -> str | None:
+    """Fetch raw HTML from a URL for link extraction purposes.
+
+    This is a lightweight HTTP GET that follows redirects and returns
+    the response text. It is used by ``CrawlEngine`` to discover child
+    links from scraped pages, separate from the content scraping done
+    via ``ScraperClient``.
+
+    Args:
+        url: The URL to fetch.
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        The response text (HTML), or ``None`` if the fetch failed.
+    """
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout) as client:
+            resp = await client.get(url)
+            if resp.status_code == 200:
+                return resp.text
+            logger.debug("fetch_html got status %d for %s", resp.status_code, url)
+            return None
+    except Exception as e:
+        logger.debug("fetch_html failed for %s: %s", url, e)
+        return None
+
+
+def _match_path(
+    url: str,
+    include_paths: list[str] | None,
+    exclude_paths: list[str] | None,
+    regex_on_full_url: bool = False,
+) -> bool:
+    """Check whether a URL passes include/exclude path filters.
+
+    Args:
+        url: The full URL to check.
+        include_paths: If set, URL must match at least one pattern.
+        exclude_paths: If set, URL must not match any pattern
+            (takes precedence).
+        regex_on_full_url: If True, patterns are regex; else glob.
+
+    Returns:
+        True if the URL should be crawled (passes all filters).
+    """
+    import re
+
+    target = url if regex_on_full_url else urlparse(url).path
+
+    if regex_on_full_url:
+        # Regex mode
+        if exclude_paths:
+            for pattern in exclude_paths:
+                try:
+                    if re.search(pattern, target):
+                        return False
+                except re.error:
+                    continue
+        if include_paths:
+            for pattern in include_paths:
+                try:
+                    if re.search(pattern, target):
+                        return True
+                except re.error:
+                    continue
+            return False  # include_paths set but none matched
+    else:
+        # Glob mode — convert glob patterns to regex
+        if exclude_paths:
+            for pattern in exclude_paths:
+                regex = _glob_to_regex(pattern)
+                try:
+                    if re.search(regex, target):
+                        return False
+                except re.error:
+                    continue
+        if include_paths:
+            for pattern in include_paths:
+                regex = _glob_to_regex(pattern)
+                try:
+                    if re.search(regex, target):
+                        return True
+                except re.error:
+                    continue
+            return False  # include_paths set but none matched
+
+    return True  # No include_paths constraint, or passed all
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Convert a simple glob pattern to an anchored regex pattern.
+
+    Supports ``*`` (match any chars except ``/``), ``**`` (match any
+    chars including ``/``), and ``?`` (match single char).
+
+    The returned pattern is anchored with ``^`` and ``$`` so that
+    ``re.search`` matches the full target string, not a substring.
+    """
+    i, n = 0, len(pattern)
+    inner: list[str] = []
+    while i < n:
+        c = pattern[i]
+        if c == "*" and i + 1 < n and pattern[i + 1] == "*":
+            inner.append(".*")
+            i += 2
+        elif c == "*":
+            inner.append("[^/]*")
+            i += 1
+        elif c == "?":
+            inner.append(".")
+            i += 1
+        elif c in ".^$+{}[]\\|()":
+            inner.append("\\" + c)
+            i += 1
+        else:
+            inner.append(c)
+            i += 1
+    return "^" + "".join(inner) + "$"
+
+
+# ── CrawlEngine ──────────────────────────────────────────────────
+
+
+class CrawlEngine:
+    """BFS crawl orchestrator.
+
+    Usage::
+
+        engine = CrawlEngine(scraper_client, options=CrawlOptions(max_pages=5))
+        result = await engine.run("https://example.com", job_id="...")
+    """
+
+    def __init__(
+        self,
+        scraper_client: ScraperClient,
+        store: JobStore | None = None,
+        options: CrawlOptions | None = None,
+    ):
+        self.scraper = scraper_client
+        self.store = store
+        self.options = options or CrawlOptions()
+        self._seen: set[str] = set()
+        self._queue: deque[tuple[str, int]] = deque()
+        self._pages: list[dict] = []
+        self._errors: list[dict] = []
+        self._cancel_flag: bool = False
+        self._update_interval: float = 1.0
+        self._html_client: httpx.AsyncClient | None = None
+
+    async def _get_html(self, url: str) -> str | None:
+        """Get HTML for a URL, using an internal persistent client."""
+        if self._html_client is None:
+            self._html_client = httpx.AsyncClient(follow_redirects=True, timeout=15.0)
+        try:
+            resp = await self._html_client.get(url)
+            if resp.status_code == 200:
+                return resp.text
+            return None
+        except Exception:
+            return None
+
+    async def close(self) -> None:
+        """Close the internal HTTP client."""
+        if self._html_client is not None:
+            await self._html_client.aclose()
+            self._html_client = None
+
+    async def run(self, start_url: str, job_id: str | None = None) -> CrawlResult:
+        """Execute a BFS crawl starting from ``start_url``.
+
+        Args:
+            start_url: The URL to begin crawling from.
+            job_id: Optional job ID for periodic store updates.
+
+        Returns:
+            A ``CrawlResult`` with scraped pages, totals, and errors.
+        """
+        parsed_start = urlparse(start_url)
+        base_domain = parsed_start.hostname.lower() if parsed_start.hostname else ""
+
+        # Seed the BFS queue
+        self._queue.append((start_url, 0))
+        last_store_update = time.monotonic()
+
+        while self._queue and len(self._pages) < self.options.max_pages:
+            if self._cancel_flag:
+                logger.info("Crawl cancelled via cancel flag")
+                break
+
+            url, depth = self._queue.popleft()
+            normalized = self.normalize_url(url)
+
+            # Dedup check
+            if normalized in self._seen:
+                logger.debug("Skipping already-seen URL: %s", url)
+                continue
+
+            # Max depth check: pages at max_depth are scraped but not
+            # followed; pages beyond max_depth are skipped entirely.
+            if depth > self.options.max_depth:
+                logger.debug("Skipping URL beyond max_depth: %s (depth=%d)", url, depth)
+                continue
+
+            # Mark as seen immediately to prevent re-enqueue
+            self._seen.add(normalized)
+
+            # Path filter check
+            if not _match_path(
+                url,
+                self.options.include_paths,
+                self.options.exclude_paths,
+                self.options.regex_on_full_url,
+            ):
+                logger.debug("Skipping URL excluded by path filter: %s", url)
+                continue
+
+            # Scrape the page
+            result = await self.scraper.scrape(url)
+
+            if not result.get("success"):
+                error_msg = result.get("error", "Unknown scrape error")
+                self._errors.append({"url": url, "error": error_msg})
+                logger.warning("Scrape failed for %s: %s", url, error_msg)
+
+                # Start URL failure — return error immediately
+                if depth == 0:
+                    logger.error("Start URL scrape failed: %s", error_msg)
+                    result_obj = CrawlResult(
+                        pages=[],
+                        total=0,
+                        completed=0,
+                        errors=self._errors,
+                    )
+                    await self.close()
+                    return result_obj
+                continue
+
+            # Record successful page
+            data = result.get("data", {})
+            page = {
+                "url": url,
+                "markdown": data.get("markdown", ""),
+            }
+            self._pages.append(page)
+
+            # Discover child links if within max_depth
+            if depth < self.options.max_depth:
+                html = await self._get_html(url)
+                if html:
+                    child_links = extract_links(html, url)
+                    child_links = filter_links(
+                        child_links,
+                        base_domain=base_domain,
+                        allow_subdomains=self.options.allow_subdomains,
+                        allow_external_links=self.options.allow_external_links,
+                    )
+                    for child_url in child_links:
+                        child_normalized = self.normalize_url(child_url)
+                        if child_normalized not in self._seen:
+                            self._queue.append((child_url, depth + 1))
+
+            # Periodic job store update
+            if self.store is not None and job_id is not None:
+                now = time.monotonic()
+                if now - last_store_update >= self._update_interval:
+                    self._update_store(job_id)
+                    last_store_update = now
+
+        # Final store update
+        if self.store is not None and job_id is not None:
+            self._update_store(job_id)
+
+        await self.close()
+
+        return CrawlResult(
+            pages=self._pages,
+            total=len(self._pages) + len(self._queue),
+            completed=len(self._pages),
+            errors=self._errors,
+        )
+
+    def normalize_url(self, url: str) -> str:
+        """Normalize a URL using this engine's options."""
+        return normalize_url(
+            url, ignore_query_parameters=self.options.ignore_query_parameters
+        )
+
+    def cancel(self) -> None:
+        """Signal the crawl to stop at the next opportunity."""
+        self._cancel_flag = True
+
+    def _update_store(self, job_id: str) -> None:
+        """Write current progress to the job store."""
+        if self.store is None:
+            return
+        try:
+            payload = {
+                "completed": len(self._pages),
+                "total": len(self._pages) + len(self._queue),
+                "pages": self._pages,
+                "errors": self._errors,
+            }
+            self.store.complete_job(job_id, payload)
+        except Exception:
+            logger.warning("Failed to update job store", exc_info=True)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -9,7 +9,10 @@ job store for status polling.
 
 from __future__ import annotations
 
+import json
 import logging
+import posixpath
+import re
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -76,8 +79,6 @@ def _clean_path(path: str) -> str:
     Collapses ``/./`` and ``/../`` segments, and reduces ``/.`` at the
     end to ``/``.
     """
-    import posixpath
-
     if not path:
         return "/"
 
@@ -188,8 +189,6 @@ def _match_path(
     Returns:
         True if the URL should be crawled (passes all filters).
     """
-    import re
-
     target = url if regex_on_full_url else urlparse(url).path
 
     if regex_on_full_url:
@@ -435,7 +434,13 @@ class CrawlEngine:
         self._cancel_flag = True
 
     def _update_store(self, job_id: str) -> None:
-        """Write current progress to the job store."""
+        """Write current progress to the job data key (not meta).
+
+        Updates only the ``data`` key in Valkey so the job's ``meta``
+        status (``processing``) remains unchanged during the crawl.
+        The caller's final ``store.complete_job()`` call sets both the
+        final data and the ``completed`` status.
+        """
         if self.store is None:
             return
         try:
@@ -445,6 +450,11 @@ class CrawlEngine:
                 "pages": self._pages,
                 "errors": self._errors,
             }
-            self.store.complete_job(job_id, payload)
+            # Write data key directly without changing meta status
+            self.store.redis.set(
+                f"job:{job_id}:data",
+                json.dumps(payload),
+                ex=86400,
+            )
         except Exception:
             logger.warning("Failed to update job store", exc_info=True)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -16,6 +16,7 @@ import re
 import time
 from collections import deque
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from urllib.parse import urlparse, urlunparse
 
 import httpx
@@ -400,8 +401,10 @@ class CrawlEngine:
                 logger.debug("Skipping URL excluded by path filter: %s", url)
                 continue
 
-            # Scrape the page
+            # Scrape the page with timing
+            scrape_start = time.monotonic()
             result = await self.scraper.scrape(url)
+            scrape_duration_ms = int((time.monotonic() - scrape_start) * 1000)
 
             if not result.get("success"):
                 error_msg = result.get("error", "Unknown scrape error")
@@ -421,11 +424,46 @@ class CrawlEngine:
                     return result_obj
                 continue
 
-            # Record successful page
+            # Record successful page with enriched metadata
             data = result.get("data", {})
+            metadata = data.get("metadata") or {}
+            og = metadata.get("og") or {}
+            meta = metadata.get("meta") or {}
+            title = (
+                og.get("title")
+                or meta.get("title")
+                or data.get("title")
+                or metadata.get("title")
+                or ""
+            )
+            description = (
+                og.get("description")
+                or meta.get("description")
+                or metadata.get("description")
+                or ""
+            )
+            source = data.get("source", "unknown")
+            status_code = metadata.get("statusCode") or data.get("status_code") or 200
+            content_type = (
+                metadata.get("content-type")
+                or metadata.get("contentType")
+                or "text/html"
+            )
+            scraped_at = datetime.now(UTC).isoformat()
+
             page = {
                 "url": url,
                 "markdown": data.get("markdown", ""),
+                "metadata": {
+                    "title": title,
+                    "description": description,
+                    "source": source,
+                },
+                "title": title,
+                "status_code": status_code,
+                "content_type": content_type,
+                "scraped_at": scraped_at,
+                "duration_ms": scrape_duration_ms,
             }
             self._pages.append(page)
 

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import collections.abc
 import contextlib
-import json
 import logging
 import posixpath
 import re
@@ -681,6 +680,10 @@ class CrawlEngine:
         This is the core unit of concurrent work. The semaphore ensures
         that at most ``self._effective_concurrency`` scrapes run
         simultaneously.
+
+        A per-scrape timeout (VAL-CONC-043) prevents a hanging scrape
+        from permanently occupying a semaphore slot. On timeout, the
+        URL is recorded in ``errors`` and the slot is released.
         """
         async with self._semaphore:
             if self._cancel_flag:
@@ -702,16 +705,45 @@ class CrawlEngine:
 
             self._last_scrape_start = time.monotonic()
 
-            # Scrape the page
+            # Scrape the page with a per-scrape timeout to prevent semaphore
+            # slot starvation (VAL-CONC-043 / VAL-CONC-051).
             scrape_start = time.monotonic()
+            # Default timeout: 60 seconds per individual scrape
+            per_scrape_timeout = 60.0
             try:
-                result = await self.scraper.scrape(
-                    url,
-                    ignore_robots_txt=self.options.ignore_robots_txt,
-                    robots_user_agent=self.options.robots_user_agent,
+                result = await asyncio.wait_for(
+                    self.scraper.scrape(
+                        url,
+                        ignore_robots_txt=self.options.ignore_robots_txt,
+                        robots_user_agent=self.options.robots_user_agent,
+                    ),
+                    timeout=per_scrape_timeout,
                 )
+            except TimeoutError:
+                elapsed = time.monotonic() - scrape_start
+                timeout_entry = {
+                    "url": url,
+                    "error": f"Scrape timed out after {elapsed:.1f}s",
+                    "error_code": "TIMEOUT",
+                }
+                self._errors.append(timeout_entry)
+                logger.warning(
+                    "Scrape timed out for %s after %.1fs (job %s)",
+                    url,
+                    elapsed,
+                    job_id,
+                )
+                return
+            except asyncio.CancelledError:
+                logger.debug("Scrape cancelled for %s (job %s)", url, job_id)
+                return
             except Exception as exc:
-                self._errors.append({"url": url, "error": str(exc)})
+                error_entry = {
+                    "url": url,
+                    "error": str(exc),
+                    "error_code": "SCRAPE_ERROR",
+                }
+                self._errors.append(error_entry)
                 logger.warning("Scrape exception for %s: %s", url, exc)
                 if depth == 0:
                     raise  # let the caller handle start URL failure
@@ -722,8 +754,11 @@ class CrawlEngine:
             if not result.get("success"):
                 error_msg = result.get("error", "Unknown scrape error")
 
-                # Detect politeness-blocked results
-                if "Blocked by politeness" in error_msg:
+                # Detect politeness-blocked results (VAL-CONC-025)
+                if (
+                    "Blocked by politeness" in error_msg
+                    or "ROBOTS_BLOCKED" in error_msg
+                ):
                     robots_entry = {
                         "url": url,
                         "error": error_msg,
@@ -737,7 +772,12 @@ class CrawlEngine:
                     # Blocked start URL is not a fatal error — it's expected
                     return
                 else:
-                    self._errors.append({"url": url, "error": error_msg})
+                    error_entry = {
+                        "url": url,
+                        "error": error_msg,
+                        "error_code": "SCRAPE_ERROR",
+                    }
+                    self._errors.append(error_entry)
                     logger.warning("Scrape failed for %s: %s", url, error_msg)
 
                 # Start URL failure — raise to signal immediate stop
@@ -788,6 +828,10 @@ class CrawlEngine:
             }
             self._pages.append(page)
             self._scraped_count += 1
+
+            # Atomically increment the completed count (VAL-CONC-042)
+            if self.store is not None and job_id is not None:
+                self.store.increment_completed(job_id)
 
             # Fire per-page webhook callback
             if page_callback is not None and job_id is not None:
@@ -1002,28 +1046,26 @@ class CrawlEngine:
         return None
 
     def _update_store(self, job_id: str) -> None:
-        """Write current progress to the job data key (not meta).
+        """Write current progress to the job data key using atomic updates.
 
-        Updates only the ``data`` key in Valkey so the job's ``meta``
-        status (``processing``) remains unchanged during the crawl.
+        Uses ``JobStore.update_job_progress()`` which sources the
+        ``completed`` count from a Valkey INCR counter (immune to
+        read-modify-write races, per VAL-CONC-042). The job ``meta``
+        status remains ``processing`` during the crawl.
         The caller's final ``store.complete_job()`` call sets both the
         final data and the ``completed`` status.
         """
         if self.store is None:
             return
         try:
-            payload = {
-                "completed": len(self._pages),
-                "total": len(self._pages) + len(self._queue),
-                "pages": self._pages,
-                "errors": self._errors,
-                "robots_blocked": self._robots_blocked,
-            }
-            # Write data key directly without changing meta status
-            self.store.redis.set(
-                f"job:{job_id}:data",
-                json.dumps(payload),
-                ex=86400,
+            total = len(self._pages) + len(self._queue)
+            self.store.update_job_progress(
+                job_id=job_id,
+                pages=self._pages,
+                total=total,
+                errors=self._errors,
+                robots_blocked=self._robots_blocked,
+                filtered_out=self._filtered_out if self.options.verbose else None,
             )
         except Exception:
             logger.warning("Failed to update job store", exc_info=True)

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -46,6 +46,7 @@ class CrawlOptions:
             same base URL are collapsed to one fetch.
         regex_on_full_url: If True, include/exclude paths are treated as
             regex patterns (default: glob).
+        verbose: If True, track filtered-out URLs with reasons.
         allow_subdomains: If True, follow links to subdomains.
         allow_external_links: If True, follow links to external domains.
     """
@@ -56,6 +57,7 @@ class CrawlOptions:
     exclude_paths: list[str] | None = None
     ignore_query_parameters: bool = False
     regex_on_full_url: bool = False
+    verbose: bool = False
     allow_subdomains: bool = False
     allow_external_links: bool = False
 
@@ -68,6 +70,7 @@ class CrawlResult:
     total: int = 0
     completed: int = 0
     errors: list[dict] = field(default_factory=list)
+    filtered_out: list[dict] = field(default_factory=list)
 
 
 # ── Public functions ─────────────────────────────────────────────
@@ -231,6 +234,32 @@ def _match_path(
     return True  # No include_paths constraint, or passed all
 
 
+def _matches_pattern(
+    target: str, pattern: str, regex_on_full_url: bool = False
+) -> bool:
+    """Check whether ``target`` matches a single path pattern.
+
+    Args:
+        target: The string (path or full URL) to check.
+        pattern: The glob or regex pattern to match against.
+        regex_on_full_url: If True, ``pattern`` is a regex; else glob.
+
+    Returns:
+        True if the target matches the pattern.
+    """
+    if regex_on_full_url:
+        try:
+            return bool(re.search(pattern, target))
+        except re.error:
+            return False
+    else:
+        regex = _glob_to_regex(pattern)
+        try:
+            return bool(re.search(regex, target))
+        except re.error:
+            return False
+
+
 def _glob_to_regex(pattern: str) -> str:
     """Convert a simple glob pattern to an anchored regex pattern.
 
@@ -287,6 +316,7 @@ class CrawlEngine:
         self._queue: deque[tuple[str, int]] = deque()
         self._pages: list[dict] = []
         self._errors: list[dict] = []
+        self._filtered_out: list[dict] = []
         self._cancel_flag: bool = False
         self._update_interval: float = 1.0
         self._html_client: httpx.AsyncClient | None = None
@@ -348,13 +378,25 @@ class CrawlEngine:
             # Mark as seen immediately to prevent re-enqueue
             self._seen.add(normalized)
 
-            # Path filter check
+            # Determine the URL for path filtering.
+            # When ignore_query_parameters is True, strip query params
+            # before matching so that patterns match against the path
+            # only (VAL-SCOPE-073).
+            filter_url = (
+                urlparse(url)._replace(query="").geturl()
+                if self.options.ignore_query_parameters
+                else url
+            )
             if not _match_path(
-                url,
+                filter_url,
                 self.options.include_paths,
                 self.options.exclude_paths,
                 self.options.regex_on_full_url,
             ):
+                if self.options.verbose:
+                    filter_reason = self._get_filter_reason(filter_url)
+                    if filter_reason:
+                        self._filtered_out.append(filter_reason)
                 logger.debug("Skipping URL excluded by path filter: %s", url)
                 continue
 
@@ -421,6 +463,7 @@ class CrawlEngine:
             total=len(self._pages) + len(self._queue),
             completed=len(self._pages),
             errors=self._errors,
+            filtered_out=self._filtered_out,
         )
 
     def normalize_url(self, url: str) -> str:
@@ -432,6 +475,47 @@ class CrawlEngine:
     def cancel(self) -> None:
         """Signal the crawl to stop at the next opportunity."""
         self._cancel_flag = True
+
+    def _get_filter_reason(self, url: str) -> dict | None:
+        """Determine which path filter excluded a URL and why.
+
+        Only called when ``verbose`` is True and the URL has already
+        been determined to NOT pass ``_match_path()``.
+
+        Returns:
+            A dict with ``url``, ``reason``, and ``pattern`` keys, or
+            ``None`` if no filter reason could be determined.
+        """
+        target = url if self.options.regex_on_full_url else urlparse(url).path
+
+        # Check exclude_paths first (they bypass include_paths)
+        if self.options.exclude_paths:
+            for pattern in self.options.exclude_paths:
+                if _matches_pattern(target, pattern, self.options.regex_on_full_url):
+                    return {
+                        "url": url,
+                        "reason": "exclude_paths",
+                        "pattern": pattern,
+                    }
+
+        # Check include_paths
+        if self.options.include_paths:
+            for pattern in self.options.include_paths:
+                if _matches_pattern(target, pattern, self.options.regex_on_full_url):
+                    # Would match include, so not excluded by include
+                    return {
+                        "url": url,
+                        "reason": "include_paths",
+                        "pattern": None,
+                    }
+            # No include_paths matched
+            return {
+                "url": url,
+                "reason": "include_paths",
+                "pattern": None,
+            }
+
+        return None
 
     def _update_store(self, job_id: str) -> None:
         """Write current progress to the job data key (not meta).

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -25,6 +25,7 @@ import httpx
 
 from common.url import is_private_host
 
+from .dedup import DedupManager
 from .link_extractor import classify_links, extract_links, filter_links
 from .scraper_client import ScraperClient
 from .sitemap_parser import SitemapParser
@@ -379,6 +380,9 @@ class CrawlEngine:
         self._scraped_count: int = 0
         # Track in-flight tasks for cancellation
         self._pending_tasks: set[asyncio.Task] = set()
+        # Content-level dedup (canonical + content hash)
+        self.dedup_manager = DedupManager()
+        self._dedup_skipped: int = 0  # Pages skipped by content-level dedup
 
     def _resolve_concurrency(self) -> int:
         """Determine the effective concurrency value.
@@ -596,7 +600,7 @@ class CrawlEngine:
 
         return CrawlResult(
             pages=self._pages,
-            total=len(self._pages) + len(self._queue),
+            total=len(self._pages) + len(self._queue) + self._dedup_skipped,
             completed=len(self._pages),
             errors=self._errors,
             robots_blocked=self._robots_blocked,
@@ -832,6 +836,69 @@ class CrawlEngine:
                 "scraped_at": scraped_at,
                 "duration_ms": scrape_duration_ms,
             }
+
+            # ── Content-level dedup checks ──────────────────────────
+            # Layer 2: Canonical tag check (runs first).
+            # Layer 3: Content hash check (runs second, only if canonical
+            #          check did not skip the page).
+            markdown = data.get("markdown", "")
+            canonical_dup_url: str | None = None
+            content_is_dup: bool = False
+
+            # Fetch HTML for canonical checking (also reused for link
+            # extraction below if needed).
+            html = await self._get_html(url)
+
+            if html:
+                canonical_dup_url = self.dedup_manager.check_canonical(html, url)
+
+            if canonical_dup_url:
+                # Canonical duplicate — skip this page (VAL-SCRAPE-021,
+                # VAL-SCRAPE-026).
+                error_entry = {
+                    "url": url,
+                    "error": f"Duplicate canonical URL: {canonical_dup_url}",
+                    "error_type": "duplicate_canonical",
+                    "canonical_url": canonical_dup_url,
+                }
+                self._errors.append(error_entry)
+                self._dedup_skipped += 1
+                logger.info(
+                    "Canonical dedup skipped %s → canonical %s already scraped (job %s)",
+                    url,
+                    canonical_dup_url,
+                    job_id,
+                )
+                # Skip link extraction and page storage for dedup'd pages
+                return
+            else:
+                # Layer 3: Content hash dedup (VAL-SCRAPE-024, VAL-SCRAPE-026).
+                content_hash = self.dedup_manager.compute_content_hash(markdown)
+                if content_hash is not None and self.dedup_manager.is_duplicate_content(
+                    content_hash
+                ):
+                    content_is_dup = True
+
+                if content_is_dup:
+                    error_entry = {
+                        "url": url,
+                        "error": "Duplicate content (identical markdown hash)",
+                        "error_type": "duplicate_content",
+                    }
+                    self._errors.append(error_entry)
+                    self._dedup_skipped += 1
+                    logger.info(
+                        "Content dedup skipped %s — identical content already scraped (job %s)",
+                        url,
+                        job_id,
+                    )
+                    return
+
+                # Page passed all dedup checks — register it.
+                self.dedup_manager.mark_scraped(
+                    url, canonical_url=canonical_dup_url, content_hash=content_hash
+                )
+
             self._pages.append(page)
             self._scraped_count += 1
 
@@ -854,7 +921,10 @@ class CrawlEngine:
             # Discover child links if within max_depth
             # In "only" mode, sitemap URLs are the exclusive source
             if depth < self.options.max_depth and self.options.sitemap_mode != "only":
-                html = await self._get_html(url)
+                # Reuse the HTML fetched for canonical check if available;
+                # otherwise fetch it now for link extraction only.
+                if html is None and depth < self.options.max_depth:
+                    html = await self._get_html(url)
                 if html:
                     child_links = extract_links(html, url)
                     child_links = filter_links(
@@ -1064,7 +1134,7 @@ class CrawlEngine:
         if self.store is None:
             return
         try:
-            total = len(self._pages) + len(self._queue)
+            total = len(self._pages) + len(self._queue) + self._dedup_skipped
             self.store.update_job_progress(
                 job_id=job_id,
                 pages=self._pages,

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -35,6 +35,100 @@ from .store import JobStore
 logger = logging.getLogger(__name__)
 
 
+def _now_timestamp() -> str:
+    """Return the current UTC time as an ISO 8601 timestamp string."""
+    return datetime.now(UTC).isoformat()
+
+
+def _classify_scrape_error(error_msg: str, error_code: str = "") -> str:
+    """Classify a scrape error message into a machine-readable error type.
+
+    Maps error strings from the scraper-svc and httpx to standardised
+    error types used by the ``/v2/crawl/{id}/errors`` endpoint:
+
+    - ``dns_error``: DNS resolution failures
+    - ``connection_error``: Connection refused / reset / closed
+    - ``http_error``: HTTP 4xx/5xx status codes
+    - ``timeout``: Request-level timeouts (not per-page scrape timeouts,
+      which are caught separately as ``asyncio.TimeoutError``)
+    - ``scrape_error``: Generic/fallback scrape failures
+
+    Args:
+        error_msg: The error message string from the scraper response.
+        error_code: Optional machine-readable error code from the scraper.
+
+    Returns:
+        A standardised error type string.
+    """
+    # If the scraper-svc provided a structured error_code, use it.
+    code_map = {
+        "TIMEOUT": "timeout",
+        "UPSTREAM_ERROR": "http_error",
+        "INVALID_REQUEST": "scrape_error",
+        "AUTH_ERROR": "http_error",
+    }
+    if error_code in code_map:
+        return code_map[error_code]
+
+    msg_lower = error_msg.lower()
+
+    # DNS resolution failures
+    if any(
+        pattern in msg_lower
+        for pattern in [
+            "name resolution",
+            "getaddrinfo",
+            "dns",
+            "no address found",
+            "nodename nor servname provided",
+            "temporary name error",
+            "name or service not known",
+        ]
+    ):
+        return "dns_error"
+
+    # Connection-level errors
+    if any(
+        pattern in msg_lower
+        for pattern in [
+            "connection refused",
+            "connection reset",
+            "connection closed",
+            "connection aborted",
+            "connect call failed",
+            "no route to host",
+            "network is unreachable",
+            "connection timed out",
+        ]
+    ):
+        return "connection_error"
+
+    # HTTP errors
+    if any(
+        pattern in msg_lower
+        for pattern in [
+            "http 4",
+            "http 5",
+            "status code 4",
+            "status code 5",
+            "400 bad request",
+            "401 unauthorized",
+            "403 forbidden",
+            "404 not found",
+            "500 internal",
+            "502 bad gateway",
+            "503 service unavailable",
+        ]
+    ):
+        return "http_error"
+
+    # Scraper-level timeouts (caught in fetch tiers)
+    if "timed out" in msg_lower or "timeout" in msg_lower:
+        return "timeout"
+
+    return "scrape_error"
+
+
 # ── Data types ───────────────────────────────────────────────────
 
 
@@ -739,7 +833,9 @@ class CrawlEngine:
                         {
                             "url": url,
                             "error": cache_err,
+                            "error_type": "cache_miss",
                             "error_code": "CACHE_MISS",
+                            "timestamp": _now_timestamp(),
                         }
                     )
                     logger.info(
@@ -765,6 +861,10 @@ class CrawlEngine:
                 # ── Fresh scrape — full scraper call ─────────────
                 scrape_start = time.monotonic()
                 per_scrape_timeout = 60.0
+                # Derive user-configured timeout from scrape_options (in ms → s)
+                user_timeout_ms: int | None = None
+                if self.options.scrape_options:
+                    user_timeout_ms = self.options.scrape_options.get("timeout")
                 try:
                     result = await asyncio.wait_for(
                         self.scraper.scrape(
@@ -777,10 +877,14 @@ class CrawlEngine:
                     )
                 except TimeoutError:
                     elapsed = time.monotonic() - scrape_start
-                    timeout_entry = {
+                    timeout_entry: dict = {
                         "url": url,
                         "error": f"Scrape timed out after {elapsed:.1f}s",
+                        "error_type": "timeout",
                         "error_code": "TIMEOUT",
+                        "timestamp": _now_timestamp(),
+                        "timeout_ms": user_timeout_ms or int(per_scrape_timeout * 1000),
+                        "elapsed_ms": int(elapsed * 1000),
                     }
                     self._errors.append(timeout_entry)
                     logger.warning(
@@ -797,7 +901,9 @@ class CrawlEngine:
                     error_entry = {
                         "url": url,
                         "error": str(exc),
+                        "error_type": "scrape_error",
                         "error_code": "SCRAPE_ERROR",
+                        "timestamp": _now_timestamp(),
                     }
                     self._errors.append(error_entry)
                     logger.warning("Scrape exception for %s: %s", url, exc)
@@ -818,16 +924,21 @@ class CrawlEngine:
 
             if not result.get("success"):
                 error_msg = result.get("error", "Unknown scrape error")
+                error_code = result.get("error_code", "")
 
                 # Detect politeness-blocked results (VAL-CONC-025)
                 if (
-                    "Blocked by politeness" in error_msg
+                    error_code == "ROBOTS_BLOCKED"
+                    or "Blocked by politeness" in error_msg
                     or "ROBOTS_BLOCKED" in error_msg
                 ):
+                    now_ts = _now_timestamp()
                     robots_entry = {
                         "url": url,
                         "error": error_msg,
+                        "error_type": "robots_blocked",
                         "error_code": "ROBOTS_BLOCKED",
+                        "timestamp": now_ts,
                     }
                     self._robots_blocked.append(robots_entry)
                     self._errors.append(robots_entry)
@@ -837,12 +948,24 @@ class CrawlEngine:
                     # Blocked start URL is not a fatal error — it's expected
                     return
                 else:
-                    error_entry = {
+                    # Classify error type based on error message content
+                    cls_error_type = _classify_scrape_error(error_msg, error_code)
+                    scrape_error_entry: dict = {
                         "url": url,
                         "error": error_msg,
-                        "error_code": "SCRAPE_ERROR",
+                        "error_type": cls_error_type,
+                        "error_code": error_code or "SCRAPE_ERROR",
+                        "timestamp": _now_timestamp(),
                     }
-                    self._errors.append(error_entry)
+                    # Include http_status for HTTP errors if available
+                    http_status = result.get("http_status")
+                    if http_status is not None:
+                        scrape_error_entry["http_status"] = http_status
+                    # Include error_detail from scraper-svc if available
+                    error_detail = result.get("data", {}).get("error_detail")
+                    if error_detail:
+                        scrape_error_entry["error_detail"] = error_detail
+                    self._errors.append(scrape_error_entry)
                     logger.warning("Scrape failed for %s: %s", url, error_msg)
 
                 # Start URL failure — raise to signal immediate stop
@@ -914,6 +1037,8 @@ class CrawlEngine:
                     "url": url,
                     "error": f"Duplicate canonical URL: {canonical_dup_url}",
                     "error_type": "duplicate_canonical",
+                    "error_code": "DUPLICATE_CANONICAL",
+                    "timestamp": _now_timestamp(),
                     "canonical_url": canonical_dup_url,
                 }
                 self._errors.append(error_entry)
@@ -939,6 +1064,8 @@ class CrawlEngine:
                         "url": url,
                         "error": "Duplicate content (identical markdown hash)",
                         "error_type": "duplicate_content",
+                        "error_code": "DUPLICATE_CONTENT",
+                        "timestamp": _now_timestamp(),
                     }
                     self._errors.append(error_entry)
                     self._dedup_skipped += 1

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -9,7 +9,9 @@ job store for status polling.
 
 from __future__ import annotations
 
+import asyncio
 import collections.abc
+import contextlib
 import json
 import logging
 import posixpath
@@ -54,6 +56,10 @@ class CrawlOptions:
         verbose: If True, track filtered-out URLs with reasons.
         allow_subdomains: If True, follow links to subdomains.
         allow_external_links: If True, follow links to external domains.
+        max_concurrency: Maximum concurrent page scrapes (1-50, capped).
+            When delay is set, this is forced to 1.
+        delay: Seconds to wait between successive scrapes. When set,
+            forces max_concurrency to 1.
     """
 
     max_pages: int = 10
@@ -69,6 +75,8 @@ class CrawlOptions:
     crawl_entire_domain: bool = False
     max_duration_seconds: int = 1800
     idle_timeout_seconds: int = 300
+    max_concurrency: int = 3
+    delay: float | None = None
 
 
 @dataclass
@@ -80,6 +88,18 @@ class CrawlResult:
     completed: int = 0
     errors: list[dict] = field(default_factory=list)
     filtered_out: list[dict] = field(default_factory=list)
+
+
+# ── Exceptions ──────────────────────────────────────────────────
+
+
+class StartUrlScrapeError(Exception):
+    """Raised when the start URL cannot be scraped."""
+
+    def __init__(self, url: str, error: str):
+        self.url = url
+        self.error = error
+        super().__init__(f"Start URL scrape failed for {url}: {error}")
 
 
 # ── Public functions ─────────────────────────────────────────────
@@ -304,13 +324,20 @@ def _glob_to_regex(pattern: str) -> str:
 
 
 class CrawlEngine:
-    """BFS crawl orchestrator.
+    """BFS crawl orchestrator with configurable concurrency.
 
     Usage::
 
         engine = CrawlEngine(scraper_client, options=CrawlOptions(max_pages=5))
         result = await engine.run("https://example.com", job_id="...")
+
+    Concurrency is managed with an ``asyncio.Semaphore``. When ``delay``
+    is set, ``max_concurrency`` is forced to 1 and an
+    ``asyncio.sleep(delay)`` is inserted between scrapes.
     """
+
+    # Maximum value to cap max_concurrency at (prevents resource exhaustion).
+    MAX_CONCURRENCY_CAP: int = 50
 
     def __init__(
         self,
@@ -321,6 +348,11 @@ class CrawlEngine:
         self.scraper = scraper_client
         self.store = store
         self.options = options or CrawlOptions()
+
+        # Resolve effective concurrency: delay forces sequential
+        self._effective_concurrency = self._resolve_concurrency()
+
+        self._semaphore = asyncio.Semaphore(self._effective_concurrency)
         self._seen: set[str] = set()
         self._queue: deque[tuple[str, int]] = deque()
         self._pages: list[dict] = []
@@ -329,6 +361,23 @@ class CrawlEngine:
         self._cancel_flag: bool = False
         self._update_interval: float = 1.0
         self._html_client: httpx.AsyncClient | None = None
+        self._last_scrape_start: float | None = None
+        self._scraped_count: int = 0
+        # Track in-flight tasks for cancellation
+        self._pending_tasks: set[asyncio.Task] = set()
+
+    def _resolve_concurrency(self) -> int:
+        """Determine the effective concurrency value.
+
+        When ``delay`` is set (non-zero), concurrency is forced to 1
+        so that pages are scraped sequentially with pacing.
+        Otherwise, ``max_concurrency`` is used, capped at
+        ``MAX_CONCURRENCY_CAP``.
+        """
+        delay = self.options.delay
+        if delay is not None and delay > 0:
+            return 1
+        return min(self.options.max_concurrency, self.MAX_CONCURRENCY_CAP)
 
     async def _get_html(self, url: str) -> str | None:
         """Get HTML for a URL, using an internal persistent client."""
@@ -343,7 +392,8 @@ class CrawlEngine:
             return None
 
     async def close(self) -> None:
-        """Close the internal HTTP client."""
+        """Close the internal HTTP client and cancel pending tasks."""
+        self._cancel_all_tasks()
         if self._html_client is not None:
             await self._html_client.aclose()
             self._html_client = None
@@ -359,6 +409,11 @@ class CrawlEngine:
     ) -> CrawlResult:
         """Execute a BFS crawl starting from ``start_url``.
 
+        When ``max_concurrency > 1``, multiple pages are scraped
+        concurrently using an ``asyncio.Semaphore``. When ``delay`` is
+        set, concurrency is forced to 1 and ``asyncio.sleep(delay)`` is
+        inserted between scrapes.
+
         Args:
             start_url: The URL to begin crawling from.
             job_id: Optional job ID for periodic store updates and
@@ -372,9 +427,9 @@ class CrawlEngine:
         parsed_start = urlparse(start_url)
         base_domain = parsed_start.hostname.lower() if parsed_start.hostname else ""
 
-        # Seed the BFS queue with start URL (DO NOT add to _seen — the main
-        # loop adds to _seen when it pops each URL. Adding here would cause
-        # the main loop's dedup check to skip the start URL.)
+        # Seed the BFS queue with start URL (DO NOT add to _seen — the task
+        # adds to _seen when it acquires the URL. Adding here would cause
+        # the task's dedup check to skip the start URL.)
         self._queue.append((start_url, 0))
         start_normalized = self.normalize_url(start_url)
 
@@ -398,12 +453,6 @@ class CrawlEngine:
                 sitemap_dedup: set[str] = set()
                 for sm_url in sitemap_urls:
                     sm_normalized = self.normalize_url(sm_url)
-                    # Skip if duplicate within sitemap, or if it matches
-                    # the start URL (already in queue — will be deduped
-                    # by the main loop's seen-set).  The sitemap URL is
-                    # NOT added to self._seen here because the main loop
-                    # reads _seen to decide whether to scrape. If we added
-                    # it here, the main loop would skip it.
                     if (
                         sm_normalized in sitemap_dedup
                         or sm_normalized == start_normalized
@@ -420,15 +469,25 @@ class CrawlEngine:
 
         last_store_update = time.monotonic()
         crawl_start_time = time.monotonic()
-        last_completion_time = crawl_start_time
 
-        while self._queue and len(self._pages) < self.options.max_pages:
+        logger.info(
+            "Starting crawl of %s (max_pages=%d, max_depth=%d, "
+            "concurrency=%d, delay=%s)",
+            start_url,
+            self.options.max_pages,
+            self.options.max_depth,
+            self._effective_concurrency,
+            self.options.delay,
+        )
+
+        while (self._queue or self._pending_tasks) and len(
+            self._pages
+        ) < self.options.max_pages:
             if self._cancel_flag:
                 logger.info("Crawl cancelled via cancel flag")
                 break
 
             # Cooperative cancellation: check Redis for cancelled status
-            # between pages (checked before each page scrape).
             if self.store is not None and job_id is not None:
                 job_meta = self.store.get_job(job_id)
                 if job_meta and job_meta.get("status") == "cancelled":
@@ -446,66 +505,202 @@ class CrawlEngine:
                     self.options.max_duration_seconds,
                     elapsed,
                 )
+                self._cancel_all_tasks()
+                await self.close()
                 raise TimeoutError(
                     f"Crawl exceeded max duration of {self.options.max_duration_seconds}s"
                 )
 
-            # Idle timeout (stuck-crawl) check
-            idle_elapsed = now - last_completion_time
-            if idle_elapsed > self.options.idle_timeout_seconds:
-                logger.warning(
-                    "Crawl %s idle for %ds (timeout=%ds) — killing zombie crawl",
-                    job_id,
-                    idle_elapsed,
-                    self.options.idle_timeout_seconds,
-                )
-                raise TimeoutError(
-                    f"Crawl idle for {idle_elapsed:.0f}s — "
-                    f"exceeded idle timeout of {self.options.idle_timeout_seconds}s"
-                )
-
-            url, depth = self._queue.popleft()
-            normalized = self.normalize_url(url)
-
-            # Dedup check
-            if normalized in self._seen:
-                logger.debug("Skipping already-seen URL: %s", url)
-                continue
-
-            # Max depth check: pages at max_depth are scraped but not
-            # followed; pages beyond max_depth are skipped entirely.
-            if depth > self.options.max_depth:
-                logger.debug("Skipping URL beyond max_depth: %s (depth=%d)", url, depth)
-                continue
-
-            # Mark as seen immediately to prevent re-enqueue
-            self._seen.add(normalized)
-
-            # Determine the URL for path filtering.
-            # When ignore_query_parameters is True, strip query params
-            # before matching so that patterns match against the path
-            # only (VAL-SCOPE-073).
-            filter_url = (
-                urlparse(url)._replace(query="").geturl()
-                if self.options.ignore_query_parameters
-                else url
-            )
-            if not _match_path(
-                filter_url,
-                self.options.include_paths,
-                self.options.exclude_paths,
-                self.options.regex_on_full_url,
+            # Dispatch tasks from the queue.
+            # We limit by both concurrency AND remaining capacity so that
+            # in-flight + completed pages don't exceed max_pages.
+            while (
+                self._queue
+                and len(self._pending_tasks) < self._effective_concurrency
+                and len(self._pages) + len(self._pending_tasks) < self.options.max_pages
             ):
-                if self.options.verbose:
-                    filter_reason = self._get_filter_reason(filter_url)
-                    if filter_reason:
-                        self._filtered_out.append(filter_reason)
-                logger.debug("Skipping URL excluded by path filter: %s", url)
-                continue
+                task = self._create_scrape_task(page_callback, job_id, base_domain)
+                if task is None:
+                    # Queue exhausted or all items filtered
+                    break
 
-            # Scrape the page with timing
+            # Wait for at least one task to complete (or queue to be non-empty)
+            if self._pending_tasks:
+                _completed, _remaining = await asyncio.wait(
+                    self._pending_tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                self._pending_tasks = _remaining
+                # Process completed tasks (any exceptions were handled within)
+                for task in _completed:
+                    try:
+                        task.result()
+                    except asyncio.CancelledError:
+                        logger.debug("Scrape task was cancelled")
+                    except StartUrlScrapeError:
+                        logger.error("Start URL scrape failed — aborting crawl")
+                        self._cancel_all_tasks()
+                        result_obj = CrawlResult(
+                            pages=self._pages,
+                            total=0,
+                            completed=len(self._pages),
+                            errors=self._errors,
+                        )
+                        await self.close()
+                        return result_obj
+                    except Exception as exc:
+                        logger.warning(
+                            "Scrape task raised unexpected exception: %s", exc
+                        )
+            elif not self._queue:
+                # Nothing pending and nothing left in queue — crawl is done
+                break
+
+            # Periodic job store update
+            if self.store is not None and job_id is not None:
+                now = time.monotonic()
+                if now - last_store_update >= self._update_interval:
+                    self._update_store(job_id)
+                    last_store_update = now
+
+        # Wait for any remaining pending tasks to finish
+        if self._pending_tasks:
+            _done, _still_pending = await asyncio.wait(
+                self._pending_tasks, return_when=asyncio.ALL_COMPLETED
+            )
+            self._pending_tasks = _still_pending
+            for task in _done:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    task.result()
+
+        # Final store update
+        if self.store is not None and job_id is not None:
+            self._update_store(job_id)
+
+        await self.close()
+
+        return CrawlResult(
+            pages=self._pages,
+            total=len(self._pages) + len(self._queue),
+            completed=len(self._pages),
+            errors=self._errors,
+            filtered_out=self._filtered_out,
+        )
+
+    def _create_scrape_task(
+        self,
+        page_callback: collections.abc.Callable[
+            [str, dict], collections.abc.Awaitable[None]
+        ]
+        | None,
+        job_id: str | None,
+        base_domain: str,
+    ) -> asyncio.Task | None:
+        """Pop one URL from the queue and create a scrape task for it.
+
+        Performs dedup and path filtering checks. Returns ``None`` if the
+        queue is empty or the URL is skipped.
+        """
+        if not self._queue:
+            return None
+
+        url, depth = self._queue.popleft()
+        normalized = self.normalize_url(url)
+
+        # Dedup check
+        if normalized in self._seen:
+            logger.debug("Skipping already-seen URL: %s", url)
+            return None
+
+        # Max depth check: pages at max_depth are scraped but not
+        # followed; pages beyond max_depth are skipped entirely.
+        if depth > self.options.max_depth:
+            logger.debug("Skipping URL beyond max_depth: %s (depth=%d)", url, depth)
+            return None
+
+        # Mark as seen immediately to prevent re-enqueue
+        self._seen.add(normalized)
+
+        # Path filtering
+        filter_url = (
+            urlparse(url)._replace(query="").geturl()
+            if self.options.ignore_query_parameters
+            else url
+        )
+        if not _match_path(
+            filter_url,
+            self.options.include_paths,
+            self.options.exclude_paths,
+            self.options.regex_on_full_url,
+        ):
+            if self.options.verbose:
+                filter_reason = self._get_filter_reason(filter_url)
+                if filter_reason:
+                    self._filtered_out.append(filter_reason)
+            logger.debug("Skipping URL excluded by path filter: %s", url)
+            return None
+
+        # Create the async task for this URL
+        task = asyncio.create_task(
+            self._scrape_url(
+                url=url,
+                depth=depth,
+                base_domain=base_domain,
+                page_callback=page_callback,
+                job_id=job_id,
+            )
+        )
+        self._pending_tasks.add(task)
+        return task
+
+    async def _scrape_url(
+        self,
+        url: str,
+        depth: int,
+        base_domain: str,
+        page_callback: collections.abc.Callable[
+            [str, dict], collections.abc.Awaitable[None]
+        ]
+        | None,
+        job_id: str | None,
+    ) -> None:
+        """Scrape a single URL with semaphore protection and delay pacing.
+
+        This is the core unit of concurrent work. The semaphore ensures
+        that at most ``self._effective_concurrency`` scrapes run
+        simultaneously.
+        """
+        async with self._semaphore:
+            if self._cancel_flag:
+                return
+
+            # Apply delay between scrapes (only when delay > 0)
+            delay = self.options.delay
+            if delay is not None and delay > 0 and self._last_scrape_start is not None:
+                elapsed_since_last = time.monotonic() - self._last_scrape_start
+                wait = max(0.0, delay - elapsed_since_last)
+                if wait > 0:
+                    try:
+                        await asyncio.sleep(wait)
+                    except asyncio.CancelledError:
+                        logger.debug(
+                            "Delay sleep cancelled for %s (job %s)", url, job_id
+                        )
+                        return
+
+            self._last_scrape_start = time.monotonic()
+
+            # Scrape the page
             scrape_start = time.monotonic()
-            result = await self.scraper.scrape(url)
+            try:
+                result = await self.scraper.scrape(url)
+            except Exception as exc:
+                self._errors.append({"url": url, "error": str(exc)})
+                logger.warning("Scrape exception for %s: %s", url, exc)
+                if depth == 0:
+                    raise  # let the caller handle start URL failure
+                return
+
             scrape_duration_ms = int((time.monotonic() - scrape_start) * 1000)
 
             if not result.get("success"):
@@ -513,18 +708,10 @@ class CrawlEngine:
                 self._errors.append({"url": url, "error": error_msg})
                 logger.warning("Scrape failed for %s: %s", url, error_msg)
 
-                # Start URL failure — return error immediately
+                # Start URL failure — raise to signal immediate stop
                 if depth == 0:
-                    logger.error("Start URL scrape failed: %s", error_msg)
-                    result_obj = CrawlResult(
-                        pages=[],
-                        total=0,
-                        completed=0,
-                        errors=self._errors,
-                    )
-                    await self.close()
-                    return result_obj
-                continue
+                    raise StartUrlScrapeError(url, error_msg)
+                return
 
             # Record successful page with enriched metadata
             data = result.get("data", {})
@@ -568,7 +755,7 @@ class CrawlEngine:
                 "duration_ms": scrape_duration_ms,
             }
             self._pages.append(page)
-            last_completion_time = time.monotonic()
+            self._scraped_count += 1
 
             # Fire per-page webhook callback
             if page_callback is not None and job_id is not None:
@@ -583,7 +770,7 @@ class CrawlEngine:
                     )
 
             # Discover child links if within max_depth
-            # In "only" mode, sitemap URLs are the exclusive source — skip HTML link discovery
+            # In "only" mode, sitemap URLs are the exclusive source
             if depth < self.options.max_depth and self.options.sitemap_mode != "only":
                 html = await self._get_html(url)
                 if html:
@@ -596,23 +783,16 @@ class CrawlEngine:
                     )
                     # SSRF guard: always block private/internal hosts on
                     # EXTERNAL URLs regardless of allow_external_links setting.
-                    # Internal and subdomain URLs are already vetted and are
-                    # part of the organization's own infrastructure — they
-                    # bypass the SSRF check. (VAL-SCOPE-017)
                     classified = classify_links(child_links, url)
                     if classified.get("external"):
                         classified["external"] = self._filter_ssrf_blocked(
                             classified["external"]
                         )
-                    # Rebuild the full link list from classified buckets
                     child_links = (
                         classified.get("internal", [])
                         + classified.get("subdomain", [])
                         + classified.get("external", [])
                     )
-                    # When crawl_entire_domain is False, only follow child paths
-                    # (deeper in the path hierarchy). When True, follow all
-                    # same-domain links including siblings and parents.
                     if not self.options.crawl_entire_domain:
                         child_links = self._filter_child_paths(child_links, url)
                     for child_url in child_links:
@@ -620,26 +800,15 @@ class CrawlEngine:
                         if child_normalized not in self._seen:
                             self._queue.append((child_url, depth + 1))
 
-            # Periodic job store update
-            if self.store is not None and job_id is not None:
-                now = time.monotonic()
-                if now - last_store_update >= self._update_interval:
-                    self._update_store(job_id)
-                    last_store_update = now
+    def _cancel_all_tasks(self) -> None:
+        """Cancel all in-flight scrape tasks and clear tracking.
 
-        # Final store update
-        if self.store is not None and job_id is not None:
-            self._update_store(job_id)
-
-        await self.close()
-
-        return CrawlResult(
-            pages=self._pages,
-            total=len(self._pages) + len(self._queue),
-            completed=len(self._pages),
-            errors=self._errors,
-            filtered_out=self._filtered_out,
-        )
+        This ensures semaphore slots are released and pending tasks
+        don't hold references after cancellation.
+        """
+        for task in self._pending_tasks:
+            task.cancel()
+        self._pending_tasks.clear()
 
     def normalize_url(self, url: str) -> str:
         """Normalize a URL using this engine's options."""
@@ -681,8 +850,14 @@ class CrawlEngine:
             return []
 
     def cancel(self) -> None:
-        """Signal the crawl to stop at the next opportunity."""
+        """Signal the crawl to stop and cancel all pending tasks.
+
+        This sets the cancel flag and cancels any in-flight scrape
+        tasks. Pending tasks that are blocked on the semaphore will
+        also be woken up and exit cleanly.
+        """
         self._cancel_flag = True
+        self._cancel_all_tasks()
 
     @staticmethod
     def _filter_child_paths(links: list[str], current_url: str) -> list[str]:

--- a/agent-svc/agent/crawler.py
+++ b/agent-svc/agent/crawler.py
@@ -25,6 +25,7 @@ import httpx
 
 from common.url import is_private_host
 
+from .crawl_cache import CrawlCache
 from .dedup import DedupManager
 from .link_extractor import classify_links, extract_links, filter_links
 from .scraper_client import ScraperClient
@@ -358,10 +359,12 @@ class CrawlEngine:
         scraper_client: ScraperClient,
         store: JobStore | None = None,
         options: CrawlOptions | None = None,
+        crawl_cache: CrawlCache | None = None,
     ):
         self.scraper = scraper_client
         self.store = store
         self.options = options or CrawlOptions()
+        self.crawl_cache = crawl_cache
 
         # Resolve effective concurrency: delay forces sequential
         self._effective_concurrency = self._resolve_concurrency()
@@ -714,52 +717,104 @@ class CrawlEngine:
 
             self._last_scrape_start = time.monotonic()
 
-            # Scrape the page with a per-scrape timeout to prevent semaphore
-            # slot starvation (VAL-CONC-043 / VAL-CONC-051).
-            scrape_start = time.monotonic()
-            # Default timeout: 60 seconds per individual scrape
-            per_scrape_timeout = 60.0
-            try:
-                result = await asyncio.wait_for(
-                    self.scraper.scrape(
-                        url,
-                        ignore_robots_txt=self.options.ignore_robots_txt,
-                        robots_user_agent=self.options.robots_user_agent,
-                        scrape_options=self.options.scrape_options,
-                    ),
-                    timeout=per_scrape_timeout,
-                )
-            except TimeoutError:
-                elapsed = time.monotonic() - scrape_start
-                timeout_entry = {
-                    "url": url,
-                    "error": f"Scrape timed out after {elapsed:.1f}s",
-                    "error_code": "TIMEOUT",
-                }
-                self._errors.append(timeout_entry)
-                logger.warning(
-                    "Scrape timed out for %s after %.1fs (job %s)",
+            # ── Cache check ──────────────────────────────────────
+            cache_max_age_ms: int | None = None
+            cache_min_age_ms: int | None = None
+            if self.options.scrape_options:
+                cache_max_age_ms = self.options.scrape_options.get("max_age")
+                cache_min_age_ms = self.options.scrape_options.get("min_age")
+
+            _result_from_cache: dict | None = None
+            if self.crawl_cache is not None and (
+                cache_max_age_ms is not None or cache_min_age_ms is not None
+            ):
+                use_cached, cached_data, cache_err = self.crawl_cache.check_cache(
                     url,
-                    elapsed,
+                    max_age_ms=cache_max_age_ms,
+                    min_age_ms=cache_min_age_ms,
+                )
+                if cache_err:
+                    # minAge cache miss → record error, skip scrape
+                    self._errors.append(
+                        {
+                            "url": url,
+                            "error": cache_err,
+                            "error_code": "CACHE_MISS",
+                        }
+                    )
+                    logger.info(
+                        "Cache miss (minAge) for %s (job %s): %s",
+                        url,
+                        job_id,
+                        cache_err,
+                    )
+                    return
+                if use_cached and cached_data is not None:
+                    _result_from_cache = cached_data
+
+            if _result_from_cache is not None:
+                # Use cached result — skip the scraper call entirely.
+                result = _result_from_cache
+                scrape_duration_ms = 0  # Cache hit — no network latency
+                logger.debug(
+                    "Cache HIT for %s (job %s) — skipping scraper call",
+                    url,
                     job_id,
                 )
-                return
-            except asyncio.CancelledError:
-                logger.debug("Scrape cancelled for %s (job %s)", url, job_id)
-                return
-            except Exception as exc:
-                error_entry = {
-                    "url": url,
-                    "error": str(exc),
-                    "error_code": "SCRAPE_ERROR",
-                }
-                self._errors.append(error_entry)
-                logger.warning("Scrape exception for %s: %s", url, exc)
-                if depth == 0:
-                    raise  # let the caller handle start URL failure
-                return
+            else:
+                # ── Fresh scrape — full scraper call ─────────────
+                scrape_start = time.monotonic()
+                per_scrape_timeout = 60.0
+                try:
+                    result = await asyncio.wait_for(
+                        self.scraper.scrape(
+                            url,
+                            ignore_robots_txt=self.options.ignore_robots_txt,
+                            robots_user_agent=self.options.robots_user_agent,
+                            scrape_options=self.options.scrape_options,
+                        ),
+                        timeout=per_scrape_timeout,
+                    )
+                except TimeoutError:
+                    elapsed = time.monotonic() - scrape_start
+                    timeout_entry = {
+                        "url": url,
+                        "error": f"Scrape timed out after {elapsed:.1f}s",
+                        "error_code": "TIMEOUT",
+                    }
+                    self._errors.append(timeout_entry)
+                    logger.warning(
+                        "Scrape timed out for %s after %.1fs (job %s)",
+                        url,
+                        elapsed,
+                        job_id,
+                    )
+                    return
+                except asyncio.CancelledError:
+                    logger.debug("Scrape cancelled for %s (job %s)", url, job_id)
+                    return
+                except Exception as exc:
+                    error_entry = {
+                        "url": url,
+                        "error": str(exc),
+                        "error_code": "SCRAPE_ERROR",
+                    }
+                    self._errors.append(error_entry)
+                    logger.warning("Scrape exception for %s: %s", url, exc)
+                    if depth == 0:
+                        raise  # let the caller handle start URL failure
+                    return
 
-            scrape_duration_ms = int((time.monotonic() - scrape_start) * 1000)
+                scrape_duration_ms = int((time.monotonic() - scrape_start) * 1000)
+
+                # Cache the fresh scrape result if maxAge > 0
+                if (
+                    self.crawl_cache is not None
+                    and cache_max_age_ms is not None
+                    and cache_max_age_ms > 0
+                    and result.get("success")
+                ):
+                    self.crawl_cache.set(url, result, ttl_ms=cache_max_age_ms)
 
             if not result.get("success"):
                 error_msg = result.get("error", "Unknown scrape error")

--- a/agent-svc/agent/dedup.py
+++ b/agent-svc/agent/dedup.py
@@ -1,0 +1,256 @@
+"""Multi-layer deduplication for crawl pages.
+
+Provides ``DedupManager`` which implements:
+
+1. **URL normalization** (Layer 1) — handled by ``CrawlEngine.normalize_url()``,
+   not by this module. The crawl engine's seen-set prevents re-scraping
+   the same normalized URL.
+
+2. **Canonical tag check** (Layer 2) — after scraping a page, extract the
+   ``<link rel="canonical">`` tag. If it points to a URL that has already
+   been scraped in this crawl run, skip the current page.
+
+3. **Content hash dedup** (Layer 3) — SHA-256 hash of the extracted
+   markdown. Two pages with byte-for-byte identical markdown content are
+   treated as duplicates.
+
+Canonical check *always runs before* content hash check, so that a page
+that is both canonical-duplicate and content-identical reports the
+canonical dedup reason.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from urllib.parse import urljoin, urlparse
+
+logger = logging.getLogger(__name__)
+
+
+# Regex patterns for extracting <link rel="canonical" href="...">
+# Supports both attribute orders: rel first or href first.
+_CANONICAL_RE = re.compile(
+    r'<link\s+[^>]*?rel=["\']canonical["\'][^>]*?href=["\']([^"\']+)["\'][^>]*/?>',
+    re.IGNORECASE,
+)
+_CANONICAL_RE_HREF_FIRST = re.compile(
+    r'<link\s+[^>]*?href=["\']([^"\']+)["\'][^>]*?rel=["\']canonical["\'][^>]*/?>',
+    re.IGNORECASE,
+)
+
+
+class DedupManager:
+    """Multi-layer deduplication manager for crawl runs.
+
+    Usage::
+
+        dedup = DedupManager()
+        # … scrape page at url, get html and markdown …
+        canonical_dup = dedup.check_canonical(html, url)
+        if canonical_dup:
+            # Skip this page (it's a canonical duplicate)
+            continue
+
+        content_hash = dedup.compute_content_hash(markdown)
+        if content_hash and dedup.is_duplicate_content(content_hash):
+            # Skip this page (same content as another page)
+            continue
+
+        dedup.mark_scraped(url, content_hash=content_hash)
+    """
+
+    def __init__(self) -> None:
+        # URLs that have been fully scraped (not just seen in the queue).
+        self._scraped_urls: set[str] = set()
+        # URL → canonical URL mapping for already-scraped pages.
+        self._canonical_urls: dict[str, str] = {}
+        # SHA-256 hex digests of markdown content seen so far.
+        self._content_hashes: set[str] = set()
+
+    # ── Public API ─────────────────────────────────────────────
+
+    def mark_scraped(
+        self,
+        url: str,
+        canonical_url: str | None = None,
+        content_hash: str | None = None,
+    ) -> None:
+        """Register a URL as successfully scraped.
+
+        Must be called *after* the page has passed all dedup checks.
+
+        Args:
+            url: The scraped URL (normalized form).
+            canonical_url: Optional canonical URL found on the page.
+            content_hash: Optional SHA-256 hex digest of the markdown.
+        """
+        normalized = url.rstrip("/")
+        self._scraped_urls.add(normalized)
+        if canonical_url:
+            resolved = self._resolve_url(url, canonical_url)
+            if resolved:
+                self._canonical_urls[normalized] = resolved.rstrip("/")
+        if content_hash:
+            self._content_hashes.add(content_hash)
+
+    def check_canonical(self, html: str, current_url: str) -> str | None:
+        """Check whether this page is a canonical duplicate of an already-scraped page.
+
+        Extracts the ``<link rel="canonical">`` tag from *html* and
+        resolves it against *current_url*. Returns the canonical URL if:
+
+        - The canonical URL is on the same domain as *current_url*.
+        - The canonical URL is **not** the same as *current_url* (self-referencing
+          canonical is ignored).
+        - The canonical URL (or the URL it resolves to via the canonical chain)
+          has already been scraped in this crawl run.
+
+        Returns ``None`` when:
+        - No ``<link rel="canonical">`` tag is found.
+        - The canonical is self-referencing.
+        - The canonical points to a different domain (external canonical is ignored).
+        - The canonical target has **not** been scraped yet.
+
+        Args:
+            html: The raw HTML of the scraped page.
+            current_url: The URL of the scraped page.
+
+        Returns:
+            The canonical URL if it is a duplicate of an already-scraped URL,
+            or ``None`` if no canonical dedup applies.
+        """
+        canonical_href = self._extract_canonical_href(html)
+        if canonical_href is None:
+            return None
+
+        # Resolve relative URLs against the current page URL.
+        resolved = urljoin(current_url, canonical_href)
+
+        # Normalise trailing-slash differences.
+        resolved_normalized = resolved.rstrip("/")
+        current_normalized = current_url.rstrip("/")
+
+        # Self-referencing canonical → ignore.
+        if resolved_normalized == current_normalized:
+            logger.debug(
+                "Self-referencing canonical ignored: %s → %s",
+                current_url,
+                resolved,
+            )
+            return None
+
+        # External domain → ignore.
+        current_domain = (urlparse(current_url).hostname or "").lower()
+        resolved_domain = (urlparse(resolved).hostname or "").lower()
+        if current_domain != resolved_domain:
+            logger.debug(
+                "External-domain canonical ignored: %s → %s",
+                current_url,
+                resolved,
+            )
+            return None
+
+        # Check if the resolved canonical URL (or its alias via another canonical)
+        # has already been scraped.
+        if self._is_scraped(resolved_normalized):
+            logger.debug(
+                "Canonical duplicate: %s → already scraped %s",
+                current_url,
+                resolved,
+            )
+            return resolved
+
+        return None
+
+    def compute_content_hash(self, markdown: str) -> str | None:
+        """Compute the SHA-256 hex digest of *markdown*.
+
+        Returns ``None`` when *markdown* is empty or whitespace-only
+        (empty-markdown pages are never treated as duplicates).
+
+        Args:
+            markdown: The extracted markdown text.
+
+        Returns:
+            SHA-256 hex digest string, or ``None`` for empty markdown.
+        """
+        if not markdown or not markdown.strip():
+            return None
+        return hashlib.sha256(markdown.encode("utf-8")).hexdigest()
+
+    def is_duplicate_content(self, content_hash: str) -> bool:
+        """Check whether *content_hash* has already been seen.
+
+        Args:
+            content_hash: SHA-256 hex digest to check.
+
+        Returns:
+            ``True`` if this hash was registered by a previous ``mark_scraped()``.
+        """
+        return content_hash in self._content_hashes
+
+    def is_scraped_url(self, url: str) -> bool:
+        """Check whether *url* has already been scraped.
+
+        Args:
+            url: The URL to check (will be normalised internally).
+
+        Returns:
+            ``True`` if the URL was previously registered via ``mark_scraped()``.
+        """
+        return url.rstrip("/") in self._scraped_urls
+
+    def get_canonical_for(self, url: str) -> str | None:
+        """Return the canonical URL that *url* points to, if known.
+
+        Args:
+            url: The source URL.
+
+        Returns:
+            The resolved canonical URL, or ``None`` if no canonical was
+            recorded for *url*.
+        """
+        return self._canonical_urls.get(url.rstrip("/"))
+
+    # ── Internal helpers ───────────────────────────────────────
+
+    @staticmethod
+    def _extract_canonical_href(html: str) -> str | None:
+        """Extract the ``href`` value from a ``<link rel="canonical">`` tag.
+
+        Tries both attribute-order patterns: ``rel="canonical" href="..."``
+        and ``href="..." rel="canonical"``.
+        """
+        match = _CANONICAL_RE.search(html)
+        if match:
+            return match.group(1)
+        match = _CANONICAL_RE_HREF_FIRST.search(html)
+        if match:
+            return match.group(1)
+        return None
+
+    @staticmethod
+    def _resolve_url(base: str, url: str) -> str:
+        """Resolve a potentially-relative URL against a base URL."""
+        return urljoin(base, url)
+
+    def _is_scraped(self, url: str) -> bool:
+        """Check if *url* (or a canonical alias of it) has been scraped.
+
+        Checks both the direct URL and any canonical-chain resolution.
+        """
+        normalized = url.rstrip("/")
+        if normalized in self._scraped_urls:
+            return True
+
+        # Check if any scraped URL declares this URL as its canonical.
+        for scraped, canonical in self._canonical_urls.items():
+            if canonical == normalized:
+                # The canonical target itself was scraped as another page.
+                # Check if that scraped URL is known.
+                if scraped in self._scraped_urls:
+                    return True
+
+        return False

--- a/agent-svc/agent/link_extractor.py
+++ b/agent-svc/agent/link_extractor.py
@@ -1,0 +1,230 @@
+"""Shared LinkExtractor module for extracting and filtering links from HTML.
+
+Provides ``extract_links()``, ``filter_links()``, and ``classify_links()``
+functions used by the crawl engine, ``/v2/map`` endpoint, and
+``llmstxt.py``.
+
+All functions are stateless — they accept inputs and return results
+without any stored state.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+def extract_links(html: str, base_url: str) -> list[str]:
+    """Extract and normalize all ``<a href>`` links from HTML.
+
+    Args:
+        html: Raw HTML content to parse.
+        base_url: The page URL used to resolve relative links. A
+            ``<base>`` tag in the HTML overrides this for relative
+            resolution but not for domain classification.
+
+    Returns:
+        List of absolute, fragment-stripped, deduplicated URLs with
+        ``http`` or ``https`` schemes. URLs are in discovery order
+        (first occurrence wins for duplicates).
+
+    Features:
+        - Resolves relative URLs against ``base_url`` (or ``<base>`` tag
+          if present in the HTML)
+        - Strips fragment identifiers (``#section``)
+        - Filters out non-http/https schemes (``mailto:``, ``tel:``,
+          ``javascript:``, etc.)
+        - Deduplicates URLs within the same page
+        - Handles malformed HTML gracefully (returns empty list instead
+          of raising exceptions)
+    """
+    if not html or not base_url:
+        return []
+
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception:
+        logger.warning("Failed to parse HTML from %s", base_url)
+        return []
+
+    # Determine effective base URL for relative resolution.
+    # <base> tag overrides the page URL.
+    effective_base: str = base_url
+    base_tag = soup.find("base", href=True)
+    if base_tag is not None and hasattr(base_tag, "get"):
+        href_val = base_tag.get("href")
+        if href_val:
+            effective_base = str(href_val)
+
+    seen: set[str] = set()
+    result: list[str] = []
+
+    try:
+        for a_tag in soup.find_all("a", href=True):
+            if not hasattr(a_tag, "get"):
+                continue
+            href_val = a_tag.get("href")
+            if href_val is None:
+                continue
+            href = _resolve_href_value(str(href_val))
+            if not href:
+                continue
+
+            # Resolve relative URLs against the effective base
+            try:
+                full_url = urljoin(effective_base, href)
+            except Exception:
+                continue
+
+            # Parse the resolved URL
+            try:
+                parsed = urlparse(full_url)
+            except Exception:
+                continue
+
+            # Filter out non-http/https schemes
+            scheme = parsed.scheme.lower()
+            if scheme and scheme not in ("http", "https"):
+                continue
+
+            # Strip fragment identifier
+            clean_url = _strip_fragment(full_url)
+
+            # Deduplicate within this page
+            if clean_url in seen:
+                continue
+            seen.add(clean_url)
+
+            result.append(clean_url)
+
+    except Exception:
+        logger.warning("Error extracting links from %s", base_url, exc_info=True)
+
+    return result
+
+
+def filter_links(
+    links: list[str],
+    *,
+    base_domain: str | None = None,
+    allow_subdomains: bool = False,
+    allow_external_links: bool = False,
+) -> list[str]:
+    """Filter a list of URLs by domain classification.
+
+    Args:
+        links: List of absolute URL strings (as returned by ``extract_links()``).
+        base_domain: The hostname of the base domain (e.g., ``"example.com"``).
+            If ``None``, only URLs that parse to a valid netloc are kept.
+        allow_subdomains: If ``True``, URLs on subdomains of the base domain
+            are included (e.g., ``docs.example.com`` when base is ``example.com``).
+        allow_external_links: If ``True``, URLs on entirely different domains
+            are included.
+
+    Returns:
+        Filtered list of URL strings matching the configured scope.
+    """
+    result: list[str] = []
+
+    for url in links:
+        parsed = urlparse(url)
+        hostname = parsed.hostname.lower() if parsed.hostname else ""
+
+        if not hostname:
+            # Shouldn't happen with absolute URLs, but be safe
+            result.append(url)
+            continue
+
+        if base_domain is None:
+            result.append(url)
+            continue
+
+        base = base_domain.lower()
+
+        if hostname == base:
+            # Internal (same domain) — always included
+            result.append(url)
+        elif _is_subdomain(hostname, base) and allow_subdomains:
+            result.append(url)
+        elif (
+            not _is_subdomain(hostname, base)
+            and hostname != base
+            and allow_external_links
+        ):
+            result.append(url)
+        # subdomain without allow_subdomains → skip
+        # external without allow_external_links → skip
+
+    return result
+
+
+def classify_links(links: list[str], base_url: str) -> dict[str, list[str]]:
+    """Classify a list of URLs by domain relationship to the base URL.
+
+    Args:
+        links: List of absolute URL strings.
+        base_url: The base URL used to determine the origin domain.
+
+    Returns:
+        Dict with keys ``"internal"``, ``"subdomain"``, and ``"external"``,
+        each containing a list of URL strings.
+    """
+    parsed_base = urlparse(base_url)
+    base_hostname = parsed_base.hostname.lower() if parsed_base.hostname else ""
+
+    result: dict[str, list[str]] = {
+        "internal": [],
+        "subdomain": [],
+        "external": [],
+    }
+
+    for url in links:
+        parsed = urlparse(url)
+        hostname = parsed.hostname.lower() if parsed.hostname else ""
+
+        if not hostname:
+            result["internal"].append(url)
+        elif hostname == base_hostname:
+            result["internal"].append(url)
+        elif _is_subdomain(hostname, base_hostname):
+            result["subdomain"].append(url)
+        else:
+            result["external"].append(url)
+
+    return result
+
+
+# ── Internal helpers ───────────────────────────────────────────────
+
+
+def _strip_fragment(url: str) -> str:
+    """Strip the fragment identifier from a URL, preserving the rest."""
+    try:
+        idx = url.index("#")
+        return url[:idx]
+    except ValueError:
+        return url
+
+
+def _is_subdomain(hostname: str, base: str) -> bool:
+    """Check whether ``hostname`` is a subdomain of ``base``.
+
+    ``blog.example.com`` is a subdomain of ``example.com``.
+    ``example.com`` is NOT a subdomain of ``example.com``.
+    ``other.com`` is NOT a subdomain of ``example.com``.
+    Comparison is case-insensitive.
+    """
+    hostname_lower = hostname.lower()
+    base_lower = base.lower()
+    if hostname_lower == base_lower:
+        return False
+    return hostname_lower.endswith("." + base_lower)
+
+
+def _resolve_href_value(href: str) -> str:
+    """Normalize an href attribute value to a string."""
+    return href.strip()

--- a/agent-svc/agent/llmstxt.py
+++ b/agent-svc/agent/llmstxt.py
@@ -7,12 +7,12 @@ the site's key pages.
 
 import logging
 import re
-from urllib.parse import urljoin
 
 import httpx
-from bs4 import BeautifulSoup
 
 from common.url import extract_domain
+
+from .link_extractor import extract_links, filter_links
 
 logger = logging.getLogger(__name__)
 
@@ -124,10 +124,11 @@ def _extract_description(text: str, max_chars: int = 300) -> str:
 
 
 async def discover_pages(url: str, max_pages: int = 50) -> list[str]:
-    """Discover page URLs on a site by fetching the homepage and finding same-domain links."""
-    discovered: list[str] = []
-    seen = set()
+    """Discover page URLs on a site by fetching the homepage and finding same-domain links.
 
+    Uses the shared LinkExtractor module for HTML link extraction and filtering,
+    replacing the previous inline BeautifulSoup parsing.
+    """
     try:
         async with httpx.AsyncClient(follow_redirects=True, timeout=15) as client:
             resp = await client.get(url)
@@ -135,29 +136,23 @@ async def discover_pages(url: str, max_pages: int = 50) -> list[str]:
                 logger.warning("Failed to fetch %s: %d", url, resp.status_code)
                 return [url]  # fallback: just return the input URL
 
-            soup = BeautifulSoup(resp.text, "html.parser")
-            from urllib.parse import urlparse
+            # Use the shared LinkExtractor for link extraction and filtering.
+            # Pass the domain-only base URL to match previous urljoin(base_url, href)
+            # behavior where base_url was the scheme+domain without path.
+            site_base = extract_domain(url, include_scheme=True)
+            all_links = extract_links(resp.text, site_base)
 
-            base_netloc = urlparse(url).netloc.lower()
-            base_url = extract_domain(url, include_scheme=True)
-            for a in soup.find_all("a", href=True):
-                href = a["href"].strip()  # type: ignore[union-attr]
-                full_url = urljoin(base_url, href)
+            # Filter to same-host only (backward compatible — external links excluded)
+            base_domain = extract_domain(url)
+            filtered = filter_links(
+                all_links,
+                base_domain=base_domain,
+                allow_subdomains=False,
+                allow_external_links=False,
+            )
 
-                # Skip external links, anchors, mailto, etc.
-                full_parsed = urlparse(full_url)
-                if full_parsed.netloc and full_parsed.netloc.lower() != base_netloc:
-                    continue
-                if not full_parsed.scheme.startswith("http"):
-                    continue
-                if full_url in seen:
-                    continue
-
-                seen.add(full_url)
-                discovered.append(full_url)
-
-                if len(discovered) >= max_pages:
-                    break
+            # Apply max_pages limit (LinkExtractor returns links in discovery order)
+            discovered = filtered[:max_pages]
 
     except Exception as e:
         logger.warning("Page discovery failed for %s: %s", url, e)

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -90,8 +90,12 @@ class AgentCancelResponse(BaseModel):
 
 class CrawlRequest(BaseModel):
     url: str
-    max_pages: int = 10
-    max_depth: int = 2
+    max_pages: int = Field(
+        default=10, ge=1, description="Maximum pages to scrape, must be >= 1"
+    )
+    max_depth: int = Field(
+        default=2, ge=0, description="Maximum link-follow depth, must be >= 0"
+    )
     limit: int | None = None
     ignore_sitemap: bool = False
     ignore_query_parameters: bool = False
@@ -149,6 +153,10 @@ class CrawlStatusResponse(BaseModel):
     credits_used: int | None = None
     data: list[dict[str, Any]] | None = None
     error: str | None = None
+    created_at: str | None = None
+    completed_at: str | None = None
+    expires_at: str | None = None
+    duration: int | None = None
 
 
 class BatchScrapeRequest(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -586,6 +586,35 @@ class ActivityResponse(BaseModel):
     data: list[ActivityItem] = Field(default_factory=list)
 
 
+class CrawlActiveItem(BaseModel):
+    """A single active crawl job entry for ``GET /v2/crawl/active``.
+
+    Includes crawl-specific fields (``url``, ``max_pages``, ``max_depth``,
+    ``completed``, ``total``) that distinguish it from the generic
+    ``ActivityItem`` used by the unified ``/v2/activity`` endpoint.
+    """
+
+    id: str
+    url: str | None = None
+    status: str = "processing"
+    created_at: str
+    completed: int = 0
+    total: int = 0
+    max_pages: int | None = None
+    max_depth: int | None = None
+
+
+class CrawlActiveResponse(BaseModel):
+    """Response model for ``GET /v2/crawl/active``.
+
+    Returns only jobs with ``kind: "crawl"``. Excludes completed, failed,
+    and cancelled crawls by default (filterable via ``status`` query param).
+    """
+
+    success: bool = True
+    data: list[CrawlActiveItem] = Field(default_factory=list)
+
+
 class CrawlErrorItem(BaseModel):
     """A single error entry for the GET /v2/crawl/{id}/errors endpoint.
 

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -584,3 +584,54 @@ class ActivityResponse(BaseModel):
 
     success: bool = True
     data: list[ActivityItem] = Field(default_factory=list)
+
+
+class CrawlErrorItem(BaseModel):
+    """A single error entry for the GET /v2/crawl/{id}/errors endpoint.
+
+    Attributes:
+        url: The URL that failed.
+        error: Human-readable error description (maps to ``message`` in
+            the validation contract).
+        error_type: Machine-readable error category (e.g., ``timeout``,
+            ``robots_blocked``, ``dns_error``, ``http_error``,
+            ``scrape_error``, ``cache_miss``, ``duplicate_canonical``,
+            ``duplicate_content``).
+        error_code: Machine-readable error code string (e.g., ``TIMEOUT``,
+            ``ROBOTS_BLOCKED``, ``SCRAPE_ERROR``).
+        timestamp: ISO 8601 timestamp of when the error occurred.
+        timeout_ms: For timeout errors, the configured per-scrape timeout
+            in milliseconds.
+        elapsed_ms: For timeout errors, the actual elapsed time before
+            the timeout fired, in milliseconds.
+        http_status: For HTTP errors, the HTTP status code (e.g., 404,
+            403, 500).
+    """
+
+    url: str
+    error: str = ""
+    error_type: str = "scrape_error"
+    error_code: str = ""
+    timestamp: str = ""
+    timeout_ms: int | None = None
+    elapsed_ms: int | None = None
+    http_status: int | None = None
+
+
+class CrawlErrorsResponse(BaseModel):
+    """Response model for GET /v2/crawl/{id}/errors.
+
+    Attributes:
+        success: Always ``True`` for a successful response.
+        errors: List of error objects. Includes all scrape failures,
+            cache misses, and duplicate-detection errors. Politeness-
+            blocked URLs are also included here (with ``error_type:
+            "robots_blocked"``) and in ``robots_blocked``.
+        robots_blocked: Subset of ``errors`` containing only URLs that
+            were blocked by robots.txt or politeness rate limiting.
+    """
+
+    success: bool = True
+    errors: list[CrawlErrorItem] = Field(default_factory=list)
+    robots_blocked: list[CrawlErrorItem] = Field(default_factory=list)
+    error: str | None = None

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -3,7 +3,7 @@
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ErrorDetail(BaseModel):
@@ -97,6 +97,8 @@ class CrawlRequest(BaseModel):
     ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
+    regex_on_full_url: bool = False
+    verbose: bool = False
     webhook: dict[str, Any] | None = None
 
     @field_validator("url")
@@ -111,6 +113,27 @@ class CrawlRequest(BaseModel):
         if not parsed.netloc:
             raise ValueError("URL must have a network location (host)")
         return value
+
+    @model_validator(mode="after")
+    def validate_regex_patterns(self) -> "CrawlRequest":
+        """When regex_on_full_url is True, validate that all path
+        patterns are valid Python regular expressions."""
+        if not self.regex_on_full_url:
+            return self
+        import re as _re
+
+        for field_name in ("include_paths", "exclude_paths"):
+            patterns = getattr(self, field_name)
+            if not patterns:
+                continue
+            for i, pattern in enumerate(patterns):
+                try:
+                    _re.compile(pattern)
+                except _re.error as exc:
+                    raise ValueError(
+                        f"Invalid regex in {field_name}[{i}]: '{pattern}' — {exc}"
+                    ) from exc
+        return self
 
 
 class CrawlCreateResponse(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -124,6 +124,14 @@ class CrawlRequest(BaseModel):
         ge=0,
         description="Delay in seconds between scrapes. Forces concurrency to 1 when set.",
     )
+    ignore_robots_txt: bool = Field(
+        default=False,
+        description="When True, bypass robots.txt enforcement. All discovered URLs are scraped regardless of robots.txt Disallow rules.",
+    )
+    robots_user_agent: str | None = Field(
+        default=None,
+        description="Custom User-Agent string for robots.txt evaluation. When set, robots.txt rules are evaluated against this User-Agent instead of the default bot UA.",
+    )
 
     @field_validator("url")
     @classmethod

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -270,6 +270,11 @@ class CrawlRequest(BaseModel):
         default=None,
         description="Per-page scrape options controlling output format, content filtering, viewport, and timeout behavior. Applied to every page in the crawl, including the start URL.",
     )
+    prompt: str | None = Field(
+        default=None,
+        max_length=10000,
+        description="Natural language description of what to crawl. Used to derive crawl parameters (includePaths, excludePaths, maxDepth) via LLM. Explicitly-set parameters override LLM-derived ones.",
+    )
 
     @field_validator("url")
     @classmethod
@@ -361,6 +366,61 @@ class CrawlStatusResponse(BaseModel):
     completed_at: str | None = None
     expires_at: str | None = None
     duration: int | None = None
+
+
+class ParamsPreviewRequest(BaseModel):
+    """Request model for POST /v2/crawl/params-preview.
+
+    Attributes:
+        url: The target URL to crawl (used for context).
+        prompt: Natural language description of what to crawl.
+            Required — the endpoint derives crawl parameters from this.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    url: str
+    prompt: str = Field(
+        ...,
+        max_length=10000,
+        description="Natural language description of what to crawl",
+    )
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        """Validate that url is a well-formed HTTP/HTTPS URL."""
+        from urllib.parse import urlparse
+
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            raise ValueError("URL must have a scheme (http:// or https://)")
+        if parsed.scheme.lower() not in ("http", "https"):
+            raise ValueError(f"URL scheme must be http or https, got '{parsed.scheme}'")
+        if not parsed.netloc:
+            raise ValueError("URL must have a network location (host)")
+        return value
+
+
+class ParamsPreviewResponse(BaseModel):
+    """Response model for POST /v2/crawl/params-preview.
+
+    Returns the derived crawl parameters WITHOUT starting a crawl job.
+    Explicitly-set fields (when provided alongside ``prompt``) override
+    LLM-derived equivalents — this preview shows the final merged result.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    success: bool = True
+    include_paths: list[str] | None = None
+    exclude_paths: list[str] | None = None
+    max_depth: int | None = None
+    limit: int | None = None
+    ignore_robots_txt: bool | None = None
+    robots_user_agent: str | None = None
+    deduplicate_similar_urls: bool | None = None
+    error: str | None = None
 
 
 class BatchScrapeRequest(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -4,6 +4,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic.alias_generators import to_camel
 
 
 class ErrorDetail(BaseModel):
@@ -89,6 +90,8 @@ class AgentCancelResponse(BaseModel):
 
 
 class CrawlRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
     url: str
     max_pages: int = Field(
         default=10, ge=1, description="Maximum pages to scrape, must be >= 1"

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -114,6 +114,16 @@ class CrawlRequest(BaseModel):
     crawl_entire_domain: bool = False
     allow_subdomains: bool = False
     allow_external_links: bool = False
+    max_concurrency: int = Field(
+        default=3,
+        ge=1,
+        description="Maximum concurrent page scrapes (1-50, values > 50 are capped)",
+    )
+    delay: float | None = Field(
+        default=None,
+        ge=0,
+        description="Delay in seconds between scrapes. Forces concurrency to 1 when set.",
+    )
 
     @field_validator("url")
     @classmethod
@@ -126,6 +136,26 @@ class CrawlRequest(BaseModel):
             raise ValueError(f"URL scheme must be http or https, got '{parsed.scheme}'")
         if not parsed.netloc:
             raise ValueError("URL must have a network location (host)")
+        return value
+
+    @field_validator("max_concurrency")
+    @classmethod
+    def validate_max_concurrency(cls, value: int) -> int:
+        """Validate and cap max_concurrency values.
+
+        Values of 0 or negative are rejected (would deadlock the semaphore).
+        Values above 50 are silently capped to 50 to prevent resource exhaustion.
+        """
+        if value < 1:
+            raise ValueError(f"max_concurrency must be >= 1, got {value}")
+        return min(value, 50)
+
+    @field_validator("delay")
+    @classmethod
+    def validate_delay(cls, value: float | None) -> float | None:
+        """Reject negative delay values."""
+        if value is not None and value < 0:
+            raise ValueError(f"delay must be >= 0, got {value}")
         return value
 
     @model_validator(mode="after")

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -147,6 +147,8 @@ class MapRequest(BaseModel):
     url: str
     limit: int = 100
     search: str | None = None
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
 
 
 class MapResponse(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -111,6 +111,9 @@ class CrawlRequest(BaseModel):
     regex_on_full_url: bool = False
     verbose: bool = False
     webhook: dict[str, Any] | None = None
+    crawl_entire_domain: bool = False
+    allow_subdomains: bool = False
+    allow_external_links: bool = False
 
     @field_validator("url")
     @classmethod

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -84,6 +84,24 @@ class ScrapeOptions(BaseModel):
     remove_base64_images: bool = Field(
         default=False, description="Strip data:image/... URIs from output"
     )
+    max_age: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Maximum age of cached content in milliseconds. If the cached response"
+            " is younger than ``max_age``, it is returned without re-scraping."
+            " When set to 0, caching is bypassed entirely (every request is fresh)."
+        ),
+    )
+    min_age: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Minimum age for cache-only mode in milliseconds. When set, only cached"
+            " content is returned. A cache miss produces a cache_miss error for that"
+            " URL rather than fetching fresh content."
+        ),
+    )
 
     @field_validator("formats")
     @classmethod
@@ -112,6 +130,31 @@ class ScrapeOptions(BaseModel):
         if value is not None and value < 0:
             raise ValueError(f"wait_for must be >= 0, got {value}")
         return value
+
+    @field_validator("max_age")
+    @classmethod
+    def validate_max_age(cls, value: int | None) -> int | None:
+        """Reject negative max_age values.
+
+        VAL-SCRAPE-032: negative maxAge returns 422.
+        """
+        if value is not None and value < 0:
+            raise ValueError(f"max_age must be >= 0, got {value}")
+        return value
+
+    @model_validator(mode="after")
+    def validate_cache_ages(self) -> "ScrapeOptions":
+        """Validate that min_age does not exceed max_age.
+
+        VAL-SCRAPE-033: minAge greater than maxAge is rejected.
+        """
+        min_age = self.min_age
+        max_age = self.max_age
+        if min_age is not None and max_age is not None and min_age > max_age:
+            raise ValueError(
+                f"min_age ({min_age}ms) cannot exceed max_age ({max_age}ms)"
+            )
+        return self
 
 
 class ScrapeRequest(BaseModel):

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -101,6 +101,10 @@ class CrawlRequest(BaseModel):
     )
     limit: int | None = None
     ignore_sitemap: bool = False
+    sitemap: str = Field(
+        default="include",
+        description="Sitemap mode: 'include' (default), 'skip', or 'only'",
+    )
     ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
@@ -140,6 +144,24 @@ class CrawlRequest(BaseModel):
                     raise ValueError(
                         f"Invalid regex in {field_name}[{i}]: '{pattern}' — {exc}"
                     ) from exc
+        return self
+
+    @model_validator(mode="after")
+    def resolve_sitemap_mode(self) -> "CrawlRequest":
+        """Backward compatibility: ignore_sitemap=true → sitemap='skip'.
+
+        Also validates that sitemap is one of the allowed values.
+        """
+        # Backward compatibility: ignore_sitemap overrides sitemap field
+        if self.ignore_sitemap:
+            self.sitemap = "skip"
+
+        # Validate sitemap value
+        allowed = ("include", "skip", "only")
+        if self.sitemap not in allowed:
+            raise ValueError(
+                f"Invalid sitemap mode '{self.sitemap}'. Must be one of: {', '.join(allowed)}"
+            )
         return self
 
 

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -6,6 +6,11 @@ from urllib.parse import urlparse
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.alias_generators import to_camel
 
+# ── Valid scrape format values ──────────────────────────────────
+VALID_SCRAPE_FORMATS: frozenset[str] = frozenset(
+    {"markdown", "html", "links", "screenshot", "rawHtml", "screenshot@fullPage"}
+)
+
 
 class ErrorDetail(BaseModel):
     """A single field-level validation error."""
@@ -21,6 +26,92 @@ class ErrorResponse(BaseModel):
     error: str = "An unexpected error occurred"
     error_code: str = "INTERNAL_ERROR"
     details: list[ErrorDetail] | dict | None = None
+
+
+class ScrapeOptions(BaseModel):
+    """Firecrawl-compatible scrape options for controlling per-page extraction.
+
+    All fields are optional with documented defaults. When ``None`` (or omitted),
+    the scraper-svc applies its own sensible defaults for each field.
+
+    Attributes:
+        formats: List of output formats to return. Allowed values:
+            ``markdown`` (default), ``html``, ``links``, ``screenshot``,
+            ``rawHtml``, ``screenshot@fullPage``.
+        only_main_content: When True, strip navigation, header, footer and
+            other boilerplate from the extracted content (default: True).
+        include_tags: If set, only content from these CSS/tag selectors is
+            included in the output.
+        exclude_tags: If set, content from these CSS/tag selectors is removed
+            from the output.
+        wait_for: Time in milliseconds to wait for the page to load/stabilize
+            before extracting content. Useful for JS-rendered SPAs.
+        mobile: When True, use a mobile user-agent and viewport dimensions
+            (default: False).
+        timeout: Per-page timeout in milliseconds (default: 30000, minimum: 1000).
+        headers: Custom HTTP headers to forward with the request (e.g.,
+            ``{"Authorization": "Bearer ..."}``).
+        remove_base64_images: When True, strip ``data:image/...`` URIs from
+            the extracted content (default: False).
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    formats: list[str] = Field(
+        default=["markdown"],
+        description="Output formats: markdown, html, links, etc.",
+    )
+    only_main_content: bool = Field(
+        default=True,
+        description="Strip navigation/header/footer boilerplate",
+    )
+    include_tags: list[str] | None = Field(
+        default=None, description="Only include content from these selectors"
+    )
+    exclude_tags: list[str] | None = Field(
+        default=None, description="Exclude content from these selectors"
+    )
+    wait_for: int | None = Field(
+        default=None, ge=0, description="Wait time in milliseconds before extraction"
+    )
+    mobile: bool = Field(default=False, description="Use mobile viewport and UA")
+    timeout: int = Field(
+        default=30000, ge=1000, description="Per-page timeout in milliseconds"
+    )
+    headers: dict[str, str] | None = Field(
+        default=None, description="Custom HTTP headers"
+    )
+    remove_base64_images: bool = Field(
+        default=False, description="Strip data:image/... URIs from output"
+    )
+
+    @field_validator("formats")
+    @classmethod
+    def validate_formats(cls, value: list[str]) -> list[str]:
+        """Validate that each format is a known/recognised value."""
+        if not value:
+            raise ValueError("formats must be a non-empty list")
+        for fmt in value:
+            if fmt not in VALID_SCRAPE_FORMATS:
+                allowed = ", ".join(sorted(VALID_SCRAPE_FORMATS))
+                raise ValueError(f"Invalid format '{fmt}'. Allowed values: {allowed}")
+        return value
+
+    @field_validator("timeout")
+    @classmethod
+    def validate_timeout(cls, value: int) -> int:
+        """Reject out-of-range timeout values."""
+        if value < 1000:
+            raise ValueError(f"timeout must be >= 1000ms, got {value}")
+        return value
+
+    @field_validator("wait_for")
+    @classmethod
+    def validate_wait_for(cls, value: int | None) -> int | None:
+        """Reject negative wait_for values."""
+        if value is not None and value < 0:
+            raise ValueError(f"wait_for must be >= 0, got {value}")
+        return value
 
 
 class ScrapeRequest(BaseModel):
@@ -131,6 +222,10 @@ class CrawlRequest(BaseModel):
     robots_user_agent: str | None = Field(
         default=None,
         description="Custom User-Agent string for robots.txt evaluation. When set, robots.txt rules are evaluated against this User-Agent instead of the default bot UA.",
+    )
+    scrape_options: ScrapeOptions | None = Field(
+        default=None,
+        description="Per-page scrape options controlling output format, content filtering, viewport, and timeout behavior. Applied to every page in the crawl, including the start URL.",
     )
 
     @field_validator("url")

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -1,8 +1,9 @@
 """Pydantic models matching the Firecrawl v2 agent API contract."""
 
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ErrorDetail(BaseModel):
@@ -91,10 +92,25 @@ class CrawlRequest(BaseModel):
     url: str
     max_pages: int = 10
     max_depth: int = 2
+    limit: int | None = None
     ignore_sitemap: bool = False
+    ignore_query_parameters: bool = False
     include_paths: list[str] | None = None
     exclude_paths: list[str] | None = None
     webhook: dict[str, Any] | None = None
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        """Validate that url is a well-formed HTTP/HTTPS URL."""
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            raise ValueError("URL must have a scheme (http:// or https://)")
+        if parsed.scheme.lower() not in ("http", "https"):
+            raise ValueError(f"URL scheme must be http or https, got '{parsed.scheme}'")
+        if not parsed.netloc:
+            raise ValueError("URL must have a network location (host)")
+        return value
 
 
 class CrawlCreateResponse(BaseModel):

--- a/agent-svc/agent/nl_params.py
+++ b/agent-svc/agent/nl_params.py
@@ -1,0 +1,326 @@
+"""Natural-language to crawl-parameters translation.
+
+Uses the existing ``LLMClient`` to translate a user's natural-language
+description of what they want to crawl into structured crawl parameters
+(``includePaths``, ``excludePaths``, ``maxDepth``, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .llm import LLMClient
+
+logger = logging.getLogger(__name__)
+
+# ── LLM system prompt ──────────────────────────────────────────
+
+SYSTEM_PROMPT = """You are a crawl parameter generator. Given a natural-language description of what a user wants to crawl, you produce structured crawl parameters.
+
+Respond ONLY with valid JSON matching this schema:
+{
+  "include_paths": [string] or null,
+  "exclude_paths": [string] or null,
+  "max_depth": int or null,
+  "max_pages": int or null,
+  "ignore_robots_txt": bool or null,
+  "robots_user_agent": string or null,
+  "deduplicate_similar_urls": bool or null,
+  "reasoning": "Brief explanation of your choices"
+}
+
+Rules:
+1. include_paths should use regex patterns like "blog/.*" or "products?/.*" or "docs/.*"
+2. exclude_paths should use regex patterns like "admin/.*" or "login.*"
+3. max_depth: 2 for most sites, 0 for just one page, 3+ for deep crawls
+4. max_pages: 10 for "get everything important" on small sites, 50+ for large crawls, 1 for single page
+5. ignore_robots_txt: true only if the user explicitly asks to ignore robots.txt
+6. deduplicate_similar_urls: true for most crawls (removes query-param variants)
+7. If the user mentions "blog" or "posts", include_paths should target "blog/.*" or "posts/.*"
+8. If the user mentions "products" or "shop", include_paths should target "products?/.*" or "shop/.*"
+9. If the user says "everything" or "all" or doesn't specify scope, leave include_paths as null
+10. If the user says "except" or "but not" or "skip", put the excluded section in exclude_paths
+11. If the user mentions "docs" or "documentation", include_paths should target "docs/.*"
+12. Do NOT make up values. If the prompt doesn't suggest a value, set it to null.
+13. Keep regex patterns simple and permissive — they will be applied as regex patterns.
+
+Respond with ONLY the JSON object, no markdown, no code fences."""
+
+# ── JSON schema for structured LLM output ──────────────────────
+
+OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "include_paths": {
+            "type": "array",
+            "items": {"type": "string"},
+            "nullable": True,
+        },
+        "exclude_paths": {
+            "type": "array",
+            "items": {"type": "string"},
+            "nullable": True,
+        },
+        "max_depth": {"type": "integer", "nullable": True},
+        "max_pages": {"type": "integer", "nullable": True},
+        "ignore_robots_txt": {"type": "boolean", "nullable": True},
+        "robots_user_agent": {"type": "string", "nullable": True},
+        "deduplicate_similar_urls": {"type": "boolean", "nullable": True},
+        "reasoning": {"type": "string"},
+    },
+}
+
+
+def _safe_parse_llm_response(text: str) -> dict[str, Any] | None:
+    """Parse the LLM response text as JSON.
+
+    Handles common formatting issues like markdown code fences,
+    trailing commas, and leading/trailing whitespace.
+
+    Returns the parsed dict, or ``None`` if parsing fails entirely.
+    """
+    cleaned = text.strip()
+
+    # Strip markdown code fences if present
+    if cleaned.startswith("```"):
+        # Find the first newline after opening fence
+        first_nl = cleaned.find("\n")
+        if first_nl != -1:
+            cleaned = cleaned[first_nl + 1 :]
+        # Find closing fence
+        fence_end = cleaned.rfind("```")
+        if fence_end != -1:
+            cleaned = cleaned[:fence_end].strip()
+
+    # Try parsing as JSON
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        pass
+
+    # Try to find a JSON-like object in the text
+    try:
+        brace_start = cleaned.index("{")
+        brace_end = cleaned.rindex("}")
+        if brace_end > brace_start:
+            candidate = cleaned[brace_start : brace_end + 1]
+            return json.loads(candidate)
+    except (ValueError, json.JSONDecodeError):
+        pass
+
+    return None
+
+
+def _validate_derived_params(
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate and normalize the derived parameters.
+
+    Handles type coercion and range validation. Returns a dict with
+    only valid fields.
+    """
+    result: dict[str, Any] = {}
+
+    # include_paths and exclude_paths: must be list of strings or None
+    for field in ("include_paths", "exclude_paths"):
+        value = params.get(field)
+        if value is not None:
+            if isinstance(value, list) and all(isinstance(v, str) for v in value):
+                result[field] = value
+
+    # max_depth: must be non-negative int or None
+    md = params.get("max_depth")
+    if md is not None:
+        try:
+            md_int = int(md)
+            if md_int >= 0:
+                result["max_depth"] = md_int
+        except (ValueError, TypeError):
+            pass
+
+    # max_pages (limit): must be positive int or None
+    mp = params.get("max_pages")
+    if mp is not None:
+        try:
+            mp_int = int(mp)
+            if mp_int >= 1:
+                result["max_pages"] = mp_int
+        except (ValueError, TypeError):
+            pass
+
+    # ignore_robots_txt: bool
+    irt = params.get("ignore_robots_txt")
+    if isinstance(irt, bool):
+        result["ignore_robots_txt"] = irt
+
+    # robots_user_agent: string
+    rua = params.get("robots_user_agent")
+    if isinstance(rua, str) and rua.strip():
+        result["robots_user_agent"] = rua.strip()
+
+    # deduplicate_similar_urls: bool
+    dsu = params.get("deduplicate_similar_urls")
+    if isinstance(dsu, bool):
+        result["deduplicate_similar_urls"] = dsu
+
+    return result
+
+
+async def derive_crawl_params(
+    prompt: str,
+    llm_base_url: str,
+    llm_api_key: str,
+    llm_model: str,
+) -> dict[str, Any]:
+    """Derive crawl parameters from a natural-language prompt.
+
+    Calls the LLM with a structured system prompt and JSON schema
+    to extract crawl parameters from the user's description.
+
+    Args:
+        prompt: Natural-language description of what to crawl.
+        llm_base_url: LLM API base URL.
+        llm_api_key: LLM API key.
+        llm_model: LLM model name.
+
+    Returns:
+        A dict with derived crawl parameters. Always returns valid
+        fields (may be empty on failure). Includes an ``error`` key
+        if the LLM call failed or returned invalid JSON.
+
+        On success, returns fields like ``include_paths``,
+        ``exclude_paths``, ``max_depth``, ``max_pages``, etc.
+    """
+    client = LLMClient(
+        base_url=llm_base_url,
+        api_key=llm_api_key,
+        model=llm_model,
+    )
+
+    try:
+        # First check if LLM is reachable
+        if not await client.check_health():
+            logger.warning("LLM backend unavailable for NL→params translation")
+            return {
+                "error": (
+                    "LLM backend is not available. "
+                    "Cannot derive crawl parameters from prompt. "
+                    "Default parameters will be used."
+                )
+            }
+
+        result_text = await client.generate(
+            system_prompt=SYSTEM_PROMPT,
+            user_prompt=(
+                f"Crawl description: {prompt}\n\n"
+                f"URL: <not needed for path derivation>\n\n"
+                f"Generate crawl parameters for this description."
+            ),
+            schema=OUTPUT_SCHEMA,
+        )
+
+        # Check for error from LLM client
+        if result_text.startswith("Error:"):
+            logger.warning("LLM returned error for NL→params: %s", result_text)
+            return {
+                "error": (
+                    f"LLM returned an error: {result_text}. "
+                    "Default parameters will be used."
+                )
+            }
+
+        # Parse the JSON response
+        parsed = _safe_parse_llm_response(result_text)
+        if parsed is None:
+            logger.warning(
+                "LLM returned unparseable JSON for NL→params: %s",
+                result_text[:500],
+            )
+            return {
+                "error": ("LLM returned invalid JSON. Default parameters will be used.")
+            }
+
+        # Validate and normalize
+        result = _validate_derived_params(parsed)
+
+        if not result:
+            logger.warning(
+                "LLM returned empty/no valid params for prompt: %s",
+                prompt[:200],
+            )
+            return {
+                "error": (
+                    "LLM returned no usable parameters. "
+                    "Default parameters will be used."
+                )
+            }
+
+        logger.info(
+            "NL→params derived: include_paths=%s, exclude_paths=%s, "
+            "max_depth=%s, max_pages=%s from prompt=%s",
+            result.get("include_paths"),
+            result.get("exclude_paths"),
+            result.get("max_depth"),
+            result.get("max_pages"),
+            prompt[:200],
+        )
+        return result
+
+    except Exception as e:
+        logger.error("NL→params LLM call failed: %s", e)
+        return {"error": f"LLM call failed: {e}. Default parameters will be used."}
+    finally:
+        await client.close()
+
+
+def merge_params(
+    llm_derived: dict[str, Any],
+    explicit: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge LLM-derived params with explicit user params.
+
+    Explicitly-set params override LLM-derived equivalents.
+    Only the following fields are subject to merging:
+    - ``include_paths``
+    - ``exclude_paths``
+    - ``max_depth`` (mapped from explicit ``max_depth`` in crawl request)
+    - ``max_pages`` / ``limit`` (mapped from explicit ``max_pages``)
+
+    Args:
+        llm_derived: Params derived from the LLM (may include ``error``).
+        explicit: Dict of explicitly-set params from the crawl request.
+            Expected keys: ``include_paths``, ``exclude_paths``,
+            ``max_depth``, ``max_pages``.
+
+    Returns:
+        Merged params dict. LLM-derived values that are overridden by
+        explicit values are replaced. Explicit values that are ``None``
+        don't override non-None LLM-derived values.
+    """
+    merged: dict[str, Any] = {}
+
+    # Preserve error from LLM if present
+    if "error" in llm_derived:
+        merged["error"] = llm_derived["error"]
+
+    # Fields where explicit overrides LLM (if explicit is not None)
+    override_fields = [
+        ("include_paths", "include_paths"),
+        ("exclude_paths", "exclude_paths"),
+        ("max_depth", "max_depth"),
+        ("max_pages", "max_pages"),
+    ]
+
+    for llm_key, explicit_key in override_fields:
+        llm_val = llm_derived.get(llm_key)
+        explicit_val = explicit.get(explicit_key)
+
+        if explicit_val is not None:
+            # Explicit always wins
+            merged[llm_key] = explicit_val
+        elif llm_val is not None:
+            merged[llm_key] = llm_val
+
+    return merged

--- a/agent-svc/agent/research.py
+++ b/agent-svc/agent/research.py
@@ -200,7 +200,7 @@ async def _run_multi_query_discover_and_scrape(
             *search_tasks, return_exceptions=True
         )
         for i, (query, result_tuple) in enumerate(  # type: ignore[misc]
-            zip(queries_to_run, search_results_list), start=1
+            zip(queries_to_run, search_results_list, strict=False), start=1
         ):
             logger.info("  [%d/%d] Searching: %s", i, len(queries_to_run), query)
             if isinstance(result_tuple, Exception):

--- a/agent-svc/agent/scraper_client.py
+++ b/agent-svc/agent/scraper_client.py
@@ -37,6 +37,7 @@ class ScraperClient:
         force_browser: bool = False,
         ignore_robots_txt: bool = False,
         robots_user_agent: str | None = None,
+        scrape_options: dict | None = None,
     ) -> dict:
         """Scrape a URL via the scraper service.
 
@@ -51,6 +52,10 @@ class ScraperClient:
 
         When ``robots_user_agent`` is set, it is used as the User-Agent for
         robots.txt evaluation instead of the default bot UA.
+
+        When ``scrape_options`` is set, it is forwarded as-is to the
+        scraper-svc ``/scrape`` endpoint so that per-page extraction
+        options (formats, content filtering, viewport, etc.) are applied.
         """
         start = time.monotonic()
         try:
@@ -61,6 +66,8 @@ class ScraperClient:
                 body["ignore_robots_txt"] = True
             if robots_user_agent is not None:
                 body["robots_user_agent"] = robots_user_agent
+            if scrape_options:
+                body["scrape_options"] = scrape_options
             resp = await self._client.post(
                 f"{self.base_url}/scrape",
                 json=body,

--- a/agent-svc/agent/scraper_client.py
+++ b/agent-svc/agent/scraper_client.py
@@ -12,11 +12,24 @@ logger = logging.getLogger(__name__)
 
 
 class ScraperClient:
-    """Client for the scraper-svc HTTP API."""
+    """Client for the scraper-svc HTTP API.
+
+    Connection pool limits are configured to support high concurrency
+    (up to ``max_connections=100``, per VAL-CONC-048). This prevents
+    ``PoolTimeout`` or "connection pool exhausted" errors when many
+    concurrent scrape tasks are in flight.
+    """
 
     def __init__(self, base_url: str = "http://scraper-svc:8001"):
         self.base_url = base_url.rstrip("/")
-        self._client = httpx.AsyncClient(timeout=60)
+        self._client = httpx.AsyncClient(
+            timeout=60,
+            limits=httpx.Limits(
+                max_connections=100,
+                max_keepalive_connections=50,
+                keepalive_expiry=30.0,
+            ),
+        )
 
     async def scrape(
         self,

--- a/agent-svc/agent/scraper_client.py
+++ b/agent-svc/agent/scraper_client.py
@@ -1,5 +1,6 @@
 """HTTP client to the scraper service."""
 
+import contextlib
 import logging
 import time
 
@@ -116,10 +117,8 @@ class ScraperClient:
                 pending, return_when=_asyncio.FIRST_COMPLETED
             )
             for t in done:
-                try:
+                with contextlib.suppress(Exception):
                     t.result()
-                except Exception:
-                    pass
 
         # Cancel remaining tasks
         for t in pending:

--- a/agent-svc/agent/scraper_client.py
+++ b/agent-svc/agent/scraper_client.py
@@ -18,7 +18,13 @@ class ScraperClient:
         self.base_url = base_url.rstrip("/")
         self._client = httpx.AsyncClient(timeout=60)
 
-    async def scrape(self, url: str, force_browser: bool = False) -> dict:
+    async def scrape(
+        self,
+        url: str,
+        force_browser: bool = False,
+        ignore_robots_txt: bool = False,
+        robots_user_agent: str | None = None,
+    ) -> dict:
         """Scrape a URL via the scraper service.
 
         Returns dict with keys: success, data (with markdown, source), error.
@@ -26,12 +32,22 @@ class ScraperClient:
 
         When ``force_browser`` is True, the scraper-svc skips lightweight
         tiers and goes straight to Playwright render (Tier 3).
+
+        When ``ignore_robots_txt`` is True, the scraper-svc bypasses
+        robots.txt enforcement but still applies per-domain rate limiting.
+
+        When ``robots_user_agent`` is set, it is used as the User-Agent for
+        robots.txt evaluation instead of the default bot UA.
         """
         start = time.monotonic()
         try:
             body: dict = {"url": url}
             if force_browser:
                 body["force_browser"] = True
+            if ignore_robots_txt:
+                body["ignore_robots_txt"] = True
+            if robots_user_agent is not None:
+                body["robots_user_agent"] = robots_user_agent
             resp = await self._client.post(
                 f"{self.base_url}/scrape",
                 json=body,

--- a/agent-svc/agent/settings.py
+++ b/agent-svc/agent/settings.py
@@ -26,6 +26,12 @@ class AgentSettings(BaseModel):
         default=5, alias="AGENT_MAX_SEARCHES_PER_REQUEST"
     )
     search_rate_limit: str = Field(default="10/60s", alias="AGENT_SEARCH_RATE_LIMIT")
+    crawl_max_duration_seconds: int = Field(
+        default=1800, alias="CRAWL_MAX_DURATION_SECONDS"
+    )
+    crawl_idle_timeout_seconds: int = Field(
+        default=300, alias="CRAWL_IDLE_TIMEOUT_SECONDS"
+    )
 
 
 @functools.cache

--- a/agent-svc/agent/sitemap_parser.py
+++ b/agent-svc/agent/sitemap_parser.py
@@ -1,0 +1,505 @@
+"""SitemapParser — fetches and parses XML sitemaps for GroktoCrawl.
+
+Discovers sitemap URLs from robots.txt ``Sitemap:`` directives and
+common locations (``/sitemap.xml``, ``/sitemap_index.xml``). Parses
+XML sitemaps (``<urlset>``) and sitemap index files (``<sitemapindex>``)
+recursively, handles gzipped content, and degrades gracefully on errors.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+from collections.abc import Sequence
+from urllib.parse import urlparse
+from xml.etree import ElementTree
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Default sitemap locations to try when robots.txt has no Sitemap directive.
+_COMMON_SITEMAP_PATHS = [
+    "/sitemap.xml",
+    "/sitemap_index.xml",
+]
+
+# Maximum recursion depth for sitemap index files.
+_MAX_RECURSION_DEPTH = 3
+
+# HTTP client timeout for sitemap fetches.
+_REQUEST_TIMEOUT = 15.0
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+
+class SitemapParser:
+    """Fetch and parse XML sitemaps for a domain.
+
+    Usage::
+
+        parser = SitemapParser()
+        urls = await parser.get_urls("example.com", limit=100)
+    """
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient | None = None,
+        common_sitemap_paths: Sequence[str] | None = None,
+        max_recursion_depth: int = _MAX_RECURSION_DEPTH,
+    ):
+        """Initialize the parser.
+
+        Args:
+            client: An optional ``httpx.AsyncClient`` to reuse. If
+                ``None``, a new client is created (and closed after
+                ``get_urls`` returns).
+            common_sitemap_paths: List of paths to check when robots.txt
+                has no ``Sitemap:`` directive. Defaults to
+                ``["/sitemap.xml", "/sitemap_index.xml"]``.
+            max_recursion_depth: Maximum depth for following nested
+                sitemap index files.
+        """
+        self._client = client
+        self._common_paths = (
+            list(common_sitemap_paths)
+            if common_sitemap_paths is not None
+            else list(_COMMON_SITEMAP_PATHS)
+        )
+        self._max_depth = max_recursion_depth
+        self._owned_client = client is None
+
+    async def get_urls(
+        self,
+        domain: str,
+        limit: int | None = None,
+    ) -> list[str]:
+        """Get all URLs from sitemaps for the given domain.
+
+        Discovers sitemap URLs from robots.txt (``Sitemap:`` directives)
+        and falls back to common locations. Parses XML sitemaps and
+        sitemap index files recursively.
+
+        Args:
+            domain: The domain to fetch sitemaps for (e.g.,
+                ``"example.com"``). Should not include a scheme.
+            limit: Maximum number of URLs to return. If ``None``, all
+                discovered URLs are returned.
+
+        Returns:
+            A list of unique, absolute URLs from the sitemap(s).
+        """
+        client = await self._ensure_client()
+        try:
+            sitemap_urls = await self._discover_sitemap_urls(domain, client)
+            if not sitemap_urls:
+                logger.info("No sitemap URLs found for %s, trying common paths", domain)
+                sitemap_urls = await self._try_common_paths(domain, client)
+
+            if not sitemap_urls:
+                logger.warning("No sitemap found for %s at any location", domain)
+                return []
+
+            # Parse all discovered sitemap URLs
+            all_urls: list[str] = []
+            seen: set[str] = set()
+
+            for sitemap_url in sitemap_urls:
+                if len(all_urls) >= (limit or float("inf")):
+                    break
+                parsed = await self._parse_sitemap(
+                    sitemap_url, client, depth=0, seen=seen
+                )
+                for url in parsed:
+                    if len(all_urls) >= (limit or float("inf")):
+                        break
+                    normalized = self._normalize_sitemap_url(url)
+                    if normalized and normalized not in seen:
+                        seen.add(normalized)
+                        all_urls.append(normalized)
+
+            return all_urls
+        finally:
+            if self._owned_client:
+                await client.aclose()
+
+    async def parse_sitemap_url(
+        self, sitemap_url: str, domain: str | None = None
+    ) -> list[str]:
+        """Parse a single sitemap URL and return its URLs.
+
+        This is useful when the caller already knows the sitemap URL
+        (e.g., from a robots.txt directive parsed by the politeness
+        module).
+
+        Args:
+            sitemap_url: The full URL of the sitemap to parse.
+            domain: Optional domain hint for logging. If not provided,
+                extracted from ``sitemap_url``.
+
+        Returns:
+            A list of unique, absolute URLs from the sitemap.
+        """
+        client = await self._ensure_client()
+        try:
+            seen: set[str] = set()
+            urls = await self._parse_sitemap(sitemap_url, client, depth=0, seen=seen)
+            result: list[str] = []
+            for url in urls:
+                normalized = self._normalize_sitemap_url(url)
+                if normalized and normalized not in result:
+                    result.append(normalized)
+            return result
+        finally:
+            if self._owned_client:
+                await client.aclose()
+
+    # ── Internal helpers ─────────────────────────────────────────
+
+    async def _ensure_client(self) -> httpx.AsyncClient:
+        """Get or create an HTTP client."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                follow_redirects=True, timeout=_REQUEST_TIMEOUT
+            )
+            self._owned_client = True
+        return self._client
+
+    async def _discover_sitemap_urls(
+        self, domain: str, client: httpx.AsyncClient
+    ) -> list[str]:
+        """Discover sitemap URLs from robots.txt ``Sitemap:`` directives.
+
+        Args:
+            domain: The domain to check.
+            client: The HTTP client to use.
+
+        Returns:
+            A list of sitemap URLs from robots.txt, or empty list if
+            robots.txt has no ``Sitemap:`` directive or is unreachable.
+        """
+        robots_url = f"https://{domain}/robots.txt"
+        try:
+            resp = await client.get(robots_url)
+            if resp.status_code != 200:
+                logger.debug(
+                    "robots.txt returned %d for %s, trying common paths",
+                    resp.status_code,
+                    domain,
+                )
+                return []
+            # Decompress gzipped robots.txt if needed
+            content = await self._decompress_content(resp)
+            if not content:
+                return []
+
+            # Extract Sitemap directives
+            sitemap_urls: list[str] = []
+            for line in content.splitlines():
+                if line.lower().startswith("sitemap:"):
+                    sitemap_urls.append(line.split(":", 1)[1].strip())
+
+            logger.info(
+                "Found %d sitemap URL(s) in robots.txt for %s",
+                len(sitemap_urls),
+                domain,
+            )
+            return sitemap_urls
+        except httpx.RequestError as exc:
+            logger.warning("Failed to fetch robots.txt for %s: %s", domain, exc)
+            return []
+        except Exception as exc:
+            logger.warning("Error parsing robots.txt for %s: %s", domain, exc)
+            return []
+
+    async def _try_common_paths(
+        self, domain: str, client: httpx.AsyncClient
+    ) -> list[str]:
+        """Try common sitemap paths as a fallback.
+
+        Args:
+            domain: The domain to check.
+            client: The HTTP client to use.
+
+        Returns:
+            A list of sitemap URLs that returned a successful response.
+        """
+        found: list[str] = []
+        for path in self._common_paths:
+            url = f"https://{domain}{path}"
+            try:
+                resp = await client.get(url)
+                if resp.status_code == 200:
+                    content_type = resp.headers.get("content-type", "").lower()
+                    # Accept XML or text content, or gzipped content
+                    if (
+                        "xml" in content_type
+                        or "text" in content_type
+                        or "gzip" in content_type
+                        or "octet-stream" in content_type
+                        or path.endswith(".gz")
+                        or not content_type
+                    ):
+                        logger.info("Found sitemap at %s", url)
+                        found.append(url)
+                    else:
+                        logger.debug(
+                            "Skipping %s (content-type: %s)", url, content_type
+                        )
+                else:
+                    logger.debug(
+                        "Common path %s returned %d for %s",
+                        url,
+                        resp.status_code,
+                        domain,
+                    )
+            except httpx.RequestError as exc:
+                logger.debug(
+                    "Failed to fetch common path %s for %s: %s",
+                    path,
+                    domain,
+                    exc,
+                )
+        return found
+
+    async def _parse_sitemap(
+        self,
+        sitemap_url: str,
+        client: httpx.AsyncClient,
+        depth: int,
+        seen: set[str],
+    ) -> list[str]:
+        """Parse a single sitemap URL and return discovered URLs.
+
+        Handles both ``<urlset>`` (leaf sitemap) and ``<sitemapindex>``
+        (index file) XML formats, as well as gzipped content and plain
+        text sitemaps.
+
+        Args:
+            sitemap_url: The URL of the sitemap to fetch.
+            client: The HTTP client.
+            depth: Current recursion depth (for nested indexes).
+            seen: Set of already-seen sitemap URLs to avoid re-parsing.
+
+        Returns:
+            A list of discovered page URLs.
+        """
+        if depth > self._max_depth:
+            logger.warning("Max recursion depth reached for %s", sitemap_url)
+            return []
+
+        # Avoid re-parsing the same sitemap URL
+        sitemap_normalized = self._normalize_sitemap_url(sitemap_url)
+        if sitemap_normalized and sitemap_normalized in seen:
+            logger.debug("Sitemap already parsed: %s", sitemap_url)
+            return []
+        if sitemap_normalized:
+            seen.add(sitemap_normalized)
+
+        # Fetch the sitemap
+        try:
+            resp = await client.get(sitemap_url)
+        except httpx.RequestError as exc:
+            logger.warning("Failed to fetch sitemap %s: %s", sitemap_url, exc)
+            return []
+
+        if resp.status_code >= 500:
+            logger.warning(
+                "Sitemap %s returned HTTP %d (server error)",
+                sitemap_url,
+                resp.status_code,
+            )
+            return []
+        if resp.status_code == 404:
+            logger.warning("Sitemap %s returned 404 (not found)", sitemap_url)
+            return []
+
+        if resp.status_code != 200:
+            logger.warning(
+                "Sitemap %s returned HTTP %d, skipping",
+                sitemap_url,
+                resp.status_code,
+            )
+            return []
+
+        # Decompress if needed
+        content = await self._decompress_content(resp)
+        if not content:
+            return []
+
+        # Check if it's a plain text sitemap (not XML)
+        is_text_sitemap = sitemap_url.endswith(".txt") or (
+            not content.strip().startswith("<")
+        )
+        if is_text_sitemap and not content.strip().startswith("<"):
+            logger.warning(
+                "Text sitemap detected at %s (unsupported) — "
+                "falling back to HTML-only discovery",
+                sitemap_url,
+            )
+            return []
+
+        return await self._parse_xml_content(content, sitemap_url, client, depth, seen)
+
+    async def _parse_xml_content(
+        self,
+        content: str,
+        sitemap_url: str,
+        client: httpx.AsyncClient,
+        depth: int,
+        seen: set[str],
+    ) -> list[str]:
+        """Parse XML sitemap content and extract URLs.
+
+        Handles both ``<urlset>`` (leaf sitemap) and ``<sitemapindex>``
+        (index) XML formats.
+
+        Args:
+            content: The XML content as a string.
+            sitemap_url: The sitemap URL (for logging).
+            client: The HTTP client.
+            depth: Current recursion depth.
+            seen: Set of already-seen sitemap/sitemap URLs.
+
+        Returns:
+            A list of discovered page URLs.
+        """
+        try:
+            root = ElementTree.fromstring(content)
+        except ElementTree.ParseError as exc:
+            logger.warning(
+                "Malformed XML in sitemap %s: %s — falling back to HTML-only discovery",
+                sitemap_url,
+                exc,
+            )
+            return []
+
+        # Determine the local tag name (handles namespace-prefixed tags)
+        def _local_tag(element) -> str:
+            tag = element.tag
+            if "}" in tag:
+                return tag.split("}", 1)[1]
+            return tag
+
+        root_tag = _local_tag(root)
+
+        if root_tag == "sitemapindex":
+            return await self._parse_sitemap_index(
+                root, client, depth, seen, _local_tag
+            )
+        elif root_tag == "urlset":
+            return self._parse_urlset(root, _local_tag)
+        else:
+            logger.warning(
+                "Unknown sitemap root element <%s> in %s",
+                root_tag,
+                sitemap_url,
+            )
+            return []
+
+    def _parse_urlset(self, root: ElementTree.Element, local_tag_fn) -> list[str]:
+        """Extract URLs from a ``<urlset>`` element.
+
+        Args:
+            root: The ``<urlset>`` XML element.
+            local_tag_fn: Function to get the local tag name.
+
+        Returns:
+            A list of ``<loc>`` values.
+        """
+        urls: list[str] = []
+        for url_elem in root:
+            for child in url_elem:
+                if local_tag_fn(child) == "loc" and child.text:
+                    url = child.text.strip()
+                    if url.startswith(("http://", "https://")):
+                        urls.append(url)
+        return urls
+
+    async def _parse_sitemap_index(
+        self,
+        root: ElementTree.Element,
+        client: httpx.AsyncClient,
+        depth: int,
+        seen: set[str],
+        local_tag_fn,
+    ) -> list[str]:
+        """Recursively parse a sitemap index file.
+
+        Args:
+            root: The ``<sitemapindex>`` XML element.
+            client: The HTTP client.
+            depth: Current recursion depth.
+            seen: Set of already-seen sitemap/sitemap URLs.
+            local_tag_fn: Function to get the local tag name.
+
+        Returns:
+            A list of aggregated page URLs from all child sitemaps.
+        """
+        child_sitemaps: list[str] = []
+        for sitemap_elem in root:
+            for child in sitemap_elem:
+                if local_tag_fn(child) == "loc" and child.text:
+                    child_sitemaps.append(child.text.strip())
+
+        all_urls: list[str] = []
+        for child_url in child_sitemaps:
+            if depth + 1 > self._max_depth:
+                logger.warning(
+                    "Max recursion depth reached for child sitemap %s",
+                    child_url,
+                )
+                continue
+            child_urls = await self._parse_sitemap(child_url, client, depth + 1, seen)
+            all_urls.extend(child_urls)
+        return all_urls
+
+    @staticmethod
+    async def _decompress_content(resp: httpx.Response) -> str | None:
+        """Decompress gzipped response content if needed.
+
+        Handles ``Content-Encoding: gzip`` and ``.gz`` extension.
+
+        Args:
+            resp: The HTTP response.
+
+        Returns:
+            Decoded string content, or ``None`` if decompression fails.
+        """
+        content_encoding = resp.headers.get("content-encoding", "").lower()
+        raw = resp.content
+
+        if content_encoding == "gzip" or raw[:2] == b"\x1f\x8b":
+            try:
+                raw = gzip.decompress(raw)
+            except (gzip.BadGzipFile, OSError) as exc:
+                logger.warning("Failed to decompress gzip content: %s", exc)
+                return None
+
+        # Try UTF-8 first, then fall back to common encodings
+        for encoding in ("utf-8", "utf-8-sig", "latin-1", "iso-8859-1"):
+            try:
+                return raw.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+
+        logger.warning("Could not decode sitemap content as text")
+        return None
+
+    @staticmethod
+    def _normalize_sitemap_url(url: str) -> str | None:
+        """Normalize a sitemap URL (strip fragments, basic cleanup).
+
+        Args:
+            url: The URL to normalize.
+
+        Returns:
+            Normalized URL, or ``None`` if the URL is not HTTP(S).
+        """
+        if not url or not url.startswith(("http://", "https://")):
+            return None
+        parsed = urlparse(url)
+        # Strip fragment
+        normalized = parsed._replace(fragment="").geturl()
+        return normalized

--- a/agent-svc/agent/store.py
+++ b/agent-svc/agent/store.py
@@ -2,6 +2,8 @@
 
 Stores job metadata, status, and results in Valkey key-value store.
 Uses the same valkey connection for both the API and the worker.
+Atomic progress updates use Valkey INCR to prevent lost increments
+under concurrency (VAL-CONC-042).
 """
 
 import json
@@ -25,12 +27,17 @@ def _default_ttl() -> int:
     return 86400
 
 
+# Key for atomic completed counter
+_COMPLETED_KEY = "job:{id}:completed"
+
+
 class JobStore:
     """Simple Valkey-backed job store.
 
     Key schema:
       job:{id}:meta  -> JSON with status, created_at, etc.
       job:{id}:data  -> JSON with result data (set on completion)
+      job:{id}:completed  -> INTEGER with atomic completed count (INCR)
     """
 
     def __init__(self, redis_url: str = "redis://localhost:6379/0"):
@@ -48,7 +55,76 @@ class JobStore:
             "payload": payload or {},
         }
         self.redis.set(f"job:{job_id}:meta", json.dumps(meta), ex=_default_ttl())
+        # Initialize atomic completed counter
+        self.redis.set(_COMPLETED_KEY.format(id=job_id), 0, ex=_default_ttl())
         return job_id
+
+    def increment_completed(self, job_id: str) -> int:
+        """Atomically increment the completed page count for a crawl job.
+
+        Uses Valkey ``INCR`` which is atomic and immune to read-modify-write
+        races. Returns the new count after increment.
+
+        The completed key is initialized to 0 in ``create_job()``, so an
+        ``INCR`` is safe even on first call (the TTL is preserved from
+        creation time).
+        """
+        return self.redis.incr(_COMPLETED_KEY.format(id=job_id))
+
+    def get_completed(self, job_id: str) -> int:
+        """Get the current atomic completed count for a job.
+
+        Returns 0 if the key does not exist (e.g., job was never created
+        or has expired).
+        """
+        val = self.redis.get(_COMPLETED_KEY.format(id=job_id))
+        if val is None:
+            return 0
+        return int(val)
+
+    def update_job_progress(
+        self,
+        job_id: str,
+        pages: list[dict] | None = None,
+        total: int | None = None,
+        errors: list[dict] | None = None,
+        robots_blocked: list[dict] | None = None,
+        filtered_out: list[dict] | None = None,
+    ) -> None:
+        """Update the job data key with current crawl progress.
+
+        Uses Valkey ``GETSET`` on the data key so that concurrent calls
+        do not lose pages/errors. The completed count is maintained
+        separately via ``increment_completed()`` so that it is never
+        overwritten by a stale data payload.
+
+        Args:
+            job_id: The crawl job ID.
+            pages: Current list of successfully scraped pages.
+            total: Current total (scraped + queued).
+            errors: Current list of error entries.
+            robots_blocked: Current list of politeness-blocked entries.
+            filtered_out: Current list of filtered-out URL entries.
+        """
+        ttl = _default_ttl()
+        data_key = f"job:{job_id}:data"
+        completed = self.get_completed(job_id)
+
+        payload: dict = {
+            "completed": completed,
+            "pages": pages or [],
+            "errors": errors or [],
+            "robots_blocked": robots_blocked or [],
+        }
+        if total is not None:
+            payload["total"] = total
+        if filtered_out is not None:
+            payload["filtered_out"] = filtered_out
+
+        # Use SET (not GETSET) — we build the full payload each time,
+        # but the completed count is sourced from the atomic counter,
+        # not from the list length.
+        self.redis.set(data_key, json.dumps(payload), ex=ttl)
 
     def get_job(self, job_id: str) -> dict | None:
         """Get job metadata. Returns None if not found."""
@@ -71,6 +147,8 @@ class JobStore:
         meta["status"] = "completed"
         meta["completed_at"] = _now_iso()
         self.redis.set(f"job:{job_id}:meta", json.dumps(meta), ex=_default_ttl())
+        # Ensure the final data payload has the correct completed count
+        data["completed"] = self.get_completed(job_id)
         self.redis.set(f"job:{job_id}:data", json.dumps(data), ex=_default_ttl())
 
     def fail_job(self, job_id: str, error: str) -> None:
@@ -96,6 +174,13 @@ class JobStore:
         meta["completed_at"] = _now_iso()
         self.redis.set(f"job:{job_id}:meta", json.dumps(meta), ex=_default_ttl())
         return True
+
+    def delete_completed_counter(self, job_id: str) -> None:
+        """Delete the atomic completed counter for a job.
+
+        Called during cleanup to remove the auxiliary counter key.
+        """
+        self.redis.delete(_COMPLETED_KEY.format(id=job_id))
 
     def list_active_jobs(
         self, kind: str | None = None, status: str = "processing", limit: int = 50

--- a/agent-svc/agent/store.py
+++ b/agent-svc/agent/store.py
@@ -6,13 +6,18 @@ Uses the same valkey connection for both the API and the worker.
 
 import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from redis import Redis
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _expires_iso() -> str:
+    """Return ISO 8601 timestamp for 24 hours from now."""
+    return (datetime.now(UTC) + timedelta(hours=24)).isoformat()
 
 
 def _default_ttl() -> int:
@@ -39,6 +44,7 @@ class JobStore:
             "kind": kind,
             "status": "processing",
             "created_at": _now_iso(),
+            "expires_at": _expires_iso(),
             "payload": payload or {},
         }
         self.redis.set(f"job:{job_id}:meta", json.dumps(meta), ex=_default_ttl())

--- a/agent-svc/agent/webhook.py
+++ b/agent-svc/agent/webhook.py
@@ -2,6 +2,8 @@
 
 Called from worker functions after store.complete_job() / store.fail_job().
 Retries with exponential backoff, optional HMAC signing.
+Each event includes a unique ``webhookId`` for receiver-side deduplication
+(VAL-CONC-050).
 """
 
 import asyncio
@@ -20,6 +22,30 @@ _webhook_settings = load_settings()
 MAX_RETRIES = 3
 TIMEOUT_SECONDS = 5
 
+# Counter for generating unique webhook IDs within a job/event scope
+_webhook_id_counter: dict[str, int] = {}
+
+
+def _next_webhook_id(job_id: str, event: str) -> str:
+    """Generate a unique, deterministic webhook ID for deduplication.
+
+    Uses an in-memory counter per (job_id, event) pair. The resulting
+    ID has the format ``{job_id}-{event}-{seq}`` where ``seq`` is a
+    monotonically increasing integer unique within that job+event scope.
+
+    For page events, the caller should pass a page-specific event key
+    (e.g. ``crawl.page-{url}``) so that each page gets distinct IDs.
+    For lifecycle events (started, completed), the plain event name
+    ensures exactly one firing.
+
+    Returns:
+        A unique string like ``"abc-123-crawl.page-1"``.
+    """
+    counter_key = f"{job_id}:{event}"
+    _webhook_id_counter[counter_key] = _webhook_id_counter.get(counter_key, 0) + 1
+    seq = _webhook_id_counter[counter_key]
+    return f"{job_id}-{event}-{seq}"
+
 
 def _sign_body(body: bytes, secret: str) -> str:
     """HMAC-SHA256 sign the request body."""
@@ -31,15 +57,29 @@ async def deliver_webhook(
     event: str,
     job_id: str,
     data: dict | None = None,
+    webhook_id_key: str | None = None,
+    task_tracker: object = None,
 ) -> None:
     """POST a job event to the configured webhook URL with retry logic.
 
+    Each delivery includes a unique ``webhookId`` field for receiver-side
+    deduplication (VAL-CONC-050). The ID is generated deterministically
+    based on ``job_id`` and ``webhook_id_key`` (or ``event`` if not given).
+
     Args:
         webhook_config: Dict with 'url' and optional 'events' list.
-                        Example: {"url": "https://example.com/hook", "events": ["completed", "failed"]}
-        event: The event type (e.g. "completed", "failed", "started").
+                        Example: ``{"url": "https://example.com/hook", "events": ["completed", "failed"]}``
+        event: The event type (e.g. ``"completed"``, ``"failed"``,
+               ``"crawl.started"``, ``"crawl.page"``).
         job_id: The job identifier.
         data: Optional payload to include in the body.
+        webhook_id_key: Key used to generate a unique webhookId. If not set,
+                        falls back to ``event``. Pass unique values per-page
+                        (e.g. ``f"crawl.page-{url}"``) to ensure each page
+                        gets a distinct idempotency key.
+        task_tracker: Optional ``TaskTracker`` instance. If provided, the
+                      webhook delivery is spawned as a tracked background
+                      task instead of executing inline.
     """
     if not webhook_config:
         return
@@ -53,9 +93,13 @@ async def deliver_webhook(
     if events_filter and event not in events_filter:
         return
 
+    id_key = webhook_id_key or event
+    webhook_id = _next_webhook_id(job_id, id_key)
+
     payload = {
         "event": event,
         "id": job_id,
+        "webhookId": webhook_id,
         "data": data or {},
     }
     body = json.dumps(payload).encode()
@@ -66,44 +110,57 @@ async def deliver_webhook(
             f"sha256={_sign_body(body, _webhook_settings.webhook_secret)}"
         )
 
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
-                resp = await client.post(url, content=body, headers=headers)
-                if resp.status_code < 500:
-                    logger.info(
-                        "Webhook delivered %s for job %s (status %d)",
-                        event,
-                        job_id,
+    async def _do_deliver() -> None:
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+                    resp = await client.post(url, content=body, headers=headers)
+                    if resp.status_code < 500:
+                        logger.info(
+                            "Webhook delivered %s for job %s (webhookId=%s, status %d)",
+                            event,
+                            job_id,
+                            webhook_id,
+                            resp.status_code,
+                        )
+                        return
+                    logger.warning(
+                        "Webhook attempt %d/%d returned %d for job %s (webhookId=%s)",
+                        attempt,
+                        MAX_RETRIES,
                         resp.status_code,
+                        job_id,
+                        webhook_id,
                     )
-                    return
+            except httpx.TimeoutException:
                 logger.warning(
-                    "Webhook attempt %d/%d returned %d for job %s",
+                    "Webhook attempt %d/%d timed out for job %s (webhookId=%s)",
                     attempt,
                     MAX_RETRIES,
-                    resp.status_code,
                     job_id,
+                    webhook_id,
                 )
-        except httpx.TimeoutException:
-            logger.warning(
-                "Webhook attempt %d/%d timed out for job %s",
-                attempt,
-                MAX_RETRIES,
-                job_id,
-            )
-        except Exception as e:
-            logger.warning(
-                "Webhook attempt %d/%d failed for job %s: %s",
-                attempt,
-                MAX_RETRIES,
-                job_id,
-                e,
-            )
+            except Exception as e:
+                logger.warning(
+                    "Webhook attempt %d/%d failed for job %s: %s (webhookId=%s)",
+                    attempt,
+                    MAX_RETRIES,
+                    job_id,
+                    e,
+                    webhook_id,
+                )
 
-        if attempt < MAX_RETRIES:
-            await asyncio.sleep(2**attempt)  # 2s, 4s
+            if attempt < MAX_RETRIES:
+                await asyncio.sleep(2**attempt)  # 2s, 4s
 
-    logger.error(
-        "Webhook delivery failed for job %s after %d attempts", job_id, MAX_RETRIES
-    )
+        logger.error(
+            "Webhook delivery failed for job %s after %d attempts (webhookId=%s)",
+            job_id,
+            MAX_RETRIES,
+            webhook_id,
+        )
+
+    if task_tracker is not None and hasattr(task_tracker, "create_background_task"):
+        task_tracker.create_background_task(_do_deliver())
+    else:
+        await _do_deliver()

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -170,7 +170,12 @@ async def _process_crawl_async(
                 webhook_id_key="crawl.started",
             )
 
+        from .crawl_cache import CrawlCache
         from .crawler import CrawlEngine, CrawlOptions
+
+        crawl_cache = CrawlCache(
+            f"redis://{settings.valkey_host}:{settings.valkey_port}/{settings.valkey_db}"
+        )
 
         options = CrawlOptions(
             max_pages=max_pages,
@@ -192,7 +197,9 @@ async def _process_crawl_async(
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
             scrape_options=scrape_options,
         )
-        engine = CrawlEngine(scraper, store=store, options=options)
+        engine = CrawlEngine(
+            scraper, store=store, options=options, crawl_cache=crawl_cache
+        )
 
         # Per-page webhook callback using task_tracker (VAL-CONC-049)
         async def _page_callback(_job_id: str, page: dict[str, Any]) -> None:

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -113,6 +113,7 @@ async def _process_crawl_async(
     exclude_paths: list[str] | None = None,
     regex_on_full_url: bool = False,
     verbose: bool = False,
+    sitemap_mode: str = "include",
 ) -> None:
     """Process a crawl job with full lifecycle support.
 
@@ -158,6 +159,7 @@ async def _process_crawl_async(
             exclude_paths=exclude_paths,
             regex_on_full_url=regex_on_full_url,
             verbose=verbose,
+            sitemap_mode=sitemap_mode,
             max_duration_seconds=settings.crawl_max_duration_seconds,
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -114,13 +114,40 @@ async def _process_crawl_async(
     regex_on_full_url: bool = False,
     verbose: bool = False,
 ) -> None:
+    """Process a crawl job with full lifecycle support.
+
+    Lifecycle webhooks (when configured):
+        - ``crawl.started``: fired before the crawl begins
+        - ``crawl.page``: fired after each individual page is scraped
+        - ``crawl.completed``: fired on terminal states (completed, cancelled)
+        - ``crawl.failed``: fired on unexpected exception
+
+    Cancellation is cooperative: DELETE /v2/crawl/{id} sets the job meta
+    status to ``cancelled`` in Redis; the engine checks this between
+    page scrapes and stops early. The job store is NOT overwritten when
+    the engine detects cancellation (``cancel_job()`` already set it).
+    """
     settings = _get_worker_settings()
     store = JobStore(
         f"redis://{settings.valkey_host}:{settings.valkey_port}/{settings.valkey_db}"
     )
     scraper = ScraperClient(scraper_url)
+    start = time.monotonic()
+    job_type = "crawl"
 
-    async def work_fn() -> dict[str, Any]:
+    METRICS.counter("jobs_submitted_total", "Total jobs submitted", ["type"]).inc(
+        {"type": job_type}
+    )
+
+    try:
+        # ── Fire crawl.started webhook ────────────────────────
+        await deliver_webhook(
+            webhook_config,
+            "crawl.started",
+            job_id,
+            {"url": url, "max_pages": max_pages, "max_depth": max_depth},
+        )
+
         from .crawler import CrawlEngine, CrawlOptions
 
         options = CrawlOptions(
@@ -131,9 +158,16 @@ async def _process_crawl_async(
             exclude_paths=exclude_paths,
             regex_on_full_url=regex_on_full_url,
             verbose=verbose,
+            max_duration_seconds=settings.crawl_max_duration_seconds,
+            idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )
         engine = CrawlEngine(scraper, store=store, options=options)
-        result = await engine.run(url, job_id=job_id)
+
+        # Per-page webhook callback
+        async def _page_callback(_job_id: str, page: dict[str, Any]) -> None:
+            await deliver_webhook(webhook_config, "crawl.page", _job_id, page)
+
+        result = await engine.run(url, job_id=job_id, page_callback=_page_callback)
 
         # Fire-and-forget indexing for each page
         for page in result.pages:
@@ -141,20 +175,10 @@ async def _process_crawl_async(
             markdown = page.get("markdown", "")
             if task_tracker is not None:
                 task_tracker.create_background_task(
-                    _index_page_async(
-                        page_url,
-                        "",
-                        markdown[:2000],
-                    )
+                    _index_page_async(page_url, "", markdown[:2000])
                 )
             else:
-                asyncio.create_task(
-                    _index_page_async(
-                        page_url,
-                        "",
-                        markdown[:2000],
-                    )
-                )
+                asyncio.create_task(_index_page_async(page_url, "", markdown[:2000]))
 
         payload: dict[str, Any] = {
             "completed": result.completed,
@@ -164,11 +188,47 @@ async def _process_crawl_async(
         }
         if verbose:
             payload["filtered_out"] = result.filtered_out
-        return payload
 
-    await _run_job_with_observability(
-        job_id, "crawl", store, webhook_config, work_fn, scraper.close
-    )
+        # ── Check if job was cancelled via DELETE ─────────────
+        job_meta = store.get_job(job_id)
+        was_cancelled = job_meta is not None and job_meta.get("status") == "cancelled"
+
+        if was_cancelled:
+            # Store is already marked cancelled by cancel_job();
+            # do NOT overwrite with complete_job().
+            logger.info("Crawl %s was cancelled — preserving cancelled status", job_id)
+            await deliver_webhook(
+                webhook_config,
+                "crawl.completed",
+                job_id,
+                {**payload, "status": "cancelled"},
+            )
+        else:
+            store.complete_job(job_id, payload)
+            await deliver_webhook(webhook_config, "crawl.completed", job_id, payload)
+
+        elapsed = time.monotonic() - start
+        METRICS.histogram(
+            "job_duration_seconds", "Job processing duration", ["type", "status"]
+        ).observe({"type": job_type, "status": "completed"}, elapsed)
+        METRICS.counter("jobs_completed_total", "Total completed jobs", ["type"]).inc(
+            {"type": job_type}
+        )
+        logger.info("Crawl job %s completed in %.2fs", job_id, elapsed)
+
+    except Exception as e:
+        logger.exception("Crawl job %s failed", job_id)
+        store.fail_job(job_id, str(e))
+        await deliver_webhook(webhook_config, "crawl.failed", job_id, {"error": str(e)})
+        elapsed = time.monotonic() - start
+        METRICS.histogram(
+            "job_duration_seconds", "Job processing duration", ["type", "status"]
+        ).observe({"type": job_type, "status": "failed"}, elapsed)
+        METRICS.counter("jobs_failed_total", "Total failed jobs", ["type"]).inc(
+            {"type": job_type}
+        )
+    finally:
+        await scraper.close()
 
 
 async def _process_batch_scrape_async(

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -111,6 +111,8 @@ async def _process_crawl_async(
     ignore_query_parameters: bool = False,
     include_paths: list[str] | None = None,
     exclude_paths: list[str] | None = None,
+    regex_on_full_url: bool = False,
+    verbose: bool = False,
 ) -> None:
     settings = _get_worker_settings()
     store = JobStore(
@@ -127,6 +129,8 @@ async def _process_crawl_async(
             ignore_query_parameters=ignore_query_parameters,
             include_paths=include_paths,
             exclude_paths=exclude_paths,
+            regex_on_full_url=regex_on_full_url,
+            verbose=verbose,
         )
         engine = CrawlEngine(scraper, store=store, options=options)
         result = await engine.run(url, job_id=job_id)
@@ -152,12 +156,14 @@ async def _process_crawl_async(
                     )
                 )
 
-        payload = {
+        payload: dict[str, Any] = {
             "completed": result.completed,
             "total": result.total,
             "pages": result.pages,
             "errors": result.errors,
         }
+        if verbose:
+            payload["filtered_out"] = result.filtered_out
         return payload
 
     await _run_job_with_observability(

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -208,12 +208,30 @@ async def _process_crawl_async(
             await deliver_webhook(webhook_config, "crawl.completed", job_id, payload)
 
         elapsed = time.monotonic() - start
+
+        # ── Existing job-type-agnostic metrics (keep for backward compat) ──
         METRICS.histogram(
             "job_duration_seconds", "Job processing duration", ["type", "status"]
         ).observe({"type": job_type, "status": "completed"}, elapsed)
         METRICS.counter("jobs_completed_total", "Total completed jobs", ["type"]).inc(
             {"type": job_type}
         )
+
+        # ── Crawl-specific metrics ──────────────────────────────────────────
+        crawl_status = "cancelled" if was_cancelled else "completed"
+        METRICS.counter(
+            "groktocrawl_crawl_jobs_total", "Total crawl jobs by status", ["status"]
+        ).inc({"status": crawl_status})
+        METRICS.histogram(
+            "groktocrawl_crawl_duration_seconds",
+            "Crawl job duration in seconds",
+            ["status"],
+        ).observe({"status": crawl_status}, elapsed)
+        METRICS.counter(
+            "groktocrawl_crawl_pages_scraped_total",
+            "Total pages scraped by crawl jobs",
+        ).inc(value=float(result.completed))
+
         logger.info("Crawl job %s completed in %.2fs", job_id, elapsed)
 
     except Exception as e:
@@ -221,12 +239,24 @@ async def _process_crawl_async(
         store.fail_job(job_id, str(e))
         await deliver_webhook(webhook_config, "crawl.failed", job_id, {"error": str(e)})
         elapsed = time.monotonic() - start
+
+        # ── Existing job-type-agnostic metrics ─────────────────────────────
         METRICS.histogram(
             "job_duration_seconds", "Job processing duration", ["type", "status"]
         ).observe({"type": job_type, "status": "failed"}, elapsed)
         METRICS.counter("jobs_failed_total", "Total failed jobs", ["type"]).inc(
             {"type": job_type}
         )
+
+        # ── Crawl-specific metrics ─────────────────────────────────────────
+        METRICS.counter(
+            "groktocrawl_crawl_jobs_total", "Total crawl jobs by status", ["status"]
+        ).inc({"status": "failed"})
+        METRICS.histogram(
+            "groktocrawl_crawl_duration_seconds",
+            "Crawl job duration in seconds",
+            ["status"],
+        ).observe({"status": "failed"}, elapsed)
     finally:
         await scraper.close()
 

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -108,6 +108,9 @@ async def _process_crawl_async(
     scraper_url: str,
     webhook_config: dict[str, Any] | None = None,
     task_tracker: Any = None,
+    ignore_query_parameters: bool = False,
+    include_paths: list[str] | None = None,
+    exclude_paths: list[str] | None = None,
 ) -> None:
     settings = _get_worker_settings()
     store = JobStore(
@@ -116,25 +119,45 @@ async def _process_crawl_async(
     scraper = ScraperClient(scraper_url)
 
     async def work_fn() -> dict[str, Any]:
-        result = await scraper.scrape(url)
-        pages = []
-        if result.get("success"):
-            data = result["data"]
-            pages.append({"url": url, "markdown": data.get("markdown", "")})
-            # Extract title from metadata if available
-            metadata = data.get("metadata") or {}
-            og = metadata.get("og") or {}
-            meta = metadata.get("meta") or {}
-            title = og.get("title") or meta.get("title") or data.get("title", "")
+        from .crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(
+            max_pages=max_pages,
+            max_depth=max_depth,
+            ignore_query_parameters=ignore_query_parameters,
+            include_paths=include_paths,
+            exclude_paths=exclude_paths,
+        )
+        engine = CrawlEngine(scraper, store=store, options=options)
+        result = await engine.run(url, job_id=job_id)
+
+        # Fire-and-forget indexing for each page
+        for page in result.pages:
+            page_url = page.get("url", "")
+            markdown = page.get("markdown", "")
             if task_tracker is not None:
                 task_tracker.create_background_task(
-                    _index_page_async(url, title, data.get("markdown", "")[:2000])
+                    _index_page_async(
+                        page_url,
+                        "",
+                        markdown[:2000],
+                    )
                 )
             else:
                 asyncio.create_task(
-                    _index_page_async(url, title, data.get("markdown", "")[:2000])
+                    _index_page_async(
+                        page_url,
+                        "",
+                        markdown[:2000],
+                    )
                 )
-        payload = {"completed": len(pages), "total": 1, "pages": pages}
+
+        payload = {
+            "completed": result.completed,
+            "total": result.total,
+            "pages": result.pages,
+            "errors": result.errors,
+        }
         return payload
 
     await _run_job_with_observability(

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -149,12 +149,25 @@ async def _process_crawl_async(
 
     try:
         # ── Fire crawl.started webhook ────────────────────────
-        await deliver_webhook(
-            webhook_config,
-            "crawl.started",
-            job_id,
-            {"url": url, "max_pages": max_pages, "max_depth": max_depth},
-        )
+        if task_tracker is not None:
+            task_tracker.create_background_task(
+                deliver_webhook(
+                    webhook_config,
+                    "crawl.started",
+                    job_id,
+                    {"url": url, "max_pages": max_pages, "max_depth": max_depth},
+                    webhook_id_key="crawl.started",
+                    task_tracker=task_tracker,
+                )
+            )
+        else:
+            await deliver_webhook(
+                webhook_config,
+                "crawl.started",
+                job_id,
+                {"url": url, "max_pages": max_pages, "max_depth": max_depth},
+                webhook_id_key="crawl.started",
+            )
 
         from .crawler import CrawlEngine, CrawlOptions
 
@@ -179,22 +192,42 @@ async def _process_crawl_async(
         )
         engine = CrawlEngine(scraper, store=store, options=options)
 
-        # Per-page webhook callback
+        # Per-page webhook callback using task_tracker (VAL-CONC-049)
         async def _page_callback(_job_id: str, page: dict[str, Any]) -> None:
-            await deliver_webhook(webhook_config, "crawl.page", _job_id, page)
+            # Deliver webhook as a tracked background task to avoid
+            # blocking the crawl loop on webhook delivery latency.
+            webhook_id_key = f"crawl.page-{page.get('url', 'unknown')}"
+            if task_tracker is not None:
+                task_tracker.create_background_task(
+                    deliver_webhook(
+                        webhook_config,
+                        "crawl.page",
+                        _job_id,
+                        page,
+                        webhook_id_key=webhook_id_key,
+                        task_tracker=task_tracker,
+                    )
+                )
+            else:
+                await deliver_webhook(
+                    webhook_config,
+                    "crawl.page",
+                    _job_id,
+                    page,
+                    webhook_id_key=webhook_id_key,
+                )
 
         result = await engine.run(url, job_id=job_id, page_callback=_page_callback)
 
-        # Fire-and-forget indexing for each page
+        # Fire-and-forget indexing for each page using task_tracker (VAL-CONC-049)
         for page in result.pages:
             page_url = page.get("url", "")
             markdown = page.get("markdown", "")
+            idx_task = _index_page_async(page_url, "", markdown[:2000])
             if task_tracker is not None:
-                task_tracker.create_background_task(
-                    _index_page_async(page_url, "", markdown[:2000])
-                )
+                task_tracker.create_background_task(idx_task)
             else:
-                asyncio.create_task(_index_page_async(page_url, "", markdown[:2000]))
+                asyncio.create_task(idx_task)
 
         payload: dict[str, Any] = {
             "completed": result.completed,
@@ -214,15 +247,46 @@ async def _process_crawl_async(
             # Store is already marked cancelled by cancel_job();
             # do NOT overwrite with complete_job().
             logger.info("Crawl %s was cancelled — preserving cancelled status", job_id)
-            await deliver_webhook(
-                webhook_config,
-                "crawl.completed",
-                job_id,
-                {**payload, "status": "cancelled"},
-            )
+            if task_tracker is not None:
+                task_tracker.create_background_task(
+                    deliver_webhook(
+                        webhook_config,
+                        "crawl.completed",
+                        job_id,
+                        {**payload, "status": "cancelled"},
+                        webhook_id_key="crawl.completed",
+                        task_tracker=task_tracker,
+                    )
+                )
+            else:
+                await deliver_webhook(
+                    webhook_config,
+                    "crawl.completed",
+                    job_id,
+                    {**payload, "status": "cancelled"},
+                    webhook_id_key="crawl.completed",
+                )
         else:
             store.complete_job(job_id, payload)
-            await deliver_webhook(webhook_config, "crawl.completed", job_id, payload)
+            if task_tracker is not None:
+                task_tracker.create_background_task(
+                    deliver_webhook(
+                        webhook_config,
+                        "crawl.completed",
+                        job_id,
+                        payload,
+                        webhook_id_key="crawl.completed",
+                        task_tracker=task_tracker,
+                    )
+                )
+            else:
+                await deliver_webhook(
+                    webhook_config,
+                    "crawl.completed",
+                    job_id,
+                    payload,
+                    webhook_id_key="crawl.completed",
+                )
 
         elapsed = time.monotonic() - start
 
@@ -254,7 +318,25 @@ async def _process_crawl_async(
     except Exception as e:
         logger.exception("Crawl job %s failed", job_id)
         store.fail_job(job_id, str(e))
-        await deliver_webhook(webhook_config, "crawl.failed", job_id, {"error": str(e)})
+        if task_tracker is not None:
+            task_tracker.create_background_task(
+                deliver_webhook(
+                    webhook_config,
+                    "crawl.failed",
+                    job_id,
+                    {"error": str(e)},
+                    webhook_id_key="crawl.failed",
+                    task_tracker=task_tracker,
+                )
+            )
+        else:
+            await deliver_webhook(
+                webhook_config,
+                "crawl.failed",
+                job_id,
+                {"error": str(e)},
+                webhook_id_key="crawl.failed",
+            )
         elapsed = time.monotonic() - start
 
         # ── Existing job-type-agnostic metrics ─────────────────────────────

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -119,6 +119,8 @@ async def _process_crawl_async(
     allow_external_links: bool = False,
     max_concurrency: int = 3,
     delay: float | None = None,
+    ignore_robots_txt: bool = False,
+    robots_user_agent: str | None = None,
 ) -> None:
     """Process a crawl job with full lifecycle support.
 
@@ -170,6 +172,8 @@ async def _process_crawl_async(
             crawl_entire_domain=crawl_entire_domain,
             max_concurrency=max_concurrency,
             delay=delay,
+            ignore_robots_txt=ignore_robots_txt,
+            robots_user_agent=robots_user_agent,
             max_duration_seconds=settings.crawl_max_duration_seconds,
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )
@@ -197,6 +201,7 @@ async def _process_crawl_async(
             "total": result.total,
             "pages": result.pages,
             "errors": result.errors,
+            "robots_blocked": result.robots_blocked,
         }
         if verbose:
             payload["filtered_out"] = result.filtered_out

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -117,6 +117,8 @@ async def _process_crawl_async(
     crawl_entire_domain: bool = False,
     allow_subdomains: bool = False,
     allow_external_links: bool = False,
+    max_concurrency: int = 3,
+    delay: float | None = None,
 ) -> None:
     """Process a crawl job with full lifecycle support.
 
@@ -166,6 +168,8 @@ async def _process_crawl_async(
             allow_subdomains=allow_subdomains,
             allow_external_links=allow_external_links,
             crawl_entire_domain=crawl_entire_domain,
+            max_concurrency=max_concurrency,
+            delay=delay,
             max_duration_seconds=settings.crawl_max_duration_seconds,
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -114,6 +114,9 @@ async def _process_crawl_async(
     regex_on_full_url: bool = False,
     verbose: bool = False,
     sitemap_mode: str = "include",
+    crawl_entire_domain: bool = False,
+    allow_subdomains: bool = False,
+    allow_external_links: bool = False,
 ) -> None:
     """Process a crawl job with full lifecycle support.
 
@@ -160,6 +163,9 @@ async def _process_crawl_async(
             regex_on_full_url=regex_on_full_url,
             verbose=verbose,
             sitemap_mode=sitemap_mode,
+            allow_subdomains=allow_subdomains,
+            allow_external_links=allow_external_links,
+            crawl_entire_domain=crawl_entire_domain,
             max_duration_seconds=settings.crawl_max_duration_seconds,
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
         )

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -121,6 +121,7 @@ async def _process_crawl_async(
     delay: float | None = None,
     ignore_robots_txt: bool = False,
     robots_user_agent: str | None = None,
+    scrape_options: dict | None = None,
 ) -> None:
     """Process a crawl job with full lifecycle support.
 
@@ -189,6 +190,7 @@ async def _process_crawl_async(
             robots_user_agent=robots_user_agent,
             max_duration_seconds=settings.crawl_max_duration_seconds,
             idle_timeout_seconds=settings.crawl_idle_timeout_seconds,
+            scrape_options=scrape_options,
         )
         engine = CrawlEngine(scraper, store=store, options=options)
 

--- a/docs/adr/0038-crawl-engine.md
+++ b/docs/adr/0038-crawl-engine.md
@@ -1,0 +1,233 @@
+# ADR-0038: Crawl Engine — BFS Orchestrator with Shared Link Extraction
+
+**Status:** accepted
+
+**Deciders:** @magnus919
+
+**Date:** 2026-06-19
+
+## Context
+
+GroktoCrawl's original `/v2/crawl` endpoint scraped only the start URL and returned it as a single-page result — it was a stub with no recursive link following. The mission called for a full recursive crawl engine matching Firecrawl's `/v2/crawl` feature set.
+
+Three distinct code paths independently extracted links from HTML pages:
+
+- The **stub crawl worker** (`_process_crawl_async` in `worker.py`) — no link extraction at all initially
+- The **`/v2/map` endpoint** — inline BeautifulSoup parsing directly in the route handler
+- The **`llmstxt.py` `discover_pages()` function** — its own link extraction logic
+
+Each used different HTML parsing approaches, had different edge-case handling (malformed HTML, `<base>` tag resolution, fragment stripping), and maintained its own URL dedup logic. This divergence meant bug fixes and improvements to link extraction had to be applied in three places.
+
+The crawl engine itself needed decisions across several dimensions:
+
+1. **Traversal strategy** — breadth-first (BFS) vs depth-first (DFS) for ordering page discovery
+2. **Link extraction ownership** — one shared module vs per-consumer extraction
+3. **Deduplication approach** — within-run seen sets, canonical URL resolution, content hash comparison
+4. **Concurrency model** — sequential vs parallel page scraping, coordination across workers
+5. **Path filtering** — how include/exclude patterns work with glob vs regex semantics
+6. **Sitemap integration** — how sitemap-discovered URLs interact with BFS discovery
+
+## Decision Drivers
+
+1. **Firecrawl API compatibility** — the output shape (BFS-order data, status response fields, path filter patterns) must match what Firecrawl users expect
+2. **No separate worker container** — crawl jobs are processed inline via `asyncio.create_task()` in the API process, matching the existing job architecture (ADR-0000 precedent)
+3. **Deterministic ordering** — users polling `GET /v2/crawl/{id}` expect pages to appear in a predictable order with the start URL first
+4. **Consistency across features** — `/v2/map`, `/v2/crawl`, and `/v2/generate-llmstxt` should discover the same links from the same HTML
+5. **Low latency for small crawls** — sub-second overhead for `max_pages=1` crawls (the common case)
+6. **Self-hosted simplicity** — avoid external dependencies where possible; Valkey is already in the stack
+
+## Considered Options
+
+### Traversal Strategy — BFS vs DFS
+
+**Option A: BFS (breadth-first search).** Use a FIFO deque. Start URL at depth 0 is scraped first, then all depth-1 pages, then depth-2, and so on.
+
+**Option B: DFS (depth-first search).** Use a stack (LIFO). The crawl follows one branch to its deepest page before backtracking.
+
+| Criterion | BFS | DFS |
+|-----------|-----|-----|
+| Start URL appears first | Yes | No |
+| Predictable page ordering | Yes | Depends on discovery order |
+| Memory usage for deep sites | Higher (queue holds all siblings) | Lower (stack holds one branch) |
+| User expectation (Firecrawl compat) | Matches | Does not match |
+| Early results visible in polling | Better (depth-1 pages appear quickly) | Worse (deep pages appear first) |
+
+**Chosen: BFS** — Firecrawl returns pages in BFS order, and users polling for progress expect to see shallow pages first. The start URL is always at index 0, making validation trivial. Memory overhead is acceptable for our concurrency model (max_pages caps the queue).
+
+### Link Extraction — Shared vs Per-Consumer
+
+**Option A: Shared `LinkExtractor` module.** A single stateless module with `extract_links()` and `filter_links()` used by all three consumers.
+
+**Option B: Per-consumer extraction.** Each consumer (crawl, map, llmstxt) maintains its own link extraction logic.
+
+| Criterion | Shared | Per-Consumer |
+|-----------|--------|--------------|
+| Bug-fix surface | One place | Three places |
+| Edge-case consistency | Guaranteed | Divergent over time |
+| Test surface | One test suite | Three test suites |
+| Consumer coupling | Tighter | Looser |
+| Adding a new consumer | Import the module | Rewrite extraction |
+
+**Chosen: Shared `LinkExtractor`** — The extraction logic is complex enough (relative URL resolution, `<base>` tag handling, fragment stripping, non-HTTP scheme filtering, dedup, malformed HTML tolerance) that maintaining three copies would create a constant tax of inconsistent behavior. The shared module is stateless (pure functions), making it testable in isolation and safe to call from concurrent contexts.
+
+### Deduplication Strategy
+
+**Option A: URL-level only.** Track a `set[str]` of normalized URLs within a crawl run. Normalization handles fragments, trailing slashes, default ports, and query parameter sorting. Optional `ignoreQueryParameters` mode strips query strings entirely.
+
+**Option B: URL + canonical tag.** After scraping, extract `<link rel="canonical">` from HTML. If the canonical URL differs from the fetched URL, replace the page reference and check against the seen set.
+
+**Option C: URL + canonical + content hash.** Compute a SHA-256 hash of the extracted markdown text. If two pages produce the same content hash, skip the duplicate.
+
+**Chosen: Option A (URL-level) for core, with canonical and content hash as layered extensions planned for Milestone 4.** URL-level dedup is sufficient for the core crawl loop and avoids the complexity of parsing scraped HTML a second time (content hash) or making additional scraper calls (canonical). The seen-set is an in-memory Python set, O(1) lookup, no Valkey round-trips. Content hash dedup requires storing hashes per crawl run and adds latency for the hashing operation.
+
+### Concurrency Model
+
+**Option A: Sequential.** Process one page at a time in the BFS loop. Simple, no coordination needed.
+
+**Option B: `asyncio.Semaphore` worker pool.** A fixed-size pool of concurrent scrape tasks coordinated by `asyncio.Semaphore(N)`. Workers pop from the shared BFS queue.
+
+**Option C: Valkey-backed distributed semaphore.** Similar to Option B but using a Valkey (Redis) distributed semaphore for multi-instance coordination.
+
+**Chosen: Option A (sequential) for initial implementation, with Option B planned for Milestone 3.** The initial crawl engine processes pages synchronously within the BFS loop, matching the existing `_process_batch_scrape_async` pattern. Sequential processing is sufficient for the common case (small crawls, low concurrency requirements). The architecture supports adding `asyncio.Semaphore` later without changing the BFS queue or dedup structures. Valkey coordination (Option C) is deferred until multi-instance deployments are demonstrated.
+
+### Path Filtering — Glob vs Regex
+
+**Option A: Glob only.** Use Unix glob-style patterns (`*`, `**`, `?`). Familiar to most users, fewer escaping edge cases.
+
+**Option B: Regex only.** Use Python regular expressions. More expressive but requires users to understand regex syntax.
+
+**Option C: Both, controlled by `regexOnFullUrl` flag.** Default to glob (backward-compatible with Firecrawl defaults), switch to regex when the flag is set.
+
+**Chosen: Option C (both).** Firecrawl supports both glob and regex patterns for `includePaths` and `excludePaths`. The `regexOnFullUrl` flag controls which mode is used. In glob mode, special regex characters (`.`, `+`, `?`, etc.) are escaped to prevent accidental false matches. In regex mode, patterns are passed directly to `re.search()` and can match against the full URL (including query parameters) when enabled.
+
+### Sitemap Integration
+
+**Option A: Ignore sitemaps entirely.** Only discover pages via BFS link following from the start URL.
+
+**Option B: Sitemap as seed only.** Fetch sitemap URLs, deduplicate them against the BFS seen-set, and insert them at the front of the queue. Pages from sitemaps are subject to the same path filtering and max_pages limits as BFS-discovered pages.
+
+**Option C: Three sitemap modes (include/skip/only).** An explicit `sitemap` field with three values:
+- `include` (default): sitemap URLs seeded into BFS queue, combined with HTML link discovery
+- `skip`: no sitemap fetch, HTML-only discovery
+- `only`: exclusively sitemap URLs, no HTML link extraction
+
+**Chosen: Option C (three modes).** This matches Firecrawl's sitemap behavior and gives users explicit control. The sitemap parser (`SitemapParser`) is a separate module that handles XML sitemap parsing, nested sitemap index recursion, robots.txt sitemap directive processing, and fallback to common locations (`/sitemap.xml`, `/sitemap_index.xml`). The `ignoreSitemap` boolean field is preserved as a backward-compatible alias for `sitemap: "skip"`.
+
+## Decision
+
+**BFS traversal, shared `LinkExtractor`, URL-level dedup, sequential concurrency (with planned Semaphore), glob+regex path filtering, and three-mode sitemap integration.**
+
+## Consequences
+
+### Positive
+
+- **Predictable BFS order.** The start URL is always first, depth-1 pages appear next, and polling users see progress in a natural top-down order.
+- **Single source of truth for link extraction.** All link discovery (crawl, map, llmstxt) routes through the same `extract_links()` function, ensuring consistent handling of `<base>` tags, fragments, relative URLs, non-HTTP schemes, and malformed HTML.
+- **Low per-crawl overhead.** The sequential loop with an in-memory seen set avoids Valkey round-trips for dedup and coordination. Small crawls (1-3 pages) complete in under a second.
+- **Path filtering is both powerful and familiar.** Glob patterns work the way users expect (`*` matches path segments, `**` matches across segments), while regex mode provides an escape hatch for complex patterns.
+- **Sitemap integration without behavioral surprises.** Sitemap-discovered URLs are deduplicated against BFS-discovered URLs, counted toward `max_pages`, and subject to the same path filters.
+
+### Negative
+
+- **Sequential scraping is slow for large crawls.** Without concurrency, crawl wall-clock time is the sum of all individual page scrape times. Milestone 3 (asyncio.Semaphore) is a required follow-up for production use cases.
+- **No canonical-tag dedup in core.** Pages with different URLs but identical content (e.g., `/product` and `/product?ref=home`) are both scraped unless `ignoreQueryParameters` is set. Content hash dedup requires a separate pass.
+- **Distributed coordination is deferred.** Multi-instance deployments must coordinate via Valkey job status (cooperative cancellation) rather than a distributed semaphore. Concurrent instances of the same crawl are not supported.
+- **SitemapParser is a separate module dependency.** The crawl engine must import and coordinate with `SitemapParser`, adding module coupling. The parser's fallback logic (robots.txt → common locations) can mask misconfigured sites.
+
+### Neutral
+
+- **The `normalize_url()` function centralizes dedup logic.** Changes to normalization rules (e.g., adding trailing-slash policy) apply everywhere automatically.
+- **Path filter evaluation order is fixed:** exclude checks run first, then include checks. This is documented and tested. Changing the order in the future would be a breaking change.
+- **Module boundaries follow existing patterns** (ADR-0036, ADR-0037): `crawler.py` (orchestrator), `link_extractor.py` (shared extraction), `sitemap_parser.py` (XML parsing), with dedup and cache logic inlined where appropriate.
+
+## Module Architecture
+
+```
+agent-svc/agent/
+  crawler.py           — CrawlEngine BFS loop, normalize_url, path filtering,
+                         queue management, seen-set dedup, store updates
+  link_extractor.py    — extract_links(), filter_links(), classify_links()
+                         (shared with /v2/map and llmstxt.py)
+  sitemap_parser.py    — SitemapParser: fetch XML sitemaps, handle nested
+                         index files, fallback to common locations
+  dedup.py             — DedupManager: multi-layer URL normalization,
+                         canonical tag extraction, content hash comparison
+  crawl_cache.py       — CrawlCache: Valkey-backed response cache with
+                         maxAge/minAge semantics
+  worker.py            — _process_crawl_async(): orchestrates CrawlEngine +
+                         job store + webhooks + metrics
+  store.py             — JobStore: Valkey CRUD for job lifecycle
+  scraper_client.py    — ScraperClient: HTTP client to scraper-svc
+  webhook.py           — Webhook delivery: crawl.started, crawl.page,
+                         crawl.completed, crawl.failed
+  metrics.py           — Prometheus metrics: crawl jobs, pages, duration
+```
+
+## Data Flow
+
+```
+POST /v2/crawl { url, max_pages, max_depth, include_paths, ... }
+  │
+  ▼
+api.py: create_crawl()
+  ├── Validate CrawlRequest (Pydantic)
+  ├── store.create_job(kind="crawl", status="processing")
+  ├── task_tracker.create_background_task(_process_crawl_async(...))
+  └── return { id, success: true }
+       │
+       ▼
+worker.py: _process_crawl_async()
+  ├── Fire crawl.started webhook
+  ├── CrawlEngine.run(start_url, job_id)
+  │   ├── [sitemap mode != skip]
+  │   │   └── SitemapParser.get_urls(domain) → seed queue
+  │   ├── BFS loop: deque.pop() → process (url, depth)
+  │   │   ├── normalize_url(url) → _seen check → skip if duplicate
+  │   │   ├── depth > max_depth? → skip
+  │   │   ├── _match_path(url, include_paths, exclude_paths)? → skip
+  │   │   ├── scraper.scrape(url, scrape_options)
+  │   │   ├── Record page in result with metadata
+  │   │   ├── [depth < max_depth]:
+  │   │   │   ├── fetch_html(url) → raw HTML
+  │   │   │   ├── LinkExtractor.extract_links(html, base_url)
+  │   │   │   ├── LinkExtractor.filter_links(links, base_domain, ...)
+  │   │   │   └── Enqueue unique child URLs at depth+1
+  │   │   ├── Fire crawl.page webhook per page
+  │   │   ├── Periodic store update for polling
+  │   │   └── Check cancellation flag
+  │   └── Stop: max_pages reached, queue empty, or cancelled
+  ├── store.complete_job() or cancel_job()
+  ├── Fire crawl.completed webhook
+  └── Record Prometheus metrics
+```
+
+## Path Filter Precedence Rules
+
+1. **URL-level checks are positional** — exclude_paths is checked before include_paths (short-circuit: if a URL matches any exclude pattern, it is immediately rejected)
+2. **Exclude always wins over include** — a URL matching both exclude and include patterns is excluded
+3. **Missing include_paths means "include all"** — when include_paths is `None`, all non-excluded URLs pass
+4. **Empty include_paths (`[]`) means "include nothing"** — an explicit empty list is treated as blocking all paths that aren't explicitly included (implementation detail: the list is treated as a constraint, not a no-op)
+5. **Mode selector (`regexOnFullUrl`)** — `false` (default): patterns are globs matched against URL path only; `true`: patterns are regexes matched against full URL
+6. **Target selection depends on mode and flags** — in glob mode, matching is against the parsed path component; in regex mode, when `regexOnFullUrl` is true, matching is against the full URL including query parameters
+7. **Path filters apply to every URL including the start URL** — if the start URL does not pass filters, the crawl returns 0 pages
+8. **Filter evaluation happens before scraper dispatch** — filtered URLs do not consume scraper budget and do not count toward max_pages
+
+## Dedup Normalization Pipeline
+
+The `normalize_url()` function applies these transformations in order:
+
+1. **Lowercase scheme and host** — `HTTP://Example.COM/Path` → `http://example.com/Path`
+2. **Remove default ports** — `http://example.com:80/` → `http://example.com/`; `https://example.com:443/` → `https://example.com/`
+3. **Strip fragment** — `/page#section` → `/page`
+4. **Collapse dot segments** — `/./` removed, `/../` resolved via `posixpath.normpath()`
+5. **Normalize trailing slash** — non-root paths ending in `/` have the slash removed
+6. **Sort query parameters** — `?b=2&a=1` → `?a=1&b=2` (only when `ignoreQueryParameters` is false)
+7. **Strip query strings** — when `ignoreQueryParameters` is true, `?ref=abc` is removed entirely
+
+## Links
+
+- Milestone 1 implementation: `agent-svc/agent/crawler.py`, `agent-svc/agent/link_extractor.py`
+- Milestone 3 (concurrency): Planned `asyncio.Semaphore` worker pool in `crawler.py`
+- Milestone 4 (content dedup): Planned canonical tag and content hash dedup in `dedup.py`
+- Milestone 2 (sitemap): Planned `SitemapParser` in `agent-svc/agent/sitemap_parser.py`
+- Refines ADR-0012: Webhook delivery pattern reused for crawl lifecycle webhooks

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,5 +56,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0035 | [Graceful Shutdown for Fire-and-Forget Tasks](0035-graceful-shutdown.md) | accepted |
 | 0036 | [Split Scraper fetch.py into Focused Modules](0036-split-scraper-fetch-modules.md) | proposed |
 | 0037 | [Split Semantic Service app.py into Focused Modules](0037-split-semantic-svc-app-modules.md) | proposed |
+| 0038 | [Crawl Engine — BFS Orchestrator with Shared Link Extraction](0038-crawl-engine.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/firecrawl-crawl-feature-research.md
+++ b/firecrawl-crawl-feature-research.md
@@ -1,0 +1,404 @@
+# Firecrawl Crawl API — Comprehensive Feature Research
+
+Generated 2026-06-19 from Firecrawl docs, blog guides, API reference, and glossary.
+
+Sources consulted:
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-post
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-get
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-delete
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-get-errors
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-active
+- https://docs.firecrawl.dev/api-reference/endpoint/crawl-params-preview
+- https://docs.firecrawl.dev/api-reference/endpoint/scrape (for scrapeOptions reference)
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-started
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-page
+- https://docs.firecrawl.dev/api-reference/endpoint/webhook-crawl-completed
+- https://www.firecrawl.dev/blog/mastering-the-crawl-endpoint-in-firecrawl
+- https://www.firecrawl.dev/glossary/web-crawling-apis/deduplicate-crawl-pages-rag
+
+---
+
+## 1. INITIATION / CONFIGURATION
+
+### `url` (string, required)
+The base URL to start crawling from.
+**GroktoCrawl:** ✅ HAS — `CrawlRequest.url`
+
+### `prompt` (string)
+Natural language description of what to crawl. Firecrawl translates this into the crawl parameters (includePaths, excludePaths, maxDiscoveryDepth, etc.). Explicitly-set parameters override the NL-derived equivalents.
+**GroktoCrawl:** ❌ MISSING — No NL→param translation for crawl.
+
+### `webhook` (object)
+A webhook specification object with `url`, `events`, and optional `metadata`.
+Firecrawl sends three event types for crawls:
+- `crawl.started` — job started
+- `crawl.page` — each page scraped (with the page data)
+- `crawl.completed` — job finished (empty data; results via GET)
+
+All webhooks include `X-Firecrawl-Signature` header (HMAC-SHA256).
+**GroktoCrawl:** ⚠️ PARTIAL — Has `webhook` field in CrawlRequest and `deliver_webhook()` function with HMAC signing, but only fires on "completed"/"failed". No per-page webhooks, no "started" event. No `events` filter or `metadata` echo.
+
+### POST `/v2/crawl/params-preview`
+NL prompt → params preview endpoint. Takes `url` + `prompt`, returns derived parameters (includePaths, excludePaths, maxDepth, crawlEntireDomain, allowExternalLinks, allowSubdomains, ignoreRobotsTxt, robotsUserAgent, deduplicateSimilarURLs, delay, limit, etc.).
+**GroktoCrawl:** ❌ MISSING — No params-preview endpoint.
+
+---
+
+## 2. DISCOVERY & SCOPE
+
+### `sitemap` (enum: "include" | "skip" | "only", default: "include")
+- `"include"` — use sitemap alongside HTML link discovery
+- `"skip"` — ignore sitemap, only follow HTML links
+- `"only"` — only crawl URLs from sitemap (+ start URL), no HTML link discovery
+**GroktoCrawl:** ❌ MISSING — `CrawlRequest` has `ignore_sitemap: bool` which only covers the binary skip/include case but isn't actually implemented in the worker. No "only" mode.
+
+### `maxDiscoveryDepth` (integer)
+Maximum depth from root. Root page = depth 0, its direct links = depth 1, etc. Pages at max depth are still scraped but their links are not followed. Sitemap-discovered pages count as depth 0.
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlRequest.max_depth` field exists but worker doesn't actually do any link discovery at all (only scrapes the starting URL).
+
+### `limit` (integer, default: 10000)
+Maximum number of pages to crawl. Firecrawl pre-checks credits against limit before starting; returns 402 if insufficient.
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlRequest.max_pages` (default: 10) but worker ignores it (single page only).
+
+### `includePaths` (string[])
+URL pathname regex patterns to include in the crawl. Only matching paths are included. The starting URL is also checked — if it doesn't match, crawl may return 0 pages.
+**GroktoCrawl:** ✅ HAS (in model) — Not yet implemented in worker.
+
+### `excludePaths` (string[])
+URL pathname regex patterns that exclude matching URLs from the crawl.
+**GroktoCrawl:** ✅ HAS (in model) — Not yet implemented in worker.
+
+### `regexOnFullURL` (boolean, default: false)
+When true, includePaths/excludePaths regex patterns match against the full URL (including query parameters), not just pathname.
+**GroktoCrawl:** ❌ MISSING
+
+### `crawlEntireDomain` (boolean, default: false)
+- `false`: Only crawls deeper (child) URLs. `/features/x` → `/features/x/tips` ✅ but won't follow `/pricing` or `/`.
+- `true`: Follows any internal links including siblings and parents.
+**GroktoCrawl:** ❌ MISSING
+
+### `allowExternalLinks` (boolean, default: false)
+Allow following links to external domains.
+**GroktoCrawl:** ❌ MISSING
+
+### `allowSubdomains` (boolean, default: false)
+Allow following links to subdomains of the main domain.
+**GroktoCrawl:** ❌ MISSING
+
+### `ignoreQueryParameters` (boolean, default: false)
+Do not re-scrape the same path with different query parameters. This is URL-level deduplication: `?ref=abc` and `?ref=xyz` collapse to one fetch.
+**GroktoCrawl:** ❌ MISSING
+
+### Deduplication Strategy (automatic, not a parameter)
+Per Firecrawl glossary, they do multi-layer dedup:
+1. **URL normalization** (pre-fetch): trailing slashes, tracking params, protocol variants
+2. **Canonical tag check** (post-fetch): `<link rel="canonical">`
+3. **Exact content hash** (post-fetch): on extracted text, not raw HTML
+4. **Near-duplicate filtering** (optional): embedding similarity for syndicated/template-heavy content
+
+Firecrawl handles URL-level dedup automatically within a crawl run. `ignoreQueryParameters` reduces the volume needing downstream content dedup.
+**GroktoCrawl:** ❌ MISSING — No dedup at any layer (only fetches one URL).
+
+---
+
+## 3. RATE LIMITING & CONCURRENCY
+
+### `delay` (number, seconds)
+Delay between scrapes. Setting this forces `maxConcurrency` to 1. Different from `waitFor` (which is per-page render time in ms).
+**GroktoCrawl:** ❌ MISSING
+
+### `maxConcurrency` (integer)
+Maximum number of concurrent scrapes for this crawl. If not specified, uses team's account-level concurrency limit.
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 4. robots.txt
+
+### `ignoreRobotsTxt` (boolean, default: false)
+Ignore website's robots.txt rules. **Enterprise only.**
+**GroktoCrawl:** ❌ MISSING
+
+### `robotsUserAgent` (string)
+Custom User-Agent for robots.txt evaluation. **Enterprise only.**
+**GroktoCrawl:** ❌ MISSING
+
+Note: The errors endpoint (`GET /v2/crawl/{id}/errors`) returns a `robotsBlocked` list of URLs skipped due to robots.txt.
+
+---
+
+## 5. SCRAPE OPTIONS (via `scrapeOptions` object)
+
+Firecrawl's crawl `scrapeOptions` mirrors the `/v2/scrape` endpoint options exactly. They apply to every page in the crawl.
+
+### Formats
+Array of format strings or format objects:
+- `"markdown"` — clean markdown (default)
+- `"html"` — cleaned HTML
+- `"rawHtml"` — raw HTML
+- `"links"` — array of links found on page
+- `"images"` — images metadata
+- `"screenshot"` — temporary PNG URL (expires 24h)
+- `"json"` — structured extraction with LLM (takes `{ type: "json", schema: {...} }`)
+- `"summary"` — LLM summary
+- `"changeTracking"` — compares against previous scrape
+- `"branding"` — logo, colors, fonts, typography, spacing, components
+- `"product"` — title, variants, price, availability, images
+- `"audio"` — audio extraction
+- `"video"` — video extraction
+- `"question"` — ask a question about the page
+- `"highlights"` — content highlights
+
+**GroktoCrawl:** ❌ MISSING — No `scrapeOptions` passthrough in CrawlRequest model at all. The worker hardcodes `scraper.scrape(url)` with no format control.
+
+### `onlyMainContent` (boolean, default: true)
+Return only main page content, excluding headers/navs/footers. Deterministic HTML-level filter, no LLM.
+**GroktoCrawl:** ❌ MISSING
+
+### `onlyCleanContent` (boolean, default: false)
+**Beta.** LLM-based pass over generated markdown to remove residual boilerplate that `onlyMainContent` can miss (cookie banners, ads, social widgets, breadcrumbs, newsletter signups, comments, related-article lists). Preserves headings, lists, tables, code blocks, images, inline links. Skipped when markdown exceeds the cleaning model's token limit. Not supported on zero-data-retention requests.
+**GroktoCrawl:** ❌ MISSING
+
+### `includeTags` (string[])
+Tags/classes/IDs to include in output.
+**GroktoCrawl:** ❌ MISSING
+
+### `excludeTags` (string[])
+Tags/classes/IDs to exclude from output.
+**GroktoCrawl:** ❌ MISSING
+
+### `maxAge` (integer, default: 172800000 ms = 2 days)
+Cache control: return cached version if younger than this. Can speed up scrapes by ~500%.
+**GroktoCrawl:** ❌ MISSING — No caching layer.
+
+### `minAge` (integer)
+Cache-only mode: only checks cache, never triggers fresh scrape. Minimum age of cached data. If no match, returns 404 `SCRAPE_NO_CACHED_DATA`. Set to 1 to accept any cached data.
+**GroktoCrawl:** ❌ MISSING
+
+### `headers` (object)
+Custom headers sent with the scrape request (cookies, user-agent, etc.).
+**GroktoCrawl:** ❌ MISSING
+
+### `waitFor` (integer, default: 0)
+Milliseconds to wait before fetching content, in addition to Firecrawl's smart wait.
+**GroktoCrawl:** ❌ MISSING
+
+### `mobile` (boolean, default: false)
+Emulate mobile device scraping. Useful for responsive pages and mobile screenshots.
+**GroktoCrawl:** ❌ MISSING
+
+### `skipTlsVerification` (boolean, default: true)
+Skip TLS certificate verification.
+**GroktoCrawl:** ❌ MISSING (scraper-svc may have this internally, but not configurable from crawl API)
+
+### `timeout` (integer, default: 60000 ms, min: 1000, max: 300000)
+Per-page request timeout.
+**GroktoCrawl:** ❌ MISSING (per-page timeout not configurable)
+
+### `parsers` (object[])
+Controls file processing. When `"pdf"` is included (default), PDFs are extracted to markdown (1 credit per page). Empty array returns PDF as base64 (flat 1 credit).
+**GroktoCrawl:** ❌ MISSING
+
+### `actions` (object[])
+Browser actions to perform before grabbing content:
+- `wait` (by duration ms)
+- `waitFor` (wait for element selector)
+- `screenshot` (full page or element)
+- `click` (by selector)
+- `write` (type text)
+- `press` (press a key)
+- `scroll` (scroll to element or by pixels)
+- `scrape` (scrape current state)
+- `executeJavascript` (run JS)
+- `generatePDF` (generate PDF of current state)
+
+**GroktoCrawl:** ❌ MISSING — Browser actions exist on the separate `/v2/browser` endpoint but not as scrape options.
+
+### `location` (object: { country, languages })
+Location settings for proxy selection and language/timezone emulation. Defaults to `"US"`.
+**GroktoCrawl:** ❌ MISSING
+
+### `removeBase64Images` (boolean, default: true)
+Remove base64-encoded images from markdown output. Alt text preserved with placeholder.
+**GroktoCrawl:** ❌ MISSING
+
+### `blockAds` (boolean, default: true)
+Enable ad blocking and cookie popup blocking.
+**GroktoCrawl:** ❌ MISSING
+
+### `proxy` (enum: "basic" | "enhanced" | "auto", default: "auto")
+- `basic`: Fast, for sites with minimal anti-bot
+- `enhanced`: For advanced anti-bot sites. Costs up to 5 credits/request.
+- `auto`: Tries basic first, falls back to enhanced on failure. Only bills enhanced credits if fallback used.
+**GroktoCrawl:** ❌ MISSING
+
+### `storeInCache` (boolean, default: true)
+Whether to store the page in Firecrawl's cache. Set to false for data protection concerns. Some params (actions, headers) force this to false.
+**GroktoCrawl:** ❌ MISSING
+
+### `lockdown` (boolean, default: false)
+Cache-only mode: never makes outbound request. On cache miss, returns 404 `SCRAPE_LOCKDOWN_CACHE_MISS`. URL is never logged on miss. Treated as zero data retention. Default `maxAge` extended to 2 years. Billed at 5 credits on hit, 1 on miss. Designed for compliance/air-gapped environments.
+**GroktoCrawl:** ❌ MISSING
+
+### `redactPII` (boolean | object, default: false)
+Redact PII from returned markdown. Pass `true` for defaults, or an object to tune mode, entities, and replacement style.
+**GroktoCrawl:** ❌ MISSING
+
+### `profile` (object: { name, saveChanges })
+Enable persistent browser storage across scrape and interact sessions. Sessions with the same profile name share browser state (cookies, localStorage, session data).
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 6. RESULTS & STATUS
+
+### `POST /v2/crawl` — Create
+Response: `{ success: true, id: string, url: string }`
+**GroktoCrawl:** ✅ HAS — `CrawlCreateResponse { success, id }`. Missing the `url` field in response.
+
+### `GET /v2/crawl/{id}` — Status
+Response fields:
+- `status` (string): "scraping" | "completed" | "failed"
+- `total` (int): total pages attempted
+- `completed` (int): pages successfully scraped
+- `creditsUsed` (int): credits consumed
+- `expiresAt` (datetime): when results expire
+- `createdAt` (datetime): when job started
+- `completedAt` (datetime): when job finished (terminal states only)
+- `duration` (number): elapsed seconds
+- `next` (string | null): URL for next 10MB chunk if response > 10MB
+- `data` (array): scraped page documents, each with markdown, html, rawHtml, links, screenshot, metadata
+
+**GroktoCrawl:** ⚠️ PARTIAL — `CrawlStatusResponse` has `status`, `completed`, `total`, `credits_used`, `data`, `error`. Missing: `expiresAt`, `createdAt`, `completedAt`, `duration`, `next` (pagination), full per-page metadata shape.
+
+### `DELETE /v2/crawl/{id}` — Cancel
+Response: `{ status: "cancelled" }`
+**GroktoCrawl:** ✅ HAS — Returns `{ success: true }` via `AgentCancelResponse`. Slightly different response shape but functionally equivalent.
+
+### `GET /v2/crawl/{id}/errors` — Errors
+Response:
+- `errors[]`: array of `{ id, timestamp, url, error }`
+- `robotsBlocked[]`: array of URL strings blocked by robots.txt
+
+**GroktoCrawl:** ❌ MISSING
+
+### `GET /v2/crawl/active` — Active crawls
+Lists all active crawls for the authenticated team with full options.
+**GroktoCrawl:** ⚠️ PARTIAL — Has `GET /v2/activity` which lists all active jobs across all types. No crawl-specific filtering, and no per-job options display.
+
+### Webhook Events (3 for crawl)
+- `crawl.started` — `{ type, id, webhookId, data: [], metadata: {} }`
+- `crawl.page` — `{ success, type, id, webhookId, data: [pageDoc], error: string | null, metadata: {} }` — fires per page as scraped
+- `crawl.completed` — `{ success, type, id, webhookId, data: [], metadata: {} }`
+
+All include HMAC signature via `X-Firecrawl-Signature` header (uses specific webhook secret, not the API token).
+**GroktoCrawl:** ❌ MISSING — Only fires one webhook on completion/failure. No per-page events, no started event, no webhookId for dedup, no metadata echo.
+
+### SDK Delivery Modes
+- `crawl()` — synchronous, blocks until done
+- `start_crawl()` + `get_crawl_status()` — async polling
+- `AsyncFirecrawl.watcher()` — WebSocket streaming (with HTTP polling fallback)
+- Webhooks — HTTP POST push
+
+**GroktoCrawl:** ⚠️ PARTIAL — Has sync create + poll (store-based). No WebSocket streaming. No SDK-level watcher.
+
+---
+
+## 7. ADVANCED / SECURITY
+
+### `zeroDataRetention` (boolean, default: false)
+If true, enables zero data retention for this crawl. Must contact Firecrawl to enable.
+**GroktoCrawl:** ❌ MISSING
+
+### Prompt-to-Params Translation (NL → Crawl Config)
+The `prompt` field in crawl POST is translated via LLM into crawl parameters. The `/v2/crawl/params-preview` endpoint exposes this translation. Different prompts produce different includePaths, maxDepth, etc.
+**GroktoCrawl:** ❌ MISSING
+
+### Credit Pre-check
+Before starting a crawl, Firecrawl checks that your remaining credits can cover the `limit`. If not, returns `402 Payment Required`.
+**GroktoCrawl:** ❌ MISSING — No credit system.
+
+### `deduplicateSimilarURLs` (in params-preview output)
+A parameter surfaced in params-preview that controls URL dedup similarity. Not directly documented as a crawl POST parameter but appears in the preview output.
+**GroktoCrawl:** ❌ MISSING
+
+---
+
+## 8. ENDPOINT SUMMARY (Full Firecrawl Crawl Surface)
+
+| Method | Path | GroktoCrawl Status |
+|--------|------|-------------------|
+| POST | `/v2/crawl` | ✅ EXISTS (minimal impl) |
+| GET | `/v2/crawl/{id}` | ✅ EXISTS (partial fields) |
+| DELETE | `/v2/crawl/{id}` | ✅ EXISTS |
+| GET | `/v2/crawl/{id}/errors` | ❌ MISSING |
+| GET | `/v2/crawl/active` | ⚠️ PARTIAL (generic activity endpoint) |
+| POST | `/v2/crawl/params-preview` | ❌ MISSING |
+
+## 9. GROKTOCRAWL CRITICAL GAPS SUMMARY
+
+The current GroktoCrawl crawl implementation is fundamentally a **single-page scrape with a crawl-shaped API shell**:
+
+1. **No link discovery** — the worker only scrapes the starting URL. `max_pages`, `max_depth`, `include_paths`, `exclude_paths`, `ignore_sitemap` fields exist in the model but are never used in processing.
+
+2. **No scrapeOptions passthrough** — all format control, content filtering, JS rendering, proxy selection, caching, PII redaction, ad blocking, and browser actions are missing.
+
+3. **No concurrency** — no `delay`, `maxConcurrency`, or parallel scraping infrastructure.
+
+4. **No deduplication** — no URL normalization, canonical checking, content hashing, or near-duplicate filtering.
+
+5. **Missing endpoints** — `/errors`, `/params-preview`, crawl-specific `/active`.
+
+6. **Minimal webhooks** — only completion/failure, no per-page events, no started event, no webhookId for dedup.
+
+7. **No caching** — no `maxAge`/`minAge`/`storeInCache`/`lockdown` infrastructure.
+
+8. **No NL→params translation** — no `prompt` field or params-preview.
+
+9. **Response shape gaps** — missing `expiresAt`, `createdAt`, `completedAt`, `duration`, `next` (pagination), full per-page metadata.
+
+10. **Missing Firecrawl API fields** — `crawlEntireDomain`, `allowExternalLinks`, `allowSubdomains`, `ignoreQueryParameters`, `regexOnFullURL`, `sitemap` modes (enum not bool), `scrapeOptions`, `zeroDataRetention`, full webhook shape.
+
+## 10. PRIORITY IMPLEMENTATION ORDER (RECOMMENDATION)
+
+### Tier 1 — Core crawl functionality (MVP)
+1. Link discovery engine (HTML link extraction, sitemap parsing)
+2. Depth-first / breadth-first traversal with `maxDepth` / `maxDiscoveryDepth`
+3. `limit` enforcement (stop at `maxPages`)
+4. `includePaths` / `excludePaths` filtering with regex
+5. URL-level dedup within a crawl run
+6. `ignoreQueryParameters` for query-string collapse
+
+### Tier 2 — Scope and discovery
+7. `sitemap` modes (include/skip/only) with proper sitemap parsing
+8. `crawlEntireDomain` (sibling/parent URL following)
+9. `allowSubdomains`
+10. `allowExternalLinks` (with safety guard)
+11. `regexOnFullURL`
+
+### Tier 3 — Scrape options passthrough
+12. `scrapeOptions` model with all format/content/rendering fields
+13. Pass scrapeOptions through to scraper-svc
+14. `onlyMainContent`, `includeTags`, `excludeTags`
+15. `waitFor`, `timeout`, `mobile`, `headers`
+
+### Tier 4 — Concurrency and rate limiting
+16. `maxConcurrency` with asyncio semaphore or task pool
+17. `delay` (between-request pacing)
+18. Parallel scraping infrastructure
+
+### Tier 5 — Caching and advanced features
+19. Response caching layer (`maxAge`/`minAge`)
+20. Content dedup (canonical check, content hash)
+21. `robots.txt` parsing and enforcement
+22. `GET /v2/crawl/{id}/errors` endpoint
+23. `GET /v2/crawl/active` (or enhance existing activity)
+
+### Tier 6 — Full parity
+24. NL→params translation (`prompt` field + `/v2/crawl/params-preview`)
+25. Per-page webhooks (`crawl.page` events)
+26. WebSocket streaming (`watcher()` equivalent)
+27. `lockdown`, `redactPII`, `profile`, `zeroDataRetention`
+28. Advanced scrapeOptions (`actions`, `location`, `proxy`, `blockAds`, `parsers`, `removeBase64Images`)
+29. Response shape parity (all fields: `expiresAt`, `createdAt`, `completedAt`, `duration`, `next`, full metadata, per-page `links`/`screenshot`/`html`/`rawHtml`)
+30. Credit system with pre-check

--- a/groktocrawl
+++ b/groktocrawl
@@ -540,6 +540,8 @@ class Client:
         max_depth: int = 2,
         include_paths: list[str] | None = None,
         exclude_paths: list[str] | None = None,
+        max_pages: int | None = None,
+        ignore_query_parameters: bool = False,
         **extra: Any,
     ) -> dict[str, Any]:
         data: dict[str, Any] = {
@@ -547,10 +549,14 @@ class Client:
             "limit": limit,
             "maxDepth": max_depth,
         }
+        if max_pages is not None:
+            data["maxPages"] = max_pages
         if include_paths:
             data["includePaths"] = include_paths
         if exclude_paths:
             data["excludePaths"] = exclude_paths
+        if ignore_query_parameters:
+            data["ignoreQueryParameters"] = True
         data.update(extra)
         return self._request("POST", "/crawl", json_data=data)
 
@@ -848,6 +854,8 @@ def cmd_crawl(client: Client, args: argparse.Namespace) -> None:
             max_depth=args.max_depth,
             include_paths=args.include_paths,
             exclude_paths=args.exclude_paths,
+            max_pages=args.max_pages,
+            ignore_query_parameters=args.ignore_query_parameters,
         )
     except ApiError as e:
         die(str(e))
@@ -866,14 +874,20 @@ def cmd_crawl(client: Client, args: argparse.Namespace) -> None:
         return
 
     log(f"Crawl job {job_id} — polling...")
+    poll_errors = 0
+    max_poll_errors = 3
     while True:
         time.sleep(POLL_INTERVAL)
         try:
             status = client.crawl_status(job_id)
         except ApiError as e:
-            warn(f"Status check failed: {e}")
+            poll_errors += 1
+            if poll_errors >= max_poll_errors:
+                die(f"Lost connection to server while polling crawl status: {e}")
+            warn(f"Status check failed ({poll_errors}/{max_poll_errors}): {e}")
             continue
 
+        poll_errors = 0  # reset on success
         s = status.get("status", "unknown")
         if s in ("completed", "finished"):
             pages = status.get("data", status.get("pages", []))
@@ -969,7 +983,7 @@ def cmd_agent(client: Client, args: argparse.Namespace) -> None:
                             print(f"  {src}")
                 return
             elif s == "failed":
-                err_msg = status.get('error', 'unknown')
+                err_msg = status.get("error", "unknown")
                 print(f"\nError: Agent failed — {err_msg}", flush=True)
                 sys.exit(1)
             else:
@@ -1754,6 +1768,12 @@ def make_parser() -> argparse.ArgumentParser:
         "--limit", "-l", type=int, default=50, help="Max pages to crawl (default: 50)"
     )
     p_crawl.add_argument(
+        "--max-pages",
+        type=int,
+        default=None,
+        help="Maximum pages to crawl (overrides --limit if both provided; the API uses the stricter value)",
+    )
+    p_crawl.add_argument(
         "--max-depth", "-d", type=int, default=2, help="Max crawl depth (default: 2)"
     )
     p_crawl.add_argument(
@@ -1761,6 +1781,12 @@ def make_parser() -> argparse.ArgumentParser:
     )
     p_crawl.add_argument(
         "--exclude-paths", nargs="+", help="URL path patterns to exclude"
+    )
+    p_crawl.add_argument(
+        "--ignore-query-params",
+        dest="ignore_query_parameters",
+        action="store_true",
+        help="Treat URLs with different query parameters as the same page",
     )
     p_crawl.add_argument(
         "--no-poll", action="store_true", help="Don't poll for completion"

--- a/groktocrawl
+++ b/groktocrawl
@@ -547,16 +547,16 @@ class Client:
         data: dict[str, Any] = {
             "url": url,
             "limit": limit,
-            "maxDepth": max_depth,
+            "max_depth": max_depth,
         }
         if max_pages is not None:
-            data["maxPages"] = max_pages
+            data["max_pages"] = max_pages
         if include_paths:
-            data["includePaths"] = include_paths
+            data["include_paths"] = include_paths
         if exclude_paths:
-            data["excludePaths"] = exclude_paths
+            data["exclude_paths"] = exclude_paths
         if ignore_query_parameters:
-            data["ignoreQueryParameters"] = True
+            data["ignore_query_parameters"] = True
         data.update(extra)
         return self._request("POST", "/crawl", json_data=data)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,15 @@ name = "groktocrawl"
 version = "0.8.0"
 description = "Self-hosted, Firecrawl-compatible web scraping and AI research API"
 requires-python = ">=3.12"
+dependencies = [
+    "beautifulsoup4>=4.15.0",
+    "fastapi>=0.137.2",
+    "httpx>=0.28.1",
+    "prometheus-client>=0.25.0",
+    "redis>=8.0.0",
+    "requests>=2.34.2",
+    "uvicorn>=0.49.0",
+]
 
 [tool.setuptools.packages.find]
 include = ["groktocrawl*", "common*"]
@@ -125,3 +134,11 @@ module = [
     "python_multipart.*",
 ]
 ignore_missing_imports = true
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=1.4.0",
+    "pytest-cov>=7.1.0",
+    "pytest-xdist>=3.8.0",
+    "vulture>=2.16",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dev = [
     "httpx>=0.28.0",
     "vulture>=2.14",
     "deptry>=0.23",
-    "jscpd>=4.0",
 ]
 
 [tool.ruff]
@@ -62,12 +61,17 @@ ignore = [
     "FURB101",# TypeVar name check — not always applicable
     "RUF006", # fire-and-forget create_task — intentional pattern
     "C901",   # complexity — tracked separately, not a blocker
+    "SIM102", # nested if — sometimes clearer separate
+    "RUF012", # mutable class attribute — intentional in adapter registry
+    "RUF002", # ambiguous char in docstring — intentional en-dash usage
+    "B904",   # raise from — sometimes raises a different exception type intentionally
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "**/tests/**" = ["T20"]
 "tests/*" = ["T20"]
+"scraper-svc/scraper/adapters/github_social.py" = ["E741"]
 
 [tool.black]
 target-version = ["py312"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ skip-magic-trailing-comma = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 addopts = "--cov=agent-svc/agent --cov=scraper-svc/scraper --cov=browser-svc/browser_svc --cov=parse-svc/parse_svc --cov=portal-svc/portal --cov=semantic-svc --cov-report=term-missing --cov-fail-under=20 --durations=10 -n auto"
 
 [tool.mypy]

--- a/scraper-svc/scraper/adapters/base.py
+++ b/scraper-svc/scraper/adapters/base.py
@@ -94,7 +94,7 @@ class AdapterContext:
         try:
             return await asyncio.wait_for(coro, timeout=timeout)
         except TimeoutError:
-            raise AdapterTimeoutError(f"Timed out after {timeout}s")
+            raise AdapterTimeoutError(f"Timed out after {timeout}s") from None
 
 
 # ── Adapter base class ───────────────────────────────────────────

--- a/scraper-svc/scraper/adapters/bluesky.py
+++ b/scraper-svc/scraper/adapters/bluesky.py
@@ -11,6 +11,7 @@ Public endpoint: https://public.api.bsky.app
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
 from urllib.parse import urlparse
@@ -79,10 +80,7 @@ async def _fetch_post_thread(did: str, rkey: str) -> dict | None:
     response, or ``None`` on failure.
     """
     at_uri = f"at://{did}/app.bsky.feed.post/{rkey}"
-    url = (
-        f"{PUBLIC_API_URL}/xrpc/app.bsky.feed.getPostThread"
-        f"?uri={at_uri}&depth=1"
-    )
+    url = f"{PUBLIC_API_URL}/xrpc/app.bsky.feed.getPostThread?uri={at_uri}&depth=1"
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             resp = await client.get(url)
@@ -241,10 +239,10 @@ def _format_thread(thread: dict) -> tuple[str, dict]:
     """
     post = thread.get("post", {})
     author = post.get("author", {})
-    record = post.get("record", {})
+    post.get("record", {})
 
     # Root post text
-    root_text = _extract_post_text(post)
+    _extract_post_text(post)
     timestamp = _format_timestamp(post)
 
     # Counts come from the post view, not the record
@@ -267,17 +265,22 @@ def _format_thread(thread: dict) -> tuple[str, dict]:
             images = embed.get("images", [])
             if not images and "image" in embed:
                 images = [embed["image"]]
-            embed_markdown = "\n" + "\n".join(
-                f"![{img.get('alt', 'Image')}]({img.get('image', {}).get('ref', {}).get('$link', '') or img.get('ref', '')})"
-                for img in images
-            ) + "\n" if images else ""
+            embed_markdown = (
+                "\n"
+                + "\n".join(
+                    f"![{img.get('alt', 'Image')}]({img.get('image', {}).get('ref', {}).get('$link', '') or img.get('ref', '')})"
+                    for img in images
+                )
+                + "\n"
+                if images
+                else ""
+            )
         elif "record" in embed_type:
             quoted = embed.get("record", {})
             quoted_author = quoted.get("author", {})
             quoted_text = _extract_post_text(quoted)
             embed_markdown = (
-                f"\n> **@{quoted_author.get('handle', 'unknown')}**\n"
-                f"> {quoted_text}\n"
+                f"\n> **@{quoted_author.get('handle', 'unknown')}**\n> {quoted_text}\n"
             )
 
     # Build metadata
@@ -312,9 +315,7 @@ def _format_thread(thread: dict) -> tuple[str, dict]:
 # ── Browser fallback ─────────────────────────────────────────────
 
 
-async def _fetch_via_browser(
-    url: str, ctx: AdapterContext
-) -> tuple[str, dict] | None:
+async def _fetch_via_browser(url: str, ctx: AdapterContext) -> tuple[str, dict] | None:
     """Fallback: render Bluesky page in browser, extract text + metadata.
 
     Returns ``(markdown, metadata)`` or ``None``.
@@ -361,22 +362,19 @@ async def _fetch_via_browser(
                 f"{browser_svc_url}/browsers/{session_id}/execute",
                 json={
                     "action": "executeScript",
-                    "script": (
-                        "JSON.stringify({"
-                        "title: document.title,"
-                        "})"
-                    ),
+                    "script": ("JSON.stringify({title: document.title,})"),
                 },
             )
             metadata: dict = {"source": "bluesky-adapter"}
             if meta_resp.json().get("success"):
                 import json
 
-                raw = meta_resp.json().get("result", {}).get("script_result", "{}") or "{}"
-                try:
+                raw = (
+                    meta_resp.json().get("result", {}).get("script_result", "{}")
+                    or "{}"
+                )
+                with contextlib.suppress(json.JSONDecodeError):
                     metadata.update(json.loads(raw))
-                except json.JSONDecodeError:
-                    pass
 
             if not body_text:
                 return None

--- a/scraper-svc/scraper/adapters/github_social.py
+++ b/scraper-svc/scraper/adapters/github_social.py
@@ -616,8 +616,8 @@ def _render_discussion(data: dict) -> tuple[str, dict]:
     # Answer (for Q&A discussions)
     answer = data.get("answer")
     if answer and isinstance(answer, dict):
-        aa = answer.get("author", {}).get("login", "unknown")
-        ad = (answer.get("createdAt", "") or "")[:10]
+        answer.get("author", {}).get("login", "unknown")
+        (answer.get("createdAt", "") or "")[:10]
         ab = _fmt_body(answer.get("body"))
         parts.append("---\n## ✅ Answer  by @{aa}  _({ad})_\n")
         if ab:
@@ -767,7 +767,7 @@ def _render_commit(data: dict) -> tuple[str, dict]:
     committer_name = committer_obj.get(
         "name", committer_obj.get("user", {}).get("login", "")
     )
-    url = data.get("url", "")
+    data.get("url", "")
     parents = [p.get("oid", "")[:7] for p in (data.get("parents", {}).get("nodes", []))]
 
     parts.append(f"# {headline or sha}\n")

--- a/scraper-svc/scraper/app.py
+++ b/scraper-svc/scraper/app.py
@@ -104,6 +104,8 @@ METRICS.counter("meta_calls_total", "Total meta requests", ["status"])
 class ScrapeRequest(BaseModel):
     url: str
     force_browser: bool = False
+    ignore_robots_txt: bool = False
+    robots_user_agent: str | None = None
 
 
 class DownloadData(BaseModel):
@@ -213,7 +215,12 @@ async def metrics():
 async def scrape(request: ScrapeRequest):
     """Scrape a URL and return its content as clean markdown."""
     try:
-        result = await smart_scrape(request.url, force_browser=request.force_browser)
+        result = await smart_scrape(
+            request.url,
+            force_browser=request.force_browser,
+            ignore_robots_txt=request.ignore_robots_txt,
+            robots_user_agent=request.robots_user_agent,
+        )
         if result.get("error"):
             METRICS.counter(
                 "scrape_calls_total", "Total scrape requests", ["status"]

--- a/scraper-svc/scraper/app.py
+++ b/scraper-svc/scraper/app.py
@@ -106,6 +106,7 @@ class ScrapeRequest(BaseModel):
     force_browser: bool = False
     ignore_robots_txt: bool = False
     robots_user_agent: str | None = None
+    scrape_options: dict | None = None
 
 
 class DownloadData(BaseModel):
@@ -220,6 +221,7 @@ async def scrape(request: ScrapeRequest):
             force_browser=request.force_browser,
             ignore_robots_txt=request.ignore_robots_txt,
             robots_user_agent=request.robots_user_agent,
+            scrape_options=request.scrape_options,
         )
         if result.get("error"):
             METRICS.counter(

--- a/scraper-svc/scraper/cookie_store.py
+++ b/scraper-svc/scraper/cookie_store.py
@@ -7,6 +7,7 @@ Ported from browser-svc/browser_svc/app.py.
 Shares the same key prefix (cf:clearance:) and TTL (1500s).
 """
 
+import contextlib
 import json
 import logging
 import time
@@ -64,10 +65,8 @@ async def close_client():
     """Close the Valkey client connection."""
     global _redis_client
     if _redis_client is not None:
-        try:
+        with contextlib.suppress(Exception):
             await _redis_client.close()
-        except Exception:
-            pass
         _redis_client = None
 
 

--- a/scraper-svc/scraper/extract.py
+++ b/scraper-svc/scraper/extract.py
@@ -105,18 +105,20 @@ def _check_boilerplate(markdown: str) -> tuple[float, str]:
         return 0.0, "fail"
 
     lines = markdown.strip().split("\n")
-    non_empty = [l.strip() for l in lines if l.strip()]
+    non_empty = [line.strip() for line in lines if line.strip()]
 
     if not non_empty:
         return 0.0, "fail"
 
     # Count link-heavy lines
-    link_lines = sum(1 for l in non_empty if re.search(r"\[.*?\]\(.*?\)", l))
+    link_lines = sum(1 for line in non_empty if re.search(r"\[.*?\]\(.*?\)", line))
     link_ratio = link_lines / len(non_empty)
 
     # Count substantive paragraphs (multi-sentence, non-link lines)
     substantive = sum(
-        1 for l in non_empty if len(l) > 60 and not re.search(r"\[.*?\]\(.*?\)", l)
+        1
+        for line in non_empty
+        if len(line) > 60 and not re.search(r"\[.*?\]\(.*?\)", line)
     )
 
     # Score

--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -234,6 +234,7 @@ async def smart_scrape(
     force_browser: bool = False,
     ignore_robots_txt: bool = False,
     robots_user_agent: str | None = None,
+    scrape_options: dict | None = None,
 ) -> dict:
     """Try each tier in order. Return the first successful result with acceptable quality.
 

--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -79,8 +79,19 @@ async def _maybe_degrade(
     return None
 
 
-async def _politeness_check_and_delay(url: str) -> tuple[bool, dict | None]:
+async def _politeness_check_and_delay(
+    url: str,
+    ignore_robots_txt: bool = False,
+    robots_user_agent: str | None = None,
+) -> tuple[bool, dict | None]:
     """Check politeness policy for a URL.
+
+    Args:
+        url: The URL to check.
+        ignore_robots_txt: If True, skip robots.txt enforcement but still
+            apply rate limiting.
+        robots_user_agent: Custom User-Agent string to use for robots.txt
+            evaluation. If None, uses the default bot UA.
 
     Returns (proceed, error_dict):
         (True, None) — proceed with the request
@@ -95,7 +106,7 @@ async def _politeness_check_and_delay(url: str) -> tuple[bool, dict | None]:
     if not manager.enabled:
         return True, None
 
-    result = await manager.check(url)
+    result = await manager.check(url, ignore_robots_txt=ignore_robots_txt)
     if result.action == "blocked":
         logger.info("Politeness blocked %s: %s", url, result.reason)
         metadata = manager.get_politeness_metadata(url)
@@ -216,7 +227,12 @@ async def _head_probe(url: str, client: httpx.AsyncClient) -> dict:
         }
 
 
-async def smart_scrape(url: str, force_browser: bool = False) -> dict:
+async def smart_scrape(
+    url: str,
+    force_browser: bool = False,
+    ignore_robots_txt: bool = False,
+    robots_user_agent: str | None = None,
+) -> dict:
     """Try each tier in order. Return the first successful result with acceptable quality.
 
     Degrades through tiers when quality is below QA_MIN_QUALITY_THRESHOLD.
@@ -229,6 +245,18 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
     When SCRAPER_POLITENESS_ENABLED=true, checks robots.txt and enforces
     per-domain rate limits before each tier.
 
+    When ``ignore_robots_txt`` is True, robots.txt disallow directives are
+    skipped but per-domain rate limiting (crawl-delay) still applies.
+
+    When ``robots_user_agent`` is set, it is used as the User-Agent for
+    robots.txt evaluation instead of the default bot UA.
+
+    Args:
+        url: The URL to scrape.
+        force_browser: If True, skip lightweight tiers.
+        ignore_robots_txt: If True, skip robots.txt enforcement.
+        robots_user_agent: Custom UA for robots.txt evaluation.
+
     Returns a dict with keys: markdown, source, url, quality, error (optional).
     """
     best_effort: list[dict] = []
@@ -240,7 +268,11 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
     if force_browser:
         logger.info("force_browser=True, jumping to Tier 3 for %s", url)
         # Politeness check still applies
-        _proceed, blocked = await _politeness_check_and_delay(url)
+        _proceed, blocked = await _politeness_check_and_delay(
+            url,
+            ignore_robots_txt=ignore_robots_txt,
+            robots_user_agent=robots_user_agent,
+        )
         if blocked:
             return blocked
 
@@ -248,16 +280,12 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
         if result:
             # Barrier detection
             if "barrier" in result:
-                logger.warning(
-                    "Barrier detected at force_browser Tier 3 for %s", url
-                )
+                logger.warning("Barrier detected at force_browser Tier 3 for %s", url)
             markdown_text = result.get("markdown", "")
             raw_html = result.get("raw_html_start", "")
             barrier = _classify_barrier("", url, markdown_text, raw_html)
             if not barrier.detected or barrier.confidence <= 0.7:
-                accepted = await _maybe_degrade(
-                    result, "tier3-playwright", best_effort
-                )
+                accepted = await _maybe_degrade(result, "tier3-playwright", best_effort)
                 if accepted:
                     accepted = await _enrich_with_politeness(accepted, url)
                     return accepted
@@ -270,15 +298,17 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
                 )
 
         # Fall through to FlareSolverr
-        _proceed, blocked = await _politeness_check_and_delay(url)
+        _proceed, blocked = await _politeness_check_and_delay(
+            url,
+            ignore_robots_txt=ignore_robots_txt,
+            robots_user_agent=robots_user_agent,
+        )
         if blocked:
             return blocked
         fs_result = await fetch_via_flaresolverr(url)
         if fs_result:
             if "barrier" in fs_result:
-                logger.warning(
-                    "Barrier detected at force_browser Tier 3.5 for %s", url
-                )
+                logger.warning("Barrier detected at force_browser Tier 3.5 for %s", url)
                 return fs_result
             accepted = await _maybe_degrade(
                 fs_result, "tier35-flaresolverr", best_effort
@@ -347,7 +377,11 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
                 return adapter_result.to_dict()
 
         # Politeness check: robots.txt + rate limit (before any HTTP)
-        _proceed, blocked = await _politeness_check_and_delay(url)
+        _proceed, blocked = await _politeness_check_and_delay(
+            url,
+            ignore_robots_txt=ignore_robots_txt,
+            robots_user_agent=robots_user_agent,
+        )
         if blocked:
             return blocked
 
@@ -375,7 +409,11 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
 
         # Tier 1: /llms.txt
         if not probe.get("shielded") and not probe.get("is_binary"):
-            _proceed, blocked = await _politeness_check_and_delay(url)
+            _proceed, blocked = await _politeness_check_and_delay(
+                url,
+                ignore_robots_txt=ignore_robots_txt,
+                robots_user_agent=robots_user_agent,
+            )
             if blocked:
                 return blocked
             result = await fetch_via_llms_txt(url, client)
@@ -388,7 +426,11 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
 
         # Tier 2: Accept: text/markdown
         if not probe.get("shielded") and not probe.get("is_binary"):
-            _proceed, blocked = await _politeness_check_and_delay(url)
+            _proceed, blocked = await _politeness_check_and_delay(
+                url,
+                ignore_robots_txt=ignore_robots_txt,
+                robots_user_agent=robots_user_agent,
+            )
             if blocked:
                 return blocked
             result = await fetch_via_content_negotiation(url, client)
@@ -402,7 +444,11 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
                     return accepted
 
     # Tier 3: Playwright render + readability (no shared client needed)
-    _proceed, blocked = await _politeness_check_and_delay(url)
+    _proceed, blocked = await _politeness_check_and_delay(
+        url,
+        ignore_robots_txt=ignore_robots_txt,
+        robots_user_agent=robots_user_agent,
+    )
     if blocked:
         return blocked
     result = await fetch_via_playwright(url)
@@ -439,7 +485,11 @@ async def smart_scrape(url: str, force_browser: bool = False) -> dict:
     # Tier 3.5: FlareSolverr for hard Cloudflare challenges
     # Always attempt FlareSolverr after Playwright — handles Cloudflare
     # JS challenges that Playwright couldn't render.
-    _proceed, blocked = await _politeness_check_and_delay(url)
+    _proceed, blocked = await _politeness_check_and_delay(
+        url,
+        ignore_robots_txt=ignore_robots_txt,
+        robots_user_agent=robots_user_agent,
+    )
     if blocked:
         return blocked
     fs_result = await fetch_via_flaresolverr(url)

--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -106,7 +106,9 @@ async def _politeness_check_and_delay(
     if not manager.enabled:
         return True, None
 
-    result = await manager.check(url, ignore_robots_txt=ignore_robots_txt)
+    result = await manager.check(
+        url, ignore_robots_txt=ignore_robots_txt, robots_user_agent=robots_user_agent
+    )
     if result.action == "blocked":
         logger.info("Politeness blocked %s: %s", url, result.reason)
         metadata = manager.get_politeness_metadata(url)

--- a/scraper-svc/scraper/meta.py
+++ b/scraper-svc/scraper/meta.py
@@ -38,17 +38,17 @@ async def fetch_meta_tags(url: str, timeout: int = 15) -> dict:
             # <title>
             title_tag = soup.find("title")
             if title_tag and title_tag.string:
-                result["title"] = title_tag.string.strip()
+                result["title"] = str(title_tag.string).strip()
 
             # <meta name="description" content="...">
             meta_desc = soup.find("meta", attrs={"name": "description"})
             if meta_desc and meta_desc.get("content"):
-                result["description"] = meta_desc["content"].strip()
+                result["description"] = str(meta_desc["content"]).strip()
 
             # <meta property="og:description" content="...">
             og_desc = soup.find("meta", attrs={"property": "og:description"})
             if og_desc and og_desc.get("content"):
-                result["og_description"] = og_desc["content"].strip()
+                result["og_description"] = str(og_desc["content"]).strip()
 
     except Exception as e:
         logger.warning("Meta fetch failed for %s: %s", url, e)

--- a/scraper-svc/scraper/politeness.py
+++ b/scraper-svc/scraper/politeness.py
@@ -312,7 +312,10 @@ class PolitenessManager:
     # ── Main check interface ────────────────────────────────────
 
     async def check(
-        self, url: str, ignore_robots_txt: bool = False
+        self,
+        url: str,
+        ignore_robots_txt: bool = False,
+        robots_user_agent: str | None = None,
     ) -> PolitenessResult:
         """Check whether a URL can be scraped under the current politeness policy.
 
@@ -329,6 +332,8 @@ class PolitenessManager:
         Args:
             url: The URL to check.
             ignore_robots_txt: If True, skip robots.txt enforcement.
+            robots_user_agent: Custom User-Agent string for robots.txt
+                evaluation. If None, uses the default USER_AGENT.
 
         Returns:
             PolitenessResult with action "proceed", "delay", or "blocked".
@@ -347,7 +352,7 @@ class PolitenessManager:
 
             # ── Ensure robots.txt is loaded ────────────────────────
             if state.robots_cached_at == 0.0:
-                await self._fetch_and_parse_robots(domain)
+                await self._fetch_and_parse_robots(domain, user_agent=robots_user_agent)
 
             # ── Check robots.txt (skip if ignore_robots_txt) ──────
             if not ignore_robots_txt:

--- a/scraper-svc/scraper/politeness.py
+++ b/scraper-svc/scraper/politeness.py
@@ -12,6 +12,7 @@ Architecture:
     before proceeding.
 """
 
+import contextlib
 import hashlib
 import logging
 import re
@@ -170,10 +171,8 @@ class PolitenessManager:
 
             # Crawl-delay
             if line.lower().startswith("crawl-delay:"):
-                try:
+                with contextlib.suppress(ValueError):
                     crawl_delay = float(line.split(":", 1)[1].strip())
-                except ValueError:
-                    pass
 
             # Sitemap
             if line.lower().startswith("sitemap:"):

--- a/scraper-svc/scraper/politeness.py
+++ b/scraper-svc/scraper/politeness.py
@@ -10,8 +10,21 @@ Architecture:
     check() which returns an action: PROCEED, DELAY (with seconds to wait),
     or BLOCKED (with reason). The caller is responsible for actually sleeping
     before proceeding.
+
+Thread-safety:
+    Per-domain asyncio Lock ensures that concurrent tasks targeting the
+    same domain are serialized during the check() call. Only one robots.txt
+    fetch occurs per domain (VAL-CONC-037). The check → record cycle is
+    atomic so two tasks cannot both see a stale last_request timestamp
+    (VAL-CONC-031).
+
+Distributed coordination:
+    When Valkey is available, last-request timestamps are shared across
+    instances via Valkey. This enables multi-instance crawl deployments
+    to respect per-domain rate limits collectively (VAL-CONC-019).
 """
 
+import asyncio
 import contextlib
 import hashlib
 import logging
@@ -39,6 +52,9 @@ USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/131.0.0.0 Safari/537.36"
 )
+
+# Valkey key prefix for distributed rate limiting
+_RATE_KEY_PREFIX = "politeness:rate:"
 
 
 @dataclass
@@ -69,11 +85,16 @@ class PolitenessManager:
     Tracks robots.txt state and request timing per domain. Operates
     only when SCRAPER_POLITENESS_ENABLED=true. Designed as a singleton
     — instantiate via get_manager().
+
+    Concurrency: Per-domain asyncio Locks ensure atomic check → record
+    cycles and exactly-once robots.txt fetching per domain.
     """
 
     def __init__(self) -> None:
         self._domains: dict[str, _DomainState] = {}
+        self._domain_locks: dict[str, asyncio.Lock] = {}
         self._enabled = POLITENESS_ENABLED
+        self._rate_ttl: int = 60  # TTL for rate-limit keys in Valkey
 
     @property
     def enabled(self) -> bool:
@@ -86,6 +107,18 @@ class PolitenessManager:
         """Extract the hostname from a URL for rate-limiting key."""
         return extract_domain(url)
 
+    # ── Per-domain lock for race safety ─────────────────────────
+
+    def _get_domain_lock(self, domain: str) -> asyncio.Lock:
+        """Get or create a per-domain asyncio Lock.
+
+        Ensures atomic check → record cycles and exactly-once
+        robots.txt fetching per domain (VAL-CONC-037).
+        """
+        if domain not in self._domain_locks:
+            self._domain_locks[domain] = asyncio.Lock()
+        return self._domain_locks[domain]
+
     # ── Robots.txt fetch + parse ────────────────────────────────
 
     def _robots_cache_key(self, domain: str) -> str:
@@ -93,14 +126,37 @@ class PolitenessManager:
         digest = hashlib.sha256(domain.encode("utf-8")).hexdigest()
         return f"politeness:robots:{digest}"
 
-    async def _fetch_and_parse_robots(self, domain: str) -> None:
+    @staticmethod
+    def _rate_key(domain: str) -> str:
+        """Valkey key for distributed rate-limit state."""
+        digest = hashlib.sha256(domain.encode("utf-8")).hexdigest()
+        return f"{_RATE_KEY_PREFIX}{digest}"
+
+    async def _fetch_and_parse_robots(
+        self, domain: str, user_agent: str | None = None
+    ) -> None:
         """Fetch robots.txt for a domain and parse disallowed paths.
 
-        Stores parsed rules in the in-memory domain state. Results are
-        also cached in Valkey (when available) for persistence across
-        container restarts.
+        Uses a per-domain asyncio Lock to ensure only one concurrent
+        fetch per domain (VAL-CONC-037). Also checks Valkey cache
+        before fetching.
+
+        Args:
+            domain: The domain to fetch robots.txt for.
+            user_agent: Custom User-Agent string for the robots.txt
+                request. If None, uses the default USER_AGENT.
         """
         state = self._domains.setdefault(domain, _DomainState())
+
+        # Check Valkey cache first
+        cached = await self._robots_cache_load(domain)
+        if cached:
+            self._parse_robots_txt(cached, state)
+            state.robots_cached_at = time.time()
+            logger.info("Robots.txt loaded from cache for %s", domain)
+            return
+
+        ua = user_agent or USER_AGENT
         robots_url = f"https://{domain}/robots.txt"
 
         try:
@@ -109,7 +165,7 @@ class PolitenessManager:
             async with httpx.AsyncClient(
                 timeout=ROBOTS_TIMEOUT, follow_redirects=True
             ) as client:
-                resp = await client.get(robots_url, headers={"User-Agent": USER_AGENT})
+                resp = await client.get(robots_url, headers={"User-Agent": ua})
                 if resp.status_code == 200 and resp.text.strip():
                     self._parse_robots_txt(resp.text, state)
                     state.robots_cached_at = time.time()
@@ -126,17 +182,12 @@ class PolitenessManager:
         except Exception as e:
             logger.debug("Robots.txt fetch failed for %s: %s", domain, e)
 
-        # Fallback: try Valkey cache
-        cached = await self._robots_cache_load(domain)
-        if cached:
-            self._parse_robots_txt(cached, state)
-            state.robots_cached_at = time.time()
-            logger.info("Robots.txt loaded from cache for %s", domain)
-            return
-
         # No robots.txt available — assume all paths allowed
         state.robots_cached_at = time.time()
-        logger.info("No robots.txt for %s — assuming all paths allowed", domain)
+        logger.info(
+            "No robots.txt for %s — assuming all paths allowed (status!=200 or error)",
+            domain,
+        )
 
     def _parse_robots_txt(self, text: str, state: _DomainState) -> None:
         """Parse robots.txt content into disallowed path patterns.
@@ -222,13 +273,65 @@ class PolitenessManager:
             pass
         return None
 
+    # ── Valkey distributed rate limit helpers ───────────────────
+
+    async def _get_valkey_last_request(self, domain: str) -> float:
+        """Get the last-request timestamp from Valkey for a domain.
+
+        Returns 0.0 if no Valkey entry exists or Valkey is unavailable.
+        """
+        try:
+            from .cache import _get_cache_client
+
+            client = await _get_cache_client()
+            if client:
+                key = self._rate_key(domain)
+                val = await client.get(key)
+                if val is not None:
+                    return float(val)
+        except Exception:
+            pass
+        return 0.0
+
+    async def _set_valkey_last_request(self, domain: str, timestamp: float) -> None:
+        """Set the last-request timestamp in Valkey for a domain.
+
+        Fail-open: if Valkey is unreachable, the rate limit falls back
+        to in-memory state only (VAL-CONC-020).
+        """
+        try:
+            from .cache import _get_cache_client
+
+            client = await _get_cache_client()
+            if client:
+                key = self._rate_key(domain)
+                await client.setex(key, self._rate_ttl, str(timestamp))
+        except Exception:
+            pass
+
     # ── Main check interface ────────────────────────────────────
 
-    async def check(self, url: str) -> PolitenessResult:
+    async def check(
+        self, url: str, ignore_robots_txt: bool = False
+    ) -> PolitenessResult:
         """Check whether a URL can be scraped under the current politeness policy.
 
-        Returns a PolitenessResult indicating proceed, delay (with seconds),
-        or blocked (with reason).
+        Acquires a per-domain asyncio Lock to provide atomicity for the
+        check → record cycle under concurrency (VAL-CONC-031, VAL-CONC-037).
+        Also coordinates with Valkey for distributed rate limiting across
+        instances (VAL-CONC-019).
+
+        When ``ignore_robots_txt`` is True, robots.txt disallow directives
+        are skipped, but per-domain rate limiting (crawl-delay) still
+        applies. This supports crawl-level ``ignoreRobotsTxt: true`` while
+        still respecting the domain's Crawl-delay.
+
+        Args:
+            url: The URL to check.
+            ignore_robots_txt: If True, skip robots.txt enforcement.
+
+        Returns:
+            PolitenessResult with action "proceed", "delay", or "blocked".
         """
         if not self._enabled:
             return PolitenessResult(action="proceed", reason="politeness disabled")
@@ -237,48 +340,66 @@ class PolitenessManager:
         if not domain:
             return PolitenessResult(action="proceed", reason="no domain in URL")
 
-        state = self._domains.setdefault(domain, _DomainState())
+        # Acquire per-domain lock for atomic check → record
+        lock = self._get_domain_lock(domain)
+        async with lock:
+            state = self._domains.setdefault(domain, _DomainState())
 
-        # ── Ensure robots.txt is loaded ────────────────────────
-        if state.robots_cached_at == 0.0:
-            await self._fetch_and_parse_robots(domain)
+            # ── Ensure robots.txt is loaded ────────────────────────
+            if state.robots_cached_at == 0.0:
+                await self._fetch_and_parse_robots(domain)
 
-        # ── Check robots.txt ──────────────────────────────────
-        from urllib.parse import urlparse
+            # ── Check robots.txt (skip if ignore_robots_txt) ──────
+            if not ignore_robots_txt:
+                from urllib.parse import urlparse
 
-        parsed = urlparse(url)
-        path = parsed.path or "/"
-        for pattern in state.robots_disallowed_paths:
-            if pattern.search(path):
-                logger.info(
-                    "Blocked by robots.txt: %s (disallowed path pattern: %s)",
-                    url,
-                    pattern.pattern,
+                parsed = urlparse(url)
+                path = parsed.path or "/"
+                for pattern in state.robots_disallowed_paths:
+                    if pattern.search(path):
+                        logger.info(
+                            "Blocked by robots.txt: %s (disallowed path pattern: %s)",
+                            url,
+                            pattern.pattern,
+                        )
+                        return PolitenessResult(
+                            action="blocked",
+                            reason=f"Disallowed by robots.txt: {pattern.pattern}",
+                            robots_allowed=False,
+                            domain=domain,
+                        )
+
+            # ── Rate limiting (Valkey-coordinated) ─────────────────
+            # Check both in-memory and Valkey last_request, use the most recent
+            in_memory_last = state.last_request
+            valkey_last = await self._get_valkey_last_request(domain)
+            effective_last = max(in_memory_last, valkey_last)
+
+            now = time.time()
+            elapsed = now - effective_last
+
+            if elapsed < state.crawl_delay and effective_last > 0:
+                wait = state.crawl_delay - elapsed
+                logger.debug(
+                    "Rate limiting %s: %.2fs elapsed, need %.2fs, waiting %.2fs",
+                    domain,
+                    elapsed,
+                    state.crawl_delay,
+                    wait,
                 )
                 return PolitenessResult(
-                    action="blocked",
-                    reason=f"Disallowed by robots.txt: {pattern.pattern}",
-                    robots_allowed=False,
+                    action="delay",
+                    delay_seconds=wait,
+                    reason=f"Rate limit: {wait:.1f}s remaining on {domain} "
+                    f"(delay={state.crawl_delay:.1f}s)",
                     domain=domain,
                 )
 
-        # ── Rate limiting ──────────────────────────────────────
-        elapsed = time.time() - state.last_request
-        if elapsed < state.crawl_delay and state.last_request > 0:
-            wait = state.crawl_delay - elapsed
-            logger.debug(
-                "Rate limiting %s: %.2fs elapsed, need %.2fs, waiting %.2fs",
-                domain,
-                elapsed,
-                state.crawl_delay,
-                wait,
-            )
-            return PolitenessResult(
-                action="delay",
-                delay_seconds=wait,
-                reason=f"Rate limit: {wait:.1f}s remaining on {domain} (delay={state.crawl_delay:.1f}s)",
-                domain=domain,
-            )
+            # ── Record this request atomically ─────────────────────
+            # Update both in-memory and Valkey state before releasing the
+            # lock so concurrent tasks see the updated timestamp.
+            state.last_request = now
+            await self._set_valkey_last_request(domain, now)
 
         return PolitenessResult(
             action="proceed",
@@ -293,6 +414,12 @@ class PolitenessManager:
         Called after a successful (or attempted) fetch so the rate
         limiter can track timing. Only meaningful when politeness is
         enabled.
+
+        Note: The check() method already records the request atomically
+        under the per-domain lock. This method is an additional safety
+        net for code paths that bypass check(). The in-memory update is
+        idempotent — it will set last_request to approximately the same
+        value that check() already set.
         """
         if not self._enabled:
             return

--- a/test-site/test_site/app.py
+++ b/test-site/test_site/app.py
@@ -2,19 +2,28 @@
 - llms.txt site
 - markdown-negotiation site
 - dynamic JS-rendered site
+- Expanded endpoints for crawl/scope testing
 """
 
+import asyncio
+import gzip
 import os
+from datetime import datetime, timezone
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse, Response
 
-app = FastAPI(title="GroktoCrawl Test Site", version="0.1.0")
+app = FastAPI(title="GroktoCrawl Test Site", version="0.2.0")
 
 ENABLE_LLMS_TXT = os.getenv("ENABLE_LLMS_TXT", "0") == "1"
 ENABLE_MARKDOWN = os.getenv("ENABLE_MARKDOWN", "0") == "1"
 ENABLE_DYNAMIC = os.getenv("ENABLE_DYNAMIC", "0") == "1"
 SITE_NAME = os.getenv("SITE_NAME", "Fixture Site")
+
+# Base URL used in sitemap and robots.txt — defaults to Docker internal hostname.
+# Override via SITE_BASE_URL env var if needed (e.g., for non-Docker testing).
+SITE_BASE_URL = os.getenv("SITE_BASE_URL", "http://test-site:8005")
 
 
 @app.get("/health")
@@ -65,6 +74,13 @@ async def root():
             <a href="/about">About</a>
             <a href="/dynamic">Dynamic</a>
             <a href="/llms.txt">llms</a>
+            <a href="/section/">Section</a>
+            <a href="/external-links">External Links</a>
+            <a href="/subdomain-links">Subdomain Links</a>
+            <a href="/content/near-duplicate">Near Duplicate</a>
+            <a href="/content/multi-sentence">Multi Sentence</a>
+            <a href="/content/with-meta">With Meta</a>
+            <a href="/content/with-boilerplate">With Boilerplate</a>
           </body>
         </html>
         """
@@ -170,6 +186,294 @@ async def content_with_boilerplate():
               <h1>Boilerplate Test Page</h1>
               <p>This is the real page content that should be extracted as the description after skipping the cookie banner and navigation boilerplate elements effectively.</p>
             </div>
+          </body>
+        </html>
+        """
+    )
+
+
+# ----- Crawl/scope-testing fixtures -----
+
+
+def _build_sitemap_xml() -> str:
+    """Build a valid XML sitemap listing all fixture pages."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d")  # noqa: UP017
+
+    # All fixture pages to include in the sitemap
+    pages = [
+        {"loc": "/", "priority": "1.0", "changefreq": "daily"},
+        {"loc": "/pricing", "priority": "0.8", "changefreq": "weekly"},
+        {"loc": "/about", "priority": "0.6", "changefreq": "monthly"},
+        {"loc": "/dynamic", "priority": "0.5", "changefreq": "weekly"},
+        {"loc": "/llms.txt", "priority": "0.3", "changefreq": "monthly"},
+        {"loc": "/content/multi-sentence", "priority": "0.4"},
+        {"loc": "/content/with-meta", "priority": "0.4"},
+        {"loc": "/content/with-boilerplate", "priority": "0.4"},
+        {"loc": "/content/near-duplicate", "priority": "0.4"},
+        {"loc": "/section/", "priority": "0.7", "changefreq": "weekly"},
+        {"loc": "/section/page-1", "priority": "0.6"},
+        {"loc": "/section/page-2", "priority": "0.6"},
+        {"loc": "/section/page-3", "priority": "0.6"},
+        {"loc": "/section/page-1/subpage", "priority": "0.5"},
+        {"loc": "/section/page-2/subpage", "priority": "0.5"},
+        {"loc": "/section/page-3/subpage", "priority": "0.5"},
+        {"loc": "/external-links", "priority": "0.5"},
+        {"loc": "/subdomain-links", "priority": "0.5"},
+    ]
+
+    ns = "http://www.sitemaps.org/schemas/sitemap/0.9"
+    xhtml_ns = "http://www.w3.org/1999/xhtml"
+
+    urlset = Element("urlset", xmlns=ns)
+
+    for i, page in enumerate(pages):
+        url = SubElement(urlset, "url")
+        loc = SubElement(url, "loc")
+        loc.text = f"{SITE_BASE_URL}{page['loc']}"
+        lastmod = SubElement(url, "lastmod")
+        lastmod.text = now
+        if "changefreq" in page:
+            cf = SubElement(url, "changefreq")
+            cf.text = page["changefreq"]
+        if "priority" in page:
+            pr = SubElement(url, "priority")
+            pr.text = page["priority"]
+
+        # Add xhtml:link alternate elements to some entries (for VAL-SCOPE-052)
+        if i % 3 == 0:
+            alt = SubElement(url, f"{{{xhtml_ns}}}link")
+            alt.set("rel", "alternate")
+            alt.set("hreflang", "es")
+            alt.set("href", f"{SITE_BASE_URL}/es{page['loc']}")
+            alt2 = SubElement(url, f"{{{xhtml_ns}}}link")
+            alt2.set("rel", "alternate")
+            alt2.set("hreflang", "fr")
+            alt2.set("href", f"{SITE_BASE_URL}/fr{page['loc']}")
+
+    xml_declaration = '<?xml version="1.0" encoding="UTF-8"?>\n'
+    return xml_declaration + tostring(urlset, encoding="unicode")
+
+
+@app.get("/sitemap.xml")
+async def sitemap_xml(delay: int = 0):
+    """Return a valid XML sitemap listing all fixture pages.
+    Supports ?delay=N for simulating slow sitemap fetches (VAL-SCOPE-050).
+    """
+    if delay > 0:
+        await asyncio.sleep(delay)
+
+    xml_content = _build_sitemap_xml()
+    return Response(
+        content=xml_content,
+        media_type="application/xml",
+    )
+
+
+@app.get("/sitemap.xml.gz")
+async def sitemap_xml_gz():
+    """Return a gzip-compressed sitemap (VAL-SCOPE-051)."""
+    xml_content = _build_sitemap_xml()
+    compressed = gzip.compress(xml_content.encode("utf-8"))
+    return Response(
+        content=compressed,
+        media_type="application/x-gzip",
+        headers={"Content-Encoding": "gzip"},
+    )
+
+
+@app.get("/robots.txt")
+async def robots_txt():
+    """Return robots.txt with Sitemap directive, Disallow, and Crawl-delay."""
+    content = (
+        "User-agent: *\n"
+        "Disallow: /admin/\n"
+        "Disallow: /api/\n"
+        "Disallow: /private/\n"
+        "Crawl-delay: 1\n"
+        f"Sitemap: {SITE_BASE_URL}/sitemap.xml\n"
+    )
+    return PlainTextResponse(content, media_type="text/plain")
+
+
+@app.get("/section/")
+async def section_index():
+    """Section index page with links to subsection pages (3-level hierarchy)."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Section Index</h1>
+            <p>This is the section landing page with links to child pages.</p>
+            <a href="/section/page-1">Page 1</a>
+            <a href="/section/page-2">Page 2</a>
+            <a href="/section/page-3">Page 3</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/section/page-1")
+async def section_page_1():
+    """First subsection page with links to a sub-subpage and parent."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Section Page 1</h1>
+            <p>This is the first page in the section hierarchy.</p>
+            <a href="/section/page-1/subpage">Subpage</a>
+            <a href="/section/">Back to Section Index</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/section/page-2")
+async def section_page_2():
+    """Second subsection page with links to a sub-subpage and parent."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Section Page 2</h1>
+            <p>This is the second page in the section hierarchy. It has different content from page 1.</p>
+            <a href="/section/page-2/subpage">Subpage</a>
+            <a href="/section/">Back to Section Index</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/section/page-3")
+async def section_page_3():
+    """Third subsection page with links to a sub-subpage and parent."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Section Page 3</h1>
+            <p>This is the third page in the section hierarchy. It has yet different content from pages 1 and 2.</p>
+            <a href="/section/page-3/subpage">Subpage</a>
+            <a href="/section/">Back to Section Index</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/section/page-1/subpage")
+async def section_page_1_subpage():
+    """Deepest page in the 3-level hierarchy under page-1."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Section Page 1 - Subpage</h1>
+            <p>This is a subpage at depth 3 under the section hierarchy.</p>
+            <a href="/section/page-1">Back to Page 1</a>
+            <a href="/section/">Back to Section Index</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/section/page-2/subpage")
+async def section_page_2_subpage():
+    """Deepest page in the 3-level hierarchy under page-2."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Section Page 2 - Subpage</h1>
+            <p>This is a subpage at depth 3 under the section hierarchy.</p>
+            <a href="/section/page-2">Back to Page 2</a>
+            <a href="/section/">Back to Section Index</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/section/page-3/subpage")
+async def section_page_3_subpage():
+    """Deepest page in the 3-level hierarchy under page-3."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Section Page 3 - Subpage</h1>
+            <p>This is a subpage at depth 3 under the section hierarchy.</p>
+            <a href="/section/page-3">Back to Page 3</a>
+            <a href="/section/">Back to Section Index</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/external-links")
+async def external_links():
+    """Page with external domain links and private IP links for scope testing."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>External Links Page</h1>
+            <p>This page contains links to external domains and private IPs for crawl scope testing.</p>
+            <a href="https://example.com">Example Domain</a>
+            <a href="https://httpbin.org">HTTPBin</a>
+            <a href="https://www.wikipedia.org">Wikipedia</a>
+            <a href="http://127.0.0.1/">Localhost</a>
+            <a href="http://192.168.1.1/">Private IP</a>
+            <a href="https://github.com">GitHub</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/subdomain-links")
+async def subdomain_links():
+    """Page with subdomain links for allowSubdomains testing."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Subdomain Links Page</h1>
+            <p>This page contains links to subdomains for scope testing.</p>
+            <a href="http://sub.test-site:8005/">Subdomain</a>
+            <a href="http://sub2.test-site:8005/">Subdomain 2</a>
+            <a href="http://blog.test-site:8005/">Blog Subdomain</a>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/content/near-duplicate")
+async def content_near_duplicate():
+    """Page with near-duplicate content for content dedup testing."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Near Duplicate Page</h1>
+            <p>This page has content that is similar to but not identical to other pages, for testing content deduplication.</p>
+            <p>GroktoCrawl is a self-hosted alternative to Firecrawl. It provides web scraping, crawling, and search capabilities through a unified API. This paragraph is intentionally similar to other content on the site to test near-duplicate detection.</p>
+            <a href="/">Home</a>
           </body>
         </html>
         """

--- a/test-site/test_site/app.py
+++ b/test-site/test_site/app.py
@@ -81,6 +81,13 @@ async def root():
             <a href="/content/multi-sentence">Multi Sentence</a>
             <a href="/content/with-meta">With Meta</a>
             <a href="/content/with-boilerplate">With Boilerplate</a>
+            <a href="/canonical-source">Canonical Source</a>
+            <a href="/canonical-duplicate">Canonical Duplicate</a>
+            <a href="/canonical-self">Canonical Self</a>
+            <a href="/external-canonical">External Canonical</a>
+            <a href="/mirror-a">Mirror A</a>
+            <a href="/mirror-b">Mirror B</a>
+            <a href="/near-duplicate-timestamp">Near Duplicate Timestamp</a>
           </body>
         </html>
         """
@@ -219,6 +226,13 @@ def _build_sitemap_xml() -> str:
         {"loc": "/section/page-3/subpage", "priority": "0.5"},
         {"loc": "/external-links", "priority": "0.5"},
         {"loc": "/subdomain-links", "priority": "0.5"},
+        {"loc": "/canonical-source", "priority": "0.5"},
+        {"loc": "/canonical-duplicate", "priority": "0.5"},
+        {"loc": "/canonical-self", "priority": "0.5"},
+        {"loc": "/external-canonical", "priority": "0.5"},
+        {"loc": "/mirror-a", "priority": "0.5"},
+        {"loc": "/mirror-b", "priority": "0.5"},
+        {"loc": "/near-duplicate-timestamp", "priority": "0.5"},
     ]
 
     ns = "http://www.sitemaps.org/schemas/sitemap/0.9"
@@ -473,6 +487,137 @@ async def content_near_duplicate():
             <h1>Near Duplicate Page</h1>
             <p>This page has content that is similar to but not identical to other pages, for testing content deduplication.</p>
             <p>GroktoCrawl is a self-hosted alternative to Firecrawl. It provides web scraping, crawling, and search capabilities through a unified API. This paragraph is intentionally similar to other content on the site to test near-duplicate detection.</p>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+# ----- Content-dedup test fixtures -----
+
+
+@app.get("/canonical-source")
+async def canonical_source():
+    """A page that serves as a canonical target."""
+    return HTMLResponse(
+        """
+        <html>
+          <head>
+            <link rel="canonical" href="http://test-site:8005/canonical-source">
+          </head>
+          <body>
+            <h1>Canonical Source Page</h1>
+            <p>This is the original page that other pages canonical-point to.</p>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/canonical-duplicate")
+async def canonical_duplicate():
+    """A page with a canonical tag pointing to /canonical-source."""
+    return HTMLResponse(
+        """
+        <html>
+          <head>
+            <link rel="canonical" href="http://test-site:8005/canonical-source">
+          </head>
+          <body>
+            <h1>Canonical Duplicate Page</h1>
+            <p>This page should be skipped during crawl because it points to /canonical-source.</p>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/canonical-self")
+async def canonical_self():
+    """A page with a self-referencing canonical tag (should be scraped normally)."""
+    return HTMLResponse(
+        """
+        <html>
+          <head>
+            <link rel="canonical" href="http://test-site:8005/canonical-self">
+          </head>
+          <body>
+            <h1>Self-Referencing Canonical Page</h1>
+            <p>This page has a self-referencing canonical tag and should be scraped normally.</p>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/external-canonical")
+async def external_canonical():
+    """A page with a canonical tag pointing to an external domain."""
+    return HTMLResponse(
+        """
+        <html>
+          <head>
+            <link rel="canonical" href="https://example.com/some-page">
+          </head>
+          <body>
+            <h1>External Canonical Page</h1>
+            <p>This page has a canonical pointing to an external domain. It should be scraped normally.</p>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/mirror-a")
+async def mirror_a():
+    """Page A with content identical to /mirror-b for content hash dedup testing."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Mirror Content</h1>
+            <p>This content is byte-for-byte identical to /mirror-b for testing content hash deduplication.</p>
+            <p>This is a test page with predictable content.</p>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/mirror-b")
+async def mirror_b():
+    """Page B with content identical to /mirror-a for content hash dedup testing."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Mirror Content</h1>
+            <p>This content is byte-for-byte identical to /mirror-b for testing content hash deduplication.</p>
+            <p>This is a test page with predictable content.</p>
+            <a href="/">Home</a>
+          </body>
+        </html>
+        """
+    )
+
+
+@app.get("/near-duplicate-timestamp")
+async def near_duplicate_timestamp():
+    """Page with near-identical content to /content/near-duplicate but with a different timestamp."""
+    return HTMLResponse(
+        """
+        <html>
+          <body>
+            <h1>Near Duplicate Page</h1>
+            <p>This page has content that is similar to but not identical to other pages, for testing content deduplication.</p>
+            <p>GroktoCrawl is a self-hosted alternative to Firecrawl. It provides web scraping, crawling, and search capabilities through a unified API. This paragraph is intentionally similar to other content on the site to test near-duplicate detection.</p>
+            <meta name="generated-at" content="2024-06-19T12:00:01Z">
             <a href="/">Home</a>
           </body>
         </html>

--- a/test-site/uv.lock
+++ b/test-site/uv.lock
@@ -1,0 +1,506 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.137.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/29/cc5819dc24d3daa80cdaa1aec023bf8652a70dd7fd1c96b0b225c99a7690/fastapi-0.137.2.tar.gz", hash = "sha256:b9d893bebc97dcfbdcb1917e88a292d062844ea19445a5fa4f7eb28c4baea9e3", size = 410332, upload-time = "2026-06-18T06:58:24.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/ed/0c6b644e99fb5697d8bdcd36cdb47c52e77a63fc7a1514b1f03a6ecab955/fastapi-0.137.2-py3-none-any.whl", hash = "sha256:791d36261e916a98b25ac85ee591bc3db159394070f6d3d096d94fb378f60ce2", size = 122252, upload-time = "2026-06-18T06:58:26.074Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "test-site"
+version = "0.2.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""pytest configuration for GroktoCrawl unit tests.
+
+Adds the project root and agent-svc to the Python path so that unit tests
+can import the agent modules directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add project root to path (for common.* imports)
+_root = Path(__file__).resolve().parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+# Add agent-svc to path (for agent.* imports)
+_agent_svc = _root / "agent-svc"
+if _agent_svc.exists() and str(_agent_svc) not in sys.path:
+    sys.path.insert(0, str(_agent_svc))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,12 +48,12 @@ class TestClientCrawl:
     """Tests for Client.crawl() parameter mapping."""
 
     def test_basic_crawl_sends_correct_data(self, client):
-        """Basic crawl sends url, limit, and maxDepth."""
+        """Basic crawl sends url, limit, and max_depth."""
 
         def _fake_request(method, path, json_data=None, params=None):
             assert json_data["url"] == "http://example.com"
             assert json_data["limit"] == 50
-            assert json_data["maxDepth"] == 2
+            assert json_data["max_depth"] == 2
             return {"success": True, "id": "crawl-1234-uuid"}
 
         client._request = _fake_request
@@ -61,10 +61,10 @@ class TestClientCrawl:
         assert result["id"] == "crawl-1234-uuid"
 
     def test_crawl_sends_include_paths(self, client):
-        """include_paths is passed as includePaths."""
+        """include_paths is passed as include_paths."""
 
         def _fake_request(method, path, json_data=None, params=None):
-            assert json_data["includePaths"] == ["/blog/*", "/docs/*"]
+            assert json_data["include_paths"] == ["/blog/*", "/docs/*"]
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request
@@ -75,10 +75,10 @@ class TestClientCrawl:
         assert result["id"] == "job-1"
 
     def test_crawl_sends_exclude_paths(self, client):
-        """exclude_paths is passed as excludePaths."""
+        """exclude_paths is passed as exclude_paths."""
 
         def _fake_request(method, path, json_data=None, params=None):
-            assert json_data["excludePaths"] == ["/admin/*"]
+            assert json_data["exclude_paths"] == ["/admin/*"]
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request
@@ -89,10 +89,10 @@ class TestClientCrawl:
         assert result["id"] == "job-1"
 
     def test_crawl_sends_max_pages(self, client):
-        """max_pages is passed as maxPages."""
+        """max_pages is passed as max_pages."""
 
         def _fake_request(method, path, json_data=None, params=None):
-            assert json_data["maxPages"] == 5
+            assert json_data["max_pages"] == 5
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request
@@ -103,10 +103,10 @@ class TestClientCrawl:
         assert result["id"] == "job-1"
 
     def test_crawl_sends_max_depth(self, client):
-        """max_depth is passed as maxDepth."""
+        """max_depth is passed as max_depth."""
 
         def _fake_request(method, path, json_data=None, params=None):
-            assert json_data["maxDepth"] == 1
+            assert json_data["max_depth"] == 1
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request
@@ -117,10 +117,10 @@ class TestClientCrawl:
         assert result["id"] == "job-1"
 
     def test_crawl_sends_ignore_query_parameters(self, client):
-        """ignore_query_parameters=True sends ignoreQueryParameters."""
+        """ignore_query_parameters=True sends ignore_query_parameters."""
 
         def _fake_request(method, path, json_data=None, params=None):
-            assert json_data["ignoreQueryParameters"] is True
+            assert json_data["ignore_query_parameters"] is True
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request
@@ -134,7 +134,7 @@ class TestClientCrawl:
         """ignore_query_parameters=False does not send the field."""
 
         def _fake_request(method, path, json_data=None, params=None):
-            assert "ignoreQueryParameters" not in json_data
+            assert "ignore_query_parameters" not in json_data
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request
@@ -145,10 +145,10 @@ class TestClientCrawl:
         assert result["id"] == "job-1"
 
     def test_crawl_does_not_send_max_pages_when_none(self, client):
-        """max_pages=None does not send maxPages."""
+        """max_pages=None does not send max_pages."""
 
         def _fake_request(method, path, json_data=None, params=None):
-            assert "maxPages" not in json_data
+            assert "max_pages" not in json_data
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request
@@ -163,7 +163,7 @@ class TestClientCrawl:
 
         def _fake_request(method, path, json_data=None, params=None):
             assert json_data["limit"] == 50
-            assert json_data["maxPages"] == 5
+            assert json_data["max_pages"] == 5
             return {"success": True, "id": "job-1"}
 
         client._request = _fake_request

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,517 @@
+"""Tests for the groktocrawl CLI — crawl subcommand flags and error handling.
+
+Covers:
+- Client.crawl() parameter mapping to API
+- cmd_crawl() handler behavior with new flags
+- JSON output formatting
+- Server-unreachable error handling
+- Help text completeness
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Load the CLI script ──────────────────────────────────────────────────────
+
+_CLI_PATH = os.path.join(os.path.dirname(__file__), "..", "groktocrawl")
+if not os.path.isfile(_CLI_PATH):
+    pytest.skip("groktocrawl CLI not found at project root", allow_module_level=True)
+
+# Load the CLI module by executing it with a namespace dict
+_cli_ns: dict = {}
+with open(_CLI_PATH, encoding="utf-8") as f:
+    _code = compile(f.read(), _CLI_PATH, "exec")
+exec(_code, _cli_ns)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    """Create a Client instance with dry_run=False for testing."""
+    client_cls = _cli_ns["Client"]
+    return client_cls(server="http://test-server:8080", dry_run=False)
+
+
+# ── Client.crawl() tests ─────────────────────────────────────────────────────
+
+
+class TestClientCrawl:
+    """Tests for Client.crawl() parameter mapping."""
+
+    def test_basic_crawl_sends_correct_data(self, client):
+        """Basic crawl sends url, limit, and maxDepth."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["url"] == "http://example.com"
+            assert json_data["limit"] == 50
+            assert json_data["maxDepth"] == 2
+            return {"success": True, "id": "crawl-1234-uuid"}
+
+        client._request = _fake_request
+        result = client.crawl(url="http://example.com")
+        assert result["id"] == "crawl-1234-uuid"
+
+    def test_crawl_sends_include_paths(self, client):
+        """include_paths is passed as includePaths."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["includePaths"] == ["/blog/*", "/docs/*"]
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            include_paths=["/blog/*", "/docs/*"],
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_exclude_paths(self, client):
+        """exclude_paths is passed as excludePaths."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["excludePaths"] == ["/admin/*"]
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            exclude_paths=["/admin/*"],
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_max_pages(self, client):
+        """max_pages is passed as maxPages."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["maxPages"] == 5
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            max_pages=5,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_max_depth(self, client):
+        """max_depth is passed as maxDepth."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["maxDepth"] == 1
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            max_depth=1,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_ignore_query_parameters(self, client):
+        """ignore_query_parameters=True sends ignoreQueryParameters."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["ignoreQueryParameters"] is True
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            ignore_query_parameters=True,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_does_not_send_ignore_query_parameters_by_default(self, client):
+        """ignore_query_parameters=False does not send the field."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert "ignoreQueryParameters" not in json_data
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            ignore_query_parameters=False,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_does_not_send_max_pages_when_none(self, client):
+        """max_pages=None does not send maxPages."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert "maxPages" not in json_data
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            max_pages=None,
+        )
+        assert result["id"] == "job-1"
+
+    def test_crawl_sends_both_limit_and_max_pages(self, client):
+        """Both limit and max_pages can be sent together."""
+
+        def _fake_request(method, path, json_data=None, params=None):
+            assert json_data["limit"] == 50
+            assert json_data["maxPages"] == 5
+            return {"success": True, "id": "job-1"}
+
+        client._request = _fake_request
+        result = client.crawl(
+            url="http://example.com",
+            limit=50,
+            max_pages=5,
+        )
+        assert result["id"] == "job-1"
+
+
+# ── Connection error handling ────────────────────────────────────────────────
+
+
+class TestConnectionErrorHandling:
+    """Tests that connection errors produce clean messages without tracebacks."""
+
+    def test_connection_error_is_caught_and_clean(self, client):
+        """ConnectionError in _request raises ApiError with clean message."""
+        api_error_cls = _cli_ns["ApiError"]
+        with patch.object(
+            client,
+            "_request",
+            side_effect=api_error_cls(
+                "Cannot connect to http://test-server:8080: "
+                "ConnectionRefusedError(61, 'Connection refused')\n"
+                "  Is the server running? Set --server or GROKTOCRAWL_API_URL"
+            ),
+        ):
+            with pytest.raises(api_error_cls) as exc_info:
+                client.crawl(url="http://example.com")
+            msg = str(exc_info.value)
+            assert "Cannot connect" in msg
+            assert "Is the server running" in msg
+            assert "Traceback" not in msg
+
+    def test_cmd_crawl_connection_error_exits_nonzero(self):
+        """cmd_crawl exits non-zero with clean error message on connection error."""
+        api_error_cls = _cli_ns["ApiError"]
+        cmd_crawl = _cli_ns["cmd_crawl"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 50
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = None
+        mock_args.ignore_query_parameters = False
+        mock_args.no_poll = True
+        mock_args.dry_run = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.side_effect = api_error_cls(
+            "Cannot connect to http://localhost:8080: Connection refused"
+        )
+
+        stderr = _capture_stderr(cmd_crawl, mock_client, mock_args)
+        assert "Error:" in stderr
+        assert "Cannot connect" in stderr
+        assert "Traceback" not in stderr
+
+
+# ── cmd_crawl handler tests ──────────────────────────────────────────────────
+
+
+class TestCmdCrawl:
+    """Tests for the cmd_crawl() handler function."""
+
+    def test_cmd_crawl_sends_new_flags(self):
+        """cmd_crawl passes max_pages and ignore_query_parameters to client.crawl()."""
+        cmd_crawl = _cli_ns["cmd_crawl"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 50
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = 5
+        mock_args.ignore_query_parameters = True
+        mock_args.no_poll = True
+        mock_args.dry_run = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.return_value = {"success": True, "id": "job-1"}
+
+        # With no_poll=True, cmd_crawl returns normally after printing job ID
+        cmd_crawl(mock_client, mock_args)
+
+        mock_client.crawl.assert_called_once_with(
+            url="http://example.com",
+            limit=50,
+            max_depth=2,
+            include_paths=None,
+            exclude_paths=None,
+            max_pages=5,
+            ignore_query_parameters=True,
+        )
+
+    def test_cmd_crawl_json_output(self):
+        """cmd_crawl with JSON_OUTPUT produces valid JSON."""
+        cmd_crawl = _cli_ns["cmd_crawl"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 1
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = None
+        mock_args.ignore_query_parameters = False
+        mock_args.dry_run = False
+        mock_args.no_poll = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.return_value = {"success": True, "id": "job-json-test"}
+        mock_client.crawl_status.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "data": [
+                {"url": "http://example.com/page1", "markdown": "# Page 1"},
+                {"url": "http://example.com/page2", "markdown": "# Page 2"},
+            ],
+        }
+
+        original_json = _cli_ns["JSON_OUTPUT"]
+        _cli_ns["JSON_OUTPUT"] = True
+        try:
+            stdout = _capture_stdout(cmd_crawl, mock_client, mock_args)
+        finally:
+            _cli_ns["JSON_OUTPUT"] = original_json
+
+        output = stdout.strip()
+        # Output should be valid JSON
+        parsed = json.loads(output)
+        assert parsed["job_id"] == "job-json-test"
+        assert parsed["status"] == "completed"
+        assert len(parsed["pages"]) == 2
+
+    def test_cmd_crawl_polling_error_retry_limit(self):
+        """cmd_crawl exits after max polling errors."""
+        cmd_crawl = _cli_ns["cmd_crawl"]
+        api_error_cls = _cli_ns["ApiError"]
+
+        mock_args = MagicMock()
+        mock_args.url = "http://example.com"
+        mock_args.limit = 50
+        mock_args.max_depth = 2
+        mock_args.include_paths = None
+        mock_args.exclude_paths = None
+        mock_args.max_pages = None
+        mock_args.ignore_query_parameters = False
+        mock_args.dry_run = False
+        mock_args.no_poll = False
+
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.crawl.return_value = {"success": True, "id": "job-poll-err"}
+        # All status checks fail
+        mock_client.crawl_status.side_effect = api_error_cls(
+            "Status check failed: connection lost"
+        )
+
+        stderr = _capture_stderr(cmd_crawl, mock_client, mock_args)
+        assert "Lost connection" in stderr
+        assert "Traceback" not in stderr
+
+
+def _capture_stdout(func, *args, **kwargs):
+    """Run func and capture stdout, returning the string."""
+    from contextlib import redirect_stdout, suppress
+    from io import StringIO
+
+    buf = StringIO()
+    with redirect_stdout(buf), suppress(SystemExit):
+        func(*args, **kwargs)
+    return buf.getvalue()
+
+
+def _capture_stderr(func, *args, **kwargs):
+    """Run func and capture stderr, returning the string."""
+    from contextlib import redirect_stderr, suppress
+    from io import StringIO
+
+    buf = StringIO()
+    with redirect_stderr(buf), suppress(SystemExit):
+        func(*args, **kwargs)
+    return buf.getvalue()
+
+
+# ── Parser / help text tests ─────────────────────────────────────────────────
+
+
+class TestCrawlParser:
+    """Tests for the crawl subcommand argument parser."""
+
+    def test_help_contains_crawl_flags(self):
+        """crawl --help lists all flags including new ones."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        stdout = StringIO()
+        with pytest.raises(SystemExit):
+            with redirect_stdout(stdout):
+                parser.parse_args(["crawl", "--help"])
+        help_text = stdout.getvalue()
+
+        # Existing flags
+        assert "--limit" in help_text
+        assert "--max-depth" in help_text
+        assert "--include-paths" in help_text
+        assert "--exclude-paths" in help_text
+        assert "--no-poll" in help_text
+
+        # New flags
+        assert "--max-pages" in help_text
+        assert "--ignore-query-params" in help_text
+
+    def test_parse_crawl_args_max_pages(self):
+        """--max-pages is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com", "--max-pages", "5"])
+        assert args.max_pages == 5
+
+    def test_parse_crawl_args_max_pages_default_none(self):
+        """--max-pages defaults to None."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com"])
+        assert args.max_pages is None
+
+    def test_parse_crawl_args_ignore_query_params(self):
+        """--ignore-query-params is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(
+            ["crawl", "http://example.com", "--ignore-query-params"]
+        )
+        assert args.ignore_query_parameters is True
+
+    def test_parse_crawl_args_ignore_query_params_default(self):
+        """--ignore-query-params defaults to False."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com"])
+        assert args.ignore_query_parameters is False
+
+    def test_parse_crawl_args_include_paths(self):
+        """--include-paths parses multiple path patterns."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(
+            [
+                "crawl",
+                "http://example.com",
+                "--include-paths",
+                "/blog/*",
+                "/docs/*",
+            ]
+        )
+        assert args.include_paths == ["/blog/*", "/docs/*"]
+
+    def test_parse_crawl_args_exclude_paths(self):
+        """--exclude-paths parses multiple path patterns."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(
+            [
+                "crawl",
+                "http://example.com",
+                "--exclude-paths",
+                "/admin/*",
+            ]
+        )
+        assert args.exclude_paths == ["/admin/*"]
+
+    def test_parse_crawl_args_max_depth(self):
+        """--max-depth is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com", "--max-depth", "1"])
+        assert args.max_depth == 1
+
+    def test_parse_crawl_args_limit(self):
+        """--limit is parsed correctly."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com", "--limit", "10"])
+        assert args.limit == 10
+
+    def test_global_help_shows_crawl(self):
+        """Top-level --help lists the crawl subcommand."""
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        stdout = StringIO()
+        with pytest.raises(SystemExit):
+            with redirect_stdout(stdout):
+                parser.parse_args(["--help"])
+        help_text = stdout.getvalue()
+        assert "crawl" in help_text
+
+
+# ── Subprocess integration tests ──────────────────────────────────────────────
+
+
+class TestCLISubprocess:
+    """Integration tests that run the CLI as a subprocess."""
+
+    def test_help_shows_crawl_flags(self):
+        """Running groktocrawl crawl --help shows all flags."""
+        result = subprocess.run(
+            [sys.executable, _CLI_PATH, "crawl", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        # Old flags
+        assert "--limit" in result.stdout
+        assert "--max-depth" in result.stdout
+        assert "--include-paths" in result.stdout
+        assert "--exclude-paths" in result.stdout
+        assert "--no-poll" in result.stdout
+        # New flags
+        assert "--max-pages" in result.stdout
+        assert "--ignore-query-params" in result.stdout
+
+    def test_top_level_help_shows_crawl(self):
+        """Top-level --help lists crawl command."""
+        result = subprocess.run(
+            [sys.executable, _CLI_PATH, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "crawl" in result.stdout

--- a/tests/test_crawl_cache.py
+++ b/tests/test_crawl_cache.py
@@ -1,0 +1,305 @@
+"""Unit tests for the Valkey-backed crawl cache (agent-svc/agent/crawl_cache.py).
+
+Covers:
+- Cache key format (SHA-256 of URL)
+- get / set / delete lifecycle
+- check_cache with maxAge semantics
+- check_cache with minAge semantics
+- maxAge=0 bypasses cache
+- maxAge and minAge combined
+- TTL enforcement
+- Age calculation
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock Valkey/Redis client.
+
+    Uses a real dict as backing store so get/set/delete work like the
+    real thing. ``expire`` / ``ttl`` are mocked for TTL-related tests.
+    """
+    store: dict[str, str] = {}
+    expiry: dict[str, float] = {}
+
+    mock = MagicMock()
+    mock.get.side_effect = lambda key: store.get(key)
+    mock.set.side_effect = lambda key, value, ex=None: (
+        store.update({key: value})
+        or (expiry.update({key: time.monotonic() + ex}) if ex else None)
+    )
+    mock.delete.side_effect = lambda key: store.pop(key, None) or expiry.pop(key, None)
+    mock.exists.side_effect = lambda key: key in store
+
+    return mock
+
+
+@pytest.fixture
+def cache(mock_redis):
+    """Create a CrawlCache with a mocked Valkey client."""
+    from agent.crawl_cache import CrawlCache
+
+    c = CrawlCache("redis://localhost:6379/0")
+    c.redis = mock_redis
+    return c
+
+
+_SAMPLE_PAGE_DATA = {
+    "success": True,
+    "data": {
+        "markdown": "# Hello World\nThis is test content.",
+        "metadata": {"title": "Test Page", "source": "scrape"},
+    },
+}
+
+
+# ── Cache key tests ──────────────────────────────────────────────
+
+
+class TestCacheKey:
+    """CrawlCache key generation uses SHA-256 of the URL."""
+
+    def test_key_prefix(self, cache):
+        key = cache._cache_key("https://example.com/page")
+        assert key.startswith("crawl:cache:")
+
+    def test_same_url_same_key(self, cache):
+        key1 = cache._cache_key("https://example.com/page")
+        key2 = cache._cache_key("https://example.com/page")
+        assert key1 == key2
+
+    def test_different_url_different_key(self, cache):
+        key1 = cache._cache_key("https://example.com/page")
+        key2 = cache._cache_key("https://example.com/other")
+        assert key1 != key2
+
+    def test_key_is_sha256_hex_length(self, cache):
+        key = cache._cache_key("https://example.com/page")
+        # prefix "crawl:cache:" = 12 chars, SHA-256 hex = 64 chars
+        assert len(key) == 12 + 64
+
+
+# ── Get / Set / Delete lifecycle ─────────────────────────────────
+
+
+class TestCacheLifecycle:
+    """Basic get/set/delete operations."""
+
+    def test_get_missing_returns_none(self, cache):
+        assert cache.get("https://example.com/missing") is None
+
+    def test_set_and_get(self, cache):
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=60000)
+        entry = cache.get(url)
+        assert entry is not None
+        assert entry["url"] == url
+        assert entry["data"] == _SAMPLE_PAGE_DATA
+        assert "cached_at" in entry
+        assert entry["ttl_ms"] == 60000
+
+    def test_delete_removes_entry(self, cache):
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=60000)
+        assert cache.get(url) is not None
+        cache.delete(url)
+        assert cache.get(url) is None
+
+    def test_set_overwrites_existing(self, cache):
+        url = "https://example.com/page"
+        cache.set(url, {"data": "old"}, ttl_ms=60000)
+        cache.set(url, {"data": "new"}, ttl_ms=120000)
+        entry = cache.get(url)
+        assert entry is not None
+        assert entry["data"] == {"data": "new"}
+        assert entry["ttl_ms"] == 120000
+
+    def test_set_ttl_zero_or_negative_defaults_to_1s(self, cache, mock_redis):
+        """TTL of 0ms or negative should still create entry with 1s TTL."""
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=0)
+        entry = cache.get(url)
+        assert entry is not None  # Entry is stored, just expires fast
+
+
+# ── Age calculation tests ────────────────────────────────────────
+
+
+class TestAgeMs:
+    """Age calculation from cached_at timestamp."""
+
+    def test_age_increases_over_time(self, cache, mock_redis):
+        """Age should be > 0 after a brief sleep."""
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=60000)
+        age = cache.get_age_ms(url)
+        assert age is not None
+        assert age >= 0
+
+    def test_age_for_missing_url(self, cache):
+        assert cache.get_age_ms("https://example.com/missing") is None
+
+
+# ── check_cache — maxAge semantics ───────────────────────────────
+
+
+class TestCheckCacheMaxAge:
+    """check_cache() with maxAge semantics."""
+
+    def test_max_age_unset_bypasses_cache(self, cache):
+        """No maxAge → always bypass cache."""
+        use_cached, data, error = cache.check_cache("https://example.com/page")
+        assert use_cached is False
+        assert data is None
+        assert error is None
+
+    def test_max_age_zero_bypasses_cache(self, cache):
+        """maxAge=0 → bypass cache (VAL-SCRAPE-053)."""
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=60000)
+        use_cached, data, error = cache.check_cache(url, max_age_ms=0)
+        assert use_cached is False
+        assert data is None
+        assert error is None
+
+    def test_cache_miss_returns_fresh_scrape(self, cache):
+        """No cached entry → fresh scrape."""
+        use_cached, data, error = cache.check_cache(
+            "https://example.com/missing", max_age_ms=60000
+        )
+        assert use_cached is False
+        assert data is None
+        assert error is None
+
+    def test_cache_hit_within_max_age(self, cache):
+        """Cached entry younger than maxAge → use cached (VAL-SCRAPE-027)."""
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=60000)
+        use_cached, data, error = cache.check_cache(url, max_age_ms=60000)
+        assert use_cached is True
+        assert data == _SAMPLE_PAGE_DATA
+        assert error is None
+
+    def test_cache_hit_exceeds_max_age_simulated(self, cache):
+        """When age exceeds maxAge, cache is stale → fresh scrape needed.
+
+        We simulate an old entry by injecting a cached_at far in the past.
+        """
+        url = "https://example.com/page"
+
+        from datetime import UTC, datetime, timedelta
+
+        key = cache._cache_key(url)
+        old_time = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        old_entry = {
+            "url": url,
+            "data": _SAMPLE_PAGE_DATA,
+            "cached_at": old_time,
+            "ttl_ms": 60000,
+        }
+        cache.redis.set(key, json.dumps(old_entry), ex=3600)
+
+        use_cached, _data, error = cache.check_cache(url, max_age_ms=60000)
+        assert use_cached is False  # Stale → needs refresh
+        assert error is None  # No error — just needs fresh scrape
+
+
+# ── check_cache — minAge semantics ──────────────────────────────
+
+
+class TestCheckCacheMinAge:
+    """check_cache() with minAge (cache-only) semantics."""
+
+    def test_min_age_cache_miss_returns_error(self, cache):
+        """Cache miss with minAge → error (VAL-SCRAPE-029)."""
+        url = "https://example.com/page"
+        use_cached, data, error = cache.check_cache(url, min_age_ms=60000)
+        assert use_cached is False
+        assert data is None
+        assert error is not None
+        assert "cache miss" in error.lower()
+
+    def test_min_age_cache_hit_returns_cached(self, cache):
+        """Cache hit with minAge → use cached (VAL-SCRAPE-030)."""
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=60000)
+        use_cached, data, error = cache.check_cache(url, min_age_ms=60000)
+        assert use_cached is True
+        assert data == _SAMPLE_PAGE_DATA
+        assert error is None
+
+    def test_min_age_cache_hit_ignores_age(self, cache):
+        """minAge ignores age — stale cache is still served."""
+        url = "https://example.com/page"
+
+        from datetime import UTC, datetime, timedelta
+
+        key = cache._cache_key(url)
+        old_time = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
+        old_entry = {
+            "url": url,
+            "data": _SAMPLE_PAGE_DATA,
+            "cached_at": old_time,
+            "ttl_ms": 60000,
+        }
+        cache.redis.set(key, json.dumps(old_entry), ex=3600)
+
+        use_cached, data, error = cache.check_cache(url, min_age_ms=60000)
+        assert use_cached is True  # minAge serves even stale cache
+        assert data == _SAMPLE_PAGE_DATA
+        assert error is None
+
+
+# ── check_cache — combined maxAge + minAge ──────────────────────
+
+
+class TestCheckCacheCombined:
+    """check_cache() with both maxAge and minAge."""
+
+    def test_both_set_cache_miss_returns_error(self, cache):
+        """Both set, no cache → minAge takes precedence: error."""
+        url = "https://example.com/page"
+        use_cached, data, error = cache.check_cache(
+            url, max_age_ms=3600000, min_age_ms=60000
+        )
+        assert use_cached is False
+        assert data is None
+        assert error is not None
+        assert "cache miss" in error.lower()
+
+    def test_both_set_fresh_cache(self, cache):
+        """Both set, cache younger than maxAge → use cached."""
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=3600000)
+        use_cached, data, error = cache.check_cache(
+            url, max_age_ms=3600000, min_age_ms=60000
+        )
+        assert use_cached is True
+        assert data == _SAMPLE_PAGE_DATA
+        assert error is None
+
+
+# ── check_cache — no cache config ───────────────────────────────
+
+
+class TestCheckCacheNoConfig:
+    """check_cache() with neither maxAge nor minAge."""
+
+    def test_no_cache_config(self, cache):
+        """No maxAge/minAge → bypass cache regardless of content."""
+        url = "https://example.com/page"
+        cache.set(url, _SAMPLE_PAGE_DATA, ttl_ms=60000)
+        use_cached, data, error = cache.check_cache(url)
+        assert use_cached is False
+        assert data is None
+        assert error is None

--- a/tests/test_crawl_cache.py
+++ b/tests/test_crawl_cache.py
@@ -288,6 +288,37 @@ class TestCheckCacheCombined:
         assert data == _SAMPLE_PAGE_DATA
         assert error is None
 
+    def test_both_set_stale_cache_triggers_fresh_scrape(self, cache):
+        """Both set, cache older than maxAge → trigger fresh scrape.
+
+        Previously the minAge block would unconditionally return cached
+        data when minAge was set, even if the cache was older than
+        maxAge. This test verifies that when age >= maxAge, the cache
+        returns use_cached=False so the caller performs a fresh scrape
+        instead of serving stale data (VAL-SCRAPE-031)."""
+        url = "https://example.com/page"
+
+        from datetime import UTC, datetime, timedelta
+
+        key = cache._cache_key(url)
+        # Inject an entry 2 hours old
+        old_time = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        old_entry = {
+            "url": url,
+            "data": _SAMPLE_PAGE_DATA,
+            "cached_at": old_time,
+            "ttl_ms": 3600000,
+        }
+        cache.redis.set(key, json.dumps(old_entry), ex=3600)
+
+        # maxAge=60s, minAge=60s — cache is 2 hours old → stale
+        use_cached, data, error = cache.check_cache(
+            url, max_age_ms=60000, min_age_ms=60000
+        )
+        assert use_cached is False  # Must trigger fresh scrape
+        assert data is not None  # Still return cached data as fallback
+        assert error is None  # No error — just needs refresh
+
 
 # ── check_cache — no cache config ───────────────────────────────
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -616,13 +616,17 @@ class TestCrawlEngine:
 
     @pytest.mark.asyncio
     async def test_bfs_order(self, mock_scraper):
-        """Pages appear in BFS order: start URL, then depth-1, then depth-2."""
+        """Pages appear in BFS order: start URL, then depth-1, then depth-2.
+
+        Uses crawl_entire_domain=True so that non-child sibling/parent
+        links are followed (e.g., grandchild from child-a).
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
             mock_scraper,
             store=None,
-            options=CrawlOptions(max_pages=10, max_depth=2),
+            options=CrawlOptions(max_pages=10, max_depth=2, crawl_entire_domain=True),
         )
 
         async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
@@ -930,7 +934,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_include_paths_start_url_matches(self, mock_scraper):
-        """When start URL matches include_paths, it is crawled."""
+        """When start URL matches include_paths, it is crawled.
+
+        Uses crawl_entire_domain=True to follow sibling paths under
+        /blog/ from /blog/index.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -940,6 +948,7 @@ class TestPathFiltering:
                 max_pages=10,
                 max_depth=1,
                 include_paths=["/blog/*"],
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1001,7 +1010,10 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_include_paths_regex_mode(self, mock_scraper):
-        """include_paths with regex_on_full_url=True uses regex matching."""
+        """include_paths with regex_on_full_url=True uses regex matching.
+
+        Uses crawl_entire_domain=True to allow sibling paths to be followed.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1012,6 +1024,7 @@ class TestPathFiltering:
                 max_depth=1,
                 include_paths=["/section/page-[12]"],
                 regex_on_full_url=True,
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1107,7 +1120,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_exclude_overrides_include(self, mock_scraper):
-        """exclude_paths takes precedence over include_paths."""
+        """exclude_paths takes precedence over include_paths.
+
+        Uses crawl_entire_domain=True so sibling paths like /section/page-1
+        are followed from /section/index.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1118,6 +1135,7 @@ class TestPathFiltering:
                 max_depth=1,
                 include_paths=["/section/*"],
                 exclude_paths=["/section/page-2"],
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1192,7 +1210,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_glob_double_star_matches_any_depth(self, mock_scraper):
-        """Glob ** matches across directory boundaries."""
+        """Glob ** matches across directory boundaries.
+
+        Uses crawl_entire_domain=True so sibling paths like /blog/2024
+        are followed from /blog/index.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1202,6 +1224,7 @@ class TestPathFiltering:
                 max_pages=20,
                 max_depth=3,
                 include_paths=["/blog/**"],
+                crawl_entire_domain=True,
             ),
         )
 
@@ -1230,7 +1253,11 @@ class TestPathFiltering:
 
     @pytest.mark.asyncio
     async def test_regex_on_full_url_with_query_params(self, mock_scraper):
-        """regex_on_full_url matches against full URL including query params."""
+        """regex_on_full_url matches against full URL including query params.
+
+        Uses crawl_entire_domain=True so sibling paths are followed from
+        /start path.
+        """
         from agent.crawler import CrawlEngine, CrawlOptions
 
         engine = CrawlEngine(
@@ -1241,6 +1268,7 @@ class TestPathFiltering:
                 max_depth=1,
                 include_paths=[r"\?ref=partner"],
                 regex_on_full_url=True,
+                crawl_entire_domain=True,
             ),
         )
 
@@ -2032,3 +2060,597 @@ class TestCrawlEngineSitemap:
         assert "http://example.com/sitemap-page1" in urls
         assert "http://example.com/sitemap-page2" in urls
         assert "http://example.com/pricing" not in urls  # HTML link, not followed
+
+
+# ── Domain Scope Controls tests ─────────────────────────────────
+
+
+class TestDomainScopeControls:
+    """Tests for crawlEntireDomain, allowSubdomains, allowExternalLinks."""
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_false_only_child_paths(self, mock_scraper):
+        """When crawlEntireDomain is False (default), only child paths are followed.
+
+        /section/page → /section/page/deeper ✅, /other ❌, / ❌
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                crawl_entire_domain=False,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page/deeper">Deeper child</a>
+                <a href="http://example.com/other">Sibling/other</a>
+                <a href="http://example.com/">Root</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page")
+
+        # Start URL + deeper child = 2 pages
+        # Sibling (/other) and root (/) should not be followed
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page" in urls
+        assert "http://example.com/section/page/deeper" in urls
+        assert "http://example.com/other" not in urls
+        assert "http://example.com/" not in urls
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_true_follows_all_same_domain(self, mock_scraper):
+        """When crawlEntireDomain is True, sibling/parent links are followed.
+
+        /section/page → /other ✅, / ✅
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page/deeper">Deeper child</a>
+                <a href="http://example.com/other">Sibling/other</a>
+                <a href="http://example.com/">Root</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page")
+
+        # Start URL + deeper child + other + root = 4 pages
+        assert result.completed == 4
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page" in urls
+        assert "http://example.com/section/page/deeper" in urls
+        assert "http://example.com/other" in urls
+        assert "http://example.com/" in urls
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_root_start_identical(self, mock_scraper):
+        """When start URL is root, crawlEntireDomain=false and true produce identical results."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        for crawl_entire in (False, True):
+            engine = CrawlEngine(
+                mock_scraper,
+                store=None,
+                options=CrawlOptions(
+                    max_pages=10,
+                    max_depth=2,
+                    crawl_entire_domain=crawl_entire,
+                ),
+            )
+
+            async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+                return MockPage.success(url, f"# Content of {url}")
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    <a href="http://example.com/about">About</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+            # Both modes should find all children (everything is a child of root)
+            urls = [p["url"] for p in result.pages]
+            assert "http://example.com/" in urls
+            assert "http://example.com/pricing" in urls
+            assert "http://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_subdomains_false_blocks_subdomains(self, mock_scraper):
+        """When allowSubdomains is False (default), subdomain links are NOT followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_subdomains=False,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://docs.example.com/doc">Docs subdomain</a>
+                <a href="http://blog.example.com/post">Blog subdomain</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing = 2 pages (subdomains blocked)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://docs.example.com/doc" not in urls
+        assert "http://blog.example.com/post" not in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_subdomains_true_follows_subdomains(self, mock_scraper):
+        """When allowSubdomains is True, subdomain links ARE followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_subdomains=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://docs.example.com/doc">Docs subdomain</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing + docs subdomain = 3 pages
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://docs.example.com/doc" in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_external_links_false_blocks_external(self, mock_scraper):
+        """When allowExternalLinks is False (default), external links are NOT followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_external_links=False,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://other.com/page">External other</a>
+                <a href="http://another.org/path">External another</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing = 2 pages (external blocked)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://other.com/page" not in urls
+        assert "http://another.org/path" not in urls
+
+    @pytest.mark.asyncio
+    async def test_allow_external_links_true_follows_external(self, mock_scraper):
+        """When allowExternalLinks is True, external domain links ARE followed."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_external_links=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://other.com/page">External other</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing + external = 3 pages
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://other.com/page" in urls
+
+    @pytest.mark.asyncio
+    async def test_ssrf_guard_blocks_private_hosts(self, mock_scraper):
+        """SSRF guard blocks private host URLs regardless of allow_external_links."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                allow_external_links=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://127.0.0.1/secret">Loopback</a>
+                <a href="http://10.0.0.1/internal">RFC 1918 10.x</a>
+                <a href="http://192.168.1.1/admin">RFC 1918 192.168.x</a>
+                <a href="http://169.254.169.254/latest/meta-data/">Metadata IP</a>
+                <a href="http://localhost:6379/valkey">Localhost</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing = 2 pages (all private hosts blocked)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://127.0.0.1/secret" not in urls
+        assert "http://10.0.0.1/internal" not in urls
+        assert "http://192.168.1.1/admin" not in urls
+        assert "http://169.254.169.254/latest/meta-data/" not in urls
+        assert "http://localhost:6379/valkey" not in urls
+
+    @pytest.mark.asyncio
+    async def test_crawl_entire_domain_plus_allow_subdomains(self, mock_scraper):
+        """crawlEntireDomain + allowSubdomains: follow sibling/parent on subdomains too."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=20,
+                max_depth=3,
+                crawl_entire_domain=True,
+                allow_subdomains=True,
+                allow_external_links=False,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://blog.example.com/post">Blog subdomain</a>
+                <a href="http://other.com/external">External</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page")
+
+        # Start URL + pricing + blog subdomain = 3 pages
+        # External should be excluded
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page" in urls
+        assert "http://example.com/pricing" in urls
+        assert "http://blog.example.com/post" in urls
+        assert "http://other.com/external" not in urls
+
+    @pytest.mark.asyncio
+    async def test_external_pages_respect_max_pages(self, mock_scraper):
+        """External pages count toward max_pages limit."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=3,
+                max_depth=2,
+                allow_external_links=True,
+                crawl_entire_domain=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://other.com/page1">External 1</a>
+                <a href="http://another.org/page2">External 2</a>
+                <a href="http://third.net/page3">External 3</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # max_pages=3: start URL + pricing + 1 external = 3
+        assert result.completed <= 3
+        assert len(result.pages) <= 3
+
+
+# ── CrawlRequest scope control field validation tests ───────────
+
+
+class TestCrawlRequestScopeControlValidation:
+    """Tests for CrawlRequest scope control field validation."""
+
+    def test_crawl_entire_domain_default_false(self):
+        """crawl_entire_domain defaults to False."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.crawl_entire_domain is False
+
+    def test_crawl_entire_domain_can_be_true(self):
+        """crawl_entire_domain can be set to True."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", crawl_entire_domain=True)
+        assert req.crawl_entire_domain is True
+
+    def test_allow_subdomains_default_false(self):
+        """allow_subdomains defaults to False."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.allow_subdomains is False
+
+    def test_allow_subdomains_can_be_true(self):
+        """allow_subdomains can be set to True."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", allow_subdomains=True)
+        assert req.allow_subdomains is True
+
+    def test_allow_external_links_default_false(self):
+        """allow_external_links defaults to False."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.allow_external_links is False
+
+    def test_allow_external_links_can_be_true(self):
+        """allow_external_links can be set to True."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", allow_external_links=True)
+        assert req.allow_external_links is True
+
+    def test_crawl_entire_domain_coerces_from_string(self):
+        """crawl_entire_domain with truthy string is coerced to True (Pydantic default)."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", crawl_entire_domain="yes")
+        assert req.crawl_entire_domain is True
+
+
+# ── _filter_child_paths unit tests ──────────────────────────────
+
+
+class TestFilterChildPaths:
+    """Tests for the CrawlEngine._filter_child_paths static method."""
+
+    def test_keeps_child_paths(self):
+        """Links that are children of the current URL path are kept."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/section/page/deeper",
+            "http://example.com/section/page/child",
+            "http://example.com/section/page/deep/est",
+        ]
+        result = CrawlEngine._filter_child_paths(
+            links, "http://example.com/section/page"
+        )
+        assert len(result) == 3
+
+    def test_filters_sibling_and_parent(self):
+        """Links to sibling or parent paths are filtered out."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/section/other",  # sibling
+            "http://example.com/section",  # parent
+            "http://example.com/",  # grandparent
+            "http://example.com/section/page/deeper",  # child (kept)
+        ]
+        result = CrawlEngine._filter_child_paths(
+            links, "http://example.com/section/page"
+        )
+        assert len(result) == 1
+        assert "http://example.com/section/page/deeper" in result
+
+    def test_keeps_different_domain_links(self):
+        """Links on different domains are kept regardless of path."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://docs.example.com/other",  # subdomain
+            "http://external.com/anything",  # external
+        ]
+        result = CrawlEngine._filter_child_paths(
+            links, "http://example.com/section/page"
+        )
+        # Different domains always pass through
+        assert len(result) == 2
+
+    def test_current_url_with_trailing_slash(self):
+        """Works correctly when current_url has a trailing slash.
+
+        Both /section/child and /section/other are children of /section/.
+        """
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/section/child",  # child (kept)
+            "http://example.com/section/other",  # also child (kept)
+            "http://example.com/section",  # parent (filtered)
+        ]
+        result = CrawlEngine._filter_child_paths(links, "http://example.com/section/")
+        assert len(result) == 2
+        assert "http://example.com/section/child" in result
+        assert "http://example.com/section/other" in result
+        assert "http://example.com/section" not in result
+
+    def test_empty_links_returns_empty(self):
+        """Empty links list returns empty list."""
+        from agent.crawler import CrawlEngine
+
+        result = CrawlEngine._filter_child_paths([], "http://example.com/page")
+        assert result == []
+
+
+# ── _filter_ssrf_blocked unit tests ─────────────────────────────
+
+
+class TestFilterSsrfBlocked:
+    """Tests for the CrawlEngine._filter_ssrf_blocked static method."""
+
+    def test_allows_public_hosts(self):
+        """Public hosts are allowed through."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/page",
+            "http://google.com/search",
+            "https://github.com/repo",
+        ]
+        result = CrawlEngine._filter_ssrf_blocked(links)
+        assert len(result) == 3
+
+    def test_blocks_private_ips(self):
+        """Private IP addresses are blocked."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://example.com/page",  # allowed
+            "http://127.0.0.1/secret",  # loopback
+            "http://10.0.0.1/internal",  # RFC 1918 10.x
+            "http://192.168.1.1/admin",  # RFC 1918 192.168.x
+        ]
+        result = CrawlEngine._filter_ssrf_blocked(links)
+        assert len(result) == 1
+        assert "http://example.com/page" in result
+
+    def test_blocks_localhost_hostname(self):
+        """Localhost hostname is blocked."""
+        from agent.crawler import CrawlEngine
+
+        links = [
+            "http://localhost:6379/valkey",
+            "http://example.com/page",
+        ]
+        result = CrawlEngine._filter_ssrf_blocked(links)
+        assert len(result) == 1
+        assert "http://example.com/page" in result
+
+    def test_empty_links(self):
+        """Empty links list returns empty list."""
+        from agent.crawler import CrawlEngine
+
+        result = CrawlEngine._filter_ssrf_blocked([])
+        assert result == []

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -4439,3 +4439,255 @@ class TestCrawlEngineDedup:
         ]
         assert len(dedup_errors) == 2
         # Verify the errors endpoint can serve these entries (they have proper fields)
+
+
+# ── CrawlEngine cache integration ────────────────────────────────
+
+
+class TestCrawlEngineCache:
+    """Tests for CrawlEngine integration with CrawlCache."""
+
+    @pytest.mark.asyncio
+    async def test_cache_check_before_scrape_with_max_age(self, mock_scraper):
+        """With maxAge set, cache is checked before each scrape."""
+        from agent.crawl_cache import CrawlCache
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        url = "http://example.com/"
+
+        # Create a real CrawlCache backed by a mock Redis
+        cache = CrawlCache("redis://localhost:6379/0")
+        cache.redis = mock_scraper._mock_cache_redis = MagicMock()
+        # Start with empty cache
+        cache.redis.get.return_value = None
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=1,
+                max_depth=0,
+                scrape_options={"max_age": 60000},  # 60s maxAge
+            ),
+            crawl_cache=cache,
+        )
+
+        mock_scraper.scrape.return_value = MockPage.success(url, "# Content")
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body></body></html>"
+
+        result = await engine.run(url)
+
+        # Verify cache was checked (get was called)
+        cache.redis.get.assert_called()
+        # And scraper was called (cache miss)
+        mock_scraper.scrape.assert_called_once()
+        assert result.completed == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_scraper_call(self, mock_scraper):
+        """When cache has fresh content, scraper is NOT called."""
+        import hashlib
+        import json
+        from datetime import UTC, datetime
+
+        from agent.crawl_cache import CrawlCache
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        url = "http://example.com/"
+
+        cache = CrawlCache("redis://localhost:6379/0")
+        store: dict[str, str] = {}
+        mock_redis = MagicMock()
+
+        def mock_get(key: str) -> str | None:
+            return store.get(key)
+
+        def mock_set(key: str, value: str, ex: int | None = None) -> None:
+            store[key] = value
+
+        mock_redis.get.side_effect = mock_get
+        mock_redis.set.side_effect = mock_set
+        mock_redis.delete.side_effect = lambda key: store.pop(key, None)
+        cache.redis = mock_redis
+
+        # Pre-populate cache with fresh content (very recent timestamp)
+        _now_iso = datetime.now(UTC).isoformat()
+        cached_entry = {
+            "url": url,
+            "data": MockPage.success(url, "# Cached Content"),
+            "cached_at": _now_iso,
+            "ttl_ms": 60000,
+        }
+        cache_key = f"crawl:cache:{hashlib.sha256(url.encode()).hexdigest()}"
+        store[cache_key] = json.dumps(cached_entry)
+
+        # Set up a counter to track scraper calls
+        call_count = 0
+
+        async def scrape_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return MockPage.success(url, "# Fresh Content")  # Different from cached
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=1,
+                max_depth=0,
+                scrape_options={"max_age": 60000},
+            ),
+            crawl_cache=cache,
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body></body></html>"
+
+        result = await engine.run(url)
+
+        # Verify scraper was NOT called (cache hit)
+        assert call_count == 0, f"Expected 0 scraper calls, got {call_count}"
+        # Verify page came from cache (markdown matches cached content)
+        assert result.completed == 1
+        assert len(result.pages) == 1
+        assert "# Cached Content" in result.pages[0].get("markdown", ""), (
+            "Page should contain cached content, not fresh content"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_with_min_age_returns_error(self, mock_scraper):
+        """With minAge set and no cache entry, error is returned for the URL."""
+        from agent.crawl_cache import CrawlCache
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        url = "http://example.com/"
+
+        cache = CrawlCache("redis://localhost:6379/0")
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None  # No cache entry
+        cache.redis = mock_redis
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=1,
+                max_depth=0,
+                scrape_options={"min_age": 60000},  # cache-only mode
+            ),
+            crawl_cache=cache,
+        )
+
+        mock_scraper.scrape.return_value = MockPage.success(url, "# Content")
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body></body></html>"
+
+        result = await engine.run(url)
+
+        # Verify scraper was NOT called (minAge prevents fresh scrape)
+        mock_scraper.scrape.assert_not_called()
+        # But page was NOT scraped — it should be an error
+        assert result.completed == 0
+        assert len(result.pages) == 0
+        # Error should mention cache miss
+        assert len(result.errors) == 1
+        assert "CACHE_MISS" in result.errors[0].get("error_code", "")
+        assert "cache miss" in result.errors[0].get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_cache_stores_result_after_fresh_scrape(self, mock_scraper):
+        """After a fresh scrape with maxAge set, the result is stored in cache."""
+        import hashlib
+        import json
+
+        from agent.crawl_cache import CrawlCache
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        url = "http://example.com/"
+
+        store_dict: dict[str, str] = {}
+        cache = CrawlCache("redis://localhost:6379/0")
+        mock_redis = MagicMock()
+        mock_redis.get.side_effect = lambda k: store_dict.get(k)
+        mock_redis.set.side_effect = lambda k, v, ex=None: store_dict.update({k: v})
+        cache.redis = mock_redis
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=1,
+                max_depth=0,
+                scrape_options={"max_age": 60000},
+            ),
+            crawl_cache=cache,
+        )
+
+        mock_scraper.scrape.return_value = MockPage.success(url, "# Fresh Content")
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body></body></html>"
+
+        result = await engine.run(url)
+
+        assert result.completed == 1
+        # Verify cache was populated
+        cache_key = f"crawl:cache:{hashlib.sha256(url.encode()).hexdigest()}"
+        assert cache_key in store_dict, "Cache should have been populated after scrape"
+        cached = json.loads(store_dict[cache_key])
+        assert cached["url"] == url
+        assert cached["ttl_ms"] == 60000
+
+    @pytest.mark.asyncio
+    async def test_max_age_zero_bypasses_cache(self, mock_scraper):
+        """maxAge=0 bypasses cache entirely — always fresh scrape."""
+        import hashlib
+        import json
+
+        from agent.crawl_cache import CrawlCache
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        url = "http://example.com/"
+
+        store_dict: dict[str, str] = {}
+        cache = CrawlCache("redis://localhost:6379/0")
+        mock_redis = MagicMock()
+        mock_redis.get.side_effect = lambda k: store_dict.get(k)
+        mock_redis.set.side_effect = lambda k, v, ex=None: store_dict.update({k: v})
+        cache.redis = mock_redis
+
+        # Pre-populate cache with stale content
+        cache_key = f"crawl:cache:{hashlib.sha256(url.encode()).hexdigest()}"
+        stale_entry = {
+            "url": url,
+            "data": MockPage.success(url, "# Stale Cached Content"),
+            "cached_at": "2026-06-19T12:00:00+00:00",
+            "ttl_ms": 60000,
+        }
+        store_dict[cache_key] = json.dumps(stale_entry)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=1,
+                max_depth=0,
+                scrape_options={"max_age": 0},  # bypass cache
+            ),
+            crawl_cache=cache,
+        )
+
+        mock_scraper.scrape.return_value = MockPage.success(
+            url, "# Freshly Scraped Content"
+        )
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body></body></html>"
+
+        result = await engine.run(url)
+
+        # Scraper was called (cache bypassed)
+        mock_scraper.scrape.assert_called_once()
+        assert result.completed == 1
+        assert "# Freshly Scraped Content" in result.pages[0].get("markdown", "")

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -927,9 +927,12 @@ class TestCrawlEngine:
         """Self-referencing links don't cause infinite loops."""
         from agent.crawler import CrawlEngine, CrawlOptions
 
-        mock_scraper.scrape = AsyncMock(
-            return_value=MockPage.success("http://example.com/")
-        )
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
 
         engine = CrawlEngine(
             mock_scraper,
@@ -1951,7 +1954,7 @@ class TestCrawlEngineSitemap:
                 "http://example.com/sitemap-only-page2",
             ]
 
-            with patch.object(engine, "_get_html"):
+            with patch.object(engine, "_get_html", return_value=None):
                 result = await engine.run("http://example.com/")
 
         # Should have start URL + 2 sitemap URLs
@@ -3288,7 +3291,7 @@ class TestCrawlTimeoutAndErrors:
                     "success": False,
                     "error": "Blocked by politeness: robots.txt disallows",
                 }
-            return MockPage.success(url)
+            return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=mixed_scrape)
 
@@ -3341,9 +3344,12 @@ class TestCrawlStoreAtomicity:
         mock_store.get_completed = MagicMock(return_value=0)
         mock_store.update_job_progress = MagicMock()
 
-        mock_scraper.scrape = AsyncMock(
-            return_value=MockPage.success("http://example.com/")
-        )
+        async def _unique_scrape(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=_unique_scrape)
 
         with patch.object(engine, "_get_html") as mock_html:
             mock_html.return_value = """
@@ -3387,7 +3393,7 @@ class TestCrawlStoreAtomicity:
                     "success": False,
                     "error": "Blocked by politeness: robots.txt disallows",
                 }
-            return MockPage.success(url)
+            return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=mixed_scrape)
 
@@ -3562,10 +3568,12 @@ class TestPolitenessFields:
         await engine.run("http://example.com/")
 
         # Verify the scraper was called with the correct params
+        # Note: scrape_options is passed as None when not configured
         mock_scraper.scrape.assert_called_once_with(
             "http://example.com/",
             ignore_robots_txt=True,
             robots_user_agent="CustomBot/1.0",
+            scrape_options=None,
         )
 
     @pytest.mark.asyncio
@@ -3906,3 +3914,528 @@ class TestScrapeOptionsModel:
         assert dumped["exclude_tags"] is None
         assert "headers" in dumped
         assert dumped["headers"] is None
+
+
+# ── DedupManager tests ────────────────────────────────────────────
+
+
+class TestDedupManager:
+    """Tests for the DedupManager multi-layer deduplication."""
+
+    # ── Canonical tag check ──────────────────────────────────────
+
+    def test_canonical_matches_prevents_duplicate(self):
+        """Page A with canonical=page B, when B is scraped, A is skipped."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        # Mark page B as already scraped
+        dedup.mark_scraped("https://example.com/page-b")
+
+        # Page A has canonical pointing to page B
+        html = '<html><head><link rel="canonical" href="https://example.com/page-b"></head><body></body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page-a")
+        assert result == "https://example.com/page-b"
+
+    def test_self_referencing_canonical_ignored(self):
+        """A page with canonical=itself is not considered a duplicate."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page")
+
+        # Self-referencing canonical should return None (not a duplicate)
+        html = '<html><head><link rel="canonical" href="https://example.com/page"></head><body></body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page")
+        assert result is None
+
+    def test_self_referencing_canonical_with_trailing_slash(self):
+        """Self-referencing canonical with trailing slash difference is ignored."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page")
+
+        # Self-referencing with trailing slash on canonical
+        html = '<html><head><link rel="canonical" href="https://example.com/page/"></head><body></body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page")
+        assert result is None
+
+    def test_canonical_external_domain_ignored(self):
+        """Canonical pointing to external domain is ignored."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://other.com/page")
+
+        # Page A has canonical pointing to an external domain
+        html = '<html><head><link rel="canonical" href="https://other.com/page"></head><body></body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page-a")
+        assert result is None  # External domain, ignored
+
+    def test_canonical_not_scraped_yet(self):
+        """Canonical URL that hasn't been scraped yet is not a duplicate."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page-a")
+
+        # Page B has canonical pointing to page-c which hasn't been scraped
+        html = '<html><head><link rel="canonical" href="https://example.com/page-c"></head><body></body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page-b")
+        assert result is None  # Canonical target hasn't been scraped
+
+    def test_canonical_relative_url_resolved(self):
+        """Relative canonical URLs are resolved against the current URL."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page-b")
+
+        # Relative canonical URL
+        html = '<html><head><link rel="canonical" href="/page-b"></head><body></body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page-a")
+        assert result == "https://example.com/page-b"
+
+    def test_canonical_href_first_attribute_order(self):
+        """href attribute before rel attribute is also parsed correctly."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page-b")
+
+        # href before rel
+        html = '<html><head><link href="https://example.com/page-b" rel="canonical"></head><body></body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page-a")
+        assert result == "https://example.com/page-b"
+
+    def test_canonical_no_tag_returns_none(self):
+        """Page without canonical tag returns None."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page-b")
+
+        html = "<html><head></head><body><p>No canonical tag</p></body></html>"
+        result = dedup.check_canonical(html, "https://example.com/page-a")
+        assert result is None
+
+    # ── Content hash dedup ──────────────────────────────────────
+
+    def test_content_hash_identical_markdown_detected(self):
+        """Two pages with identical markdown → second is duplicate."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        md = "# Same Content\n\nThis is identical markdown."
+
+        # First page: compute and register hash
+        h = dedup.compute_content_hash(md)
+        assert h is not None
+        assert not dedup.is_duplicate_content(h)
+
+        dedup.mark_scraped("https://example.com/page-a", content_hash=h)
+
+        # Second page with same content
+        h2 = dedup.compute_content_hash(md)
+        assert h2 == h
+        assert dedup.is_duplicate_content(h2)
+
+    def test_content_hash_different_markdown_not_duplicate(self):
+        """Two pages with different markdown content are NOT duplicates."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+
+        h1 = dedup.compute_content_hash("# Page A Content")
+        assert h1 is not None
+        dedup.mark_scraped("https://example.com/page-a", content_hash=h1)
+
+        h2 = dedup.compute_content_hash("# Page B Content")
+        assert h2 is not None
+        assert h2 != h1
+        assert not dedup.is_duplicate_content(h2)
+
+    def test_content_hash_near_identical_matches_exact_only(self):
+        """Pages differing only by a timestamp are NOT deduped by hash."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+
+        content_a = "<p>Hello World</p>\n<!-- generated at 2024-01-01T00:00:01Z -->"
+        content_b = "<p>Hello World</p>\n<!-- generated at 2024-01-01T00:00:02Z -->"
+
+        h1 = dedup.compute_content_hash(content_a)
+        assert h1 is not None
+        dedup.mark_scraped("https://example.com/page-a", content_hash=h1)
+
+        h2 = dedup.compute_content_hash(content_b)
+        assert h2 is not None
+        assert h2 != h1  # Different hash due to timestamp difference
+        assert not dedup.is_duplicate_content(h2)
+
+    def test_empty_markdown_not_duplicate(self):
+        """Empty markdown never counts as a duplicate."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+
+        # Empty markdown should return None hash
+        assert dedup.compute_content_hash("") is None
+        assert dedup.compute_content_hash("   ") is None
+        assert dedup.compute_content_hash("\n\n  \n") is None
+
+    def test_empty_markdown_not_deduped_via_is_duplicate(self):
+        """Explicit check that empty markdown is included (not treated as duplicate)."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+
+        # First page with some content
+        h1 = dedup.compute_content_hash("Some content")
+        assert h1 is not None
+        dedup.mark_scraped("https://example.com/page-a", content_hash=h1)
+
+        # Second page with empty markdown — hash is None, is_duplicate_content should not trigger
+        # Since compute_content_hash returns None for empty markdown, we should never call
+        # is_duplicate_content with None. The caller handles this.
+        assert dedup.compute_content_hash("") is None
+
+    # ── Canonical runs before content hash ──────────────────────
+
+    def test_canonical_check_before_content_hash(self):
+        """Canonical check runs first; content hash not checked if canonical matches."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+
+        # Set up page B as scraped
+        dedup.mark_scraped("https://example.com/page-b")
+
+        # Page A has canonical=page-B AND identical content
+        html = '<html><head><link rel="canonical" href="https://example.com/page-b"></head><body>Same content</body></html>'
+        result = dedup.check_canonical(html, "https://example.com/page-a")
+        assert result == "https://example.com/page-b"
+
+        # The content hash check would only apply if canonical check returned None
+        # (not a duplicate). Since canonical IS a duplicate, we never check content hash.
+
+    # ── mark_scraped and scraped URL tracking ───────────────────
+
+    def test_is_scraped_url_after_mark(self):
+        """URL is reported as scraped after mark_scraped()."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        assert not dedup.is_scraped_url("https://example.com/page")
+
+        dedup.mark_scraped("https://example.com/page")
+        assert dedup.is_scraped_url("https://example.com/page")
+
+    def test_is_scraped_url_trailing_slash_normalized(self):
+        """URLs with and without trailing slash normalized correctly."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page")
+
+        assert dedup.is_scraped_url("https://example.com/page")
+        assert dedup.is_scraped_url("https://example.com/page/")
+
+    def test_canonical_url_tracking(self):
+        """get_canonical_for returns the canonical URL for a scraped page."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped(
+            "https://example.com/page-a",
+            canonical_url="https://example.com/canonical-page",
+        )
+        assert (
+            dedup.get_canonical_for("https://example.com/page-a")
+            == "https://example.com/canonical-page"
+        )
+
+    def test_canonical_tracking_no_canonical(self):
+        """get_canonical_for returns None when no canonical was recorded."""
+        from agent.dedup import DedupManager
+
+        dedup = DedupManager()
+        dedup.mark_scraped("https://example.com/page")
+        assert dedup.get_canonical_for("https://example.com/page") is None
+
+
+# ── CrawlEngine dedup integration tests ───────────────────────────
+
+
+class TestCrawlEngineDedup:
+    """Tests for CrawlEngine integration with DedupManager."""
+
+    @pytest.mark.asyncio
+    async def test_canonical_dedup_skips_duplicate_page(self, mock_scraper):
+        """Page with canonical=already-scraped URL is skipped."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=5, max_depth=1),
+        )
+
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Start page links to page-a (no canonical) and page-b (canonical → page-a)
+        with patch.object(engine, "_get_html") as mock_html:
+
+            def html_side_effect(url: str) -> str | None:
+                if "page-b" in url:
+                    return (
+                        '<html><head><link rel="canonical" '
+                        'href="http://example.com/page-a"></head>'
+                        "<body>Page B with canonical to A</body></html>"
+                    )
+                return (
+                    "<html><body>"
+                    "<a href='http://example.com/page-a'>Page A</a>"
+                    "<a href='http://example.com/page-b'>Page B</a>"
+                    "</body></html>"
+                )
+
+            mock_html.side_effect = html_side_effect
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + page-a = 2 pages (page-b skipped by canonical dedup)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/page-b" not in urls
+        # Should have a dedup error for page-b
+        dedup_errors = [
+            e for e in result.errors if e.get("error_type") == "duplicate_canonical"
+        ]
+        assert len(dedup_errors) == 1
+        assert dedup_errors[0]["url"] == "http://example.com/page-b"
+
+    @pytest.mark.asyncio
+    async def test_content_hash_dedup_skips_duplicate_page(self, mock_scraper):
+        """Two pages with identical markdown → second is skipped."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=5, max_depth=1),
+        )
+
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            # Start URL returns unique content; page-a and page-b share identical content
+            if url == "http://example.com/":
+                return MockPage.success(url, markdown="# Start page content")
+            return MockPage.success(url, markdown="# Identical Content\n\nSame text.")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = (
+                "<html><body>"
+                "<a href='http://example.com/page-a'>Page A</a>"
+                "<a href='http://example.com/page-b'>Page B</a>"
+                "</body></html>"
+            )
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + page-a = 2 pages (page-b skipped by content dedup)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        # page-b should be dedup'd (identical content to page-a)
+        assert "http://example.com/page-b" not in urls
+        # Should have a dedup error for page-b
+        dedup_errors = [
+            e for e in result.errors if e.get("error_type") == "duplicate_content"
+        ]
+        assert len(dedup_errors) == 1
+        assert dedup_errors[0]["url"] == "http://example.com/page-b"
+
+    @pytest.mark.asyncio
+    async def test_canonical_check_before_content_hash_in_engine(self, mock_scraper):
+        """Canonical check runs before content hash check in crawl engine.
+
+        A page that is both canonical-dup AND content-dup should report
+        canonical as the dedup reason.
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=5, max_depth=1),
+        )
+
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            # Start URL has unique content; page-a and page-b share content
+            if url == "http://example.com/":
+                return MockPage.success(url, markdown="# Start page unique content")
+            return MockPage.success(url, markdown="# Same Content")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+
+            def html_side_effect(url: str) -> str | None:
+                if "page-b" in url:
+                    # Page B has canonical=page-a AND identical content
+                    return (
+                        '<html><head><link rel="canonical" '
+                        'href="http://example.com/page-a"></head>'
+                        "<body>Same</body></html>"
+                    )
+                return (
+                    "<html><body>"
+                    "<a href='http://example.com/page-a'>Page A</a>"
+                    "<a href='http://example.com/page-b'>Page B</a>"
+                    "</body></html>"
+                )
+
+            mock_html.side_effect = html_side_effect
+
+            result = await engine.run("http://example.com/")
+
+        # The dedup error for page-b should be canonical, NOT content
+        canonical_errors = [
+            e for e in result.errors if e.get("error_type") == "duplicate_canonical"
+        ]
+        content_errors = [
+            e for e in result.errors if e.get("error_type") == "duplicate_content"
+        ]
+        assert len(canonical_errors) == 1, (
+            f"Expected 1 canonical error, got {len(canonical_errors)}: {result.errors}"
+        )
+        assert len(content_errors) == 0, (
+            f"Expected 0 content errors, got {len(content_errors)}: {result.errors}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_self_referencing_canonical_in_crawl(self, mock_scraper):
+        """Page with self-referencing canonical is scraped normally."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=3, max_depth=1),
+        )
+
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            # All pages have self-referencing canonical tags
+            def html_side_effect(url: str) -> str | None:
+                return (
+                    f'<html><head><link rel="canonical" href="{url}"></head>'
+                    "<body>"
+                    "<a href='http://example.com/page-a'>Page A</a>"
+                    "</body></html>"
+                )
+
+            mock_html.side_effect = html_side_effect
+
+            result = await engine.run("http://example.com/")
+
+        # Both pages should be scraped (self-canonical is ignored)
+        assert result.completed == 2
+        assert len(result.pages) == 2
+        # No dedup errors
+        dedup_errors = [e for e in result.errors if e.get("error_type") is not None]
+        assert len(dedup_errors) == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_markdown_includes_page(self, mock_scraper):
+        """Pages with empty markdown are still included (not dedup'd)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=3, max_depth=1),
+        )
+
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            return MockPage.success(url, markdown="")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = (
+                "<html><body>"
+                "<a href='http://example.com/page-a'>Page A</a>"
+                "<a href='http://example.com/page-b'>Page B</a>"
+                "</body></html>"
+            )
+
+            result = await engine.run("http://example.com/")
+
+        # All 3 pages should be included (empty markdown is not treated as duplicate)
+        assert result.completed == 3
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_total_includes_dedup_pages(self, mock_scraper):
+        """Crawl total includes dedup'd pages (VAL-SCRAPE-052)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=5, max_depth=1),
+        )
+
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            # Start URL has unique content; page-a and page-b have identical content
+            if url == "http://example.com/":
+                return MockPage.success(url, markdown="# Start page unique content")
+            return MockPage.success(url, markdown="# Identical Content")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = (
+                "<html><body>"
+                "<a href='http://example.com/page-a'>Page A</a>"
+                "<a href='http://example.com/page-b'>Page B</a>"
+                "<a href='http://example.com/page-c'>Page C</a>"
+                "</body></html>"
+            )
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + page-a = 2 completed (page-b and page-c dedup'd)
+        assert result.completed == 2, (
+            f"Expected completed=2, got completed={result.completed}"
+        )
+        # Total should be 4 = 2 completed + 2 dedup'd
+        assert result.total == 4, f"Expected total=4, got total={result.total}"
+        # Verify dedup errors exist
+        dedup_errors = [
+            e for e in result.errors if e.get("error_type") == "duplicate_content"
+        ]
+        assert len(dedup_errors) == 2
+        # Verify the errors endpoint can serve these entries (they have proper fields)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -9,10 +9,12 @@ Covers:
 - URL dedup within a crawl run
 - Start URL failure handling
 - Child page error handling
+- Concurrency and delay behavior
 """
 
 from __future__ import annotations
 
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2654,3 +2656,500 @@ class TestFilterSsrfBlocked:
 
         result = CrawlEngine._filter_ssrf_blocked([])
         assert result == []
+
+
+# ── Concurrency and delay tests ─────────────────────────────────
+
+
+class TestCrawlConcurrency:
+    """Tests for crawl concurrency (max_concurrency, delay, semaphore)."""
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_1_produces_sequential_scraping(self, mock_scraper):
+        """With max_concurrency=1, pages are scraped sequentially."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=3,
+                max_depth=1,
+                max_concurrency=1,
+            ),
+        )
+
+        scrape_times = []
+
+        async def scrape_with_timing(url: str, force_browser: bool = False) -> dict:
+            scrape_times.append(time.monotonic())
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_with_timing)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 3
+        assert len(result.pages) == 3
+
+        # Scrape timestamps should be sequential (no overlap)
+        # With max_concurrency=1, each scrape is awaited before the next starts.
+        # Since we're measuring task-level timing, the _scrape_url method
+        # acquires the semaphore before scraping, ensuring sequential access.
+        # We verify by checking that all 3 pages were scraped.
+        urls = [p["url"] for p in result.pages]
+        assert urls[0] == "http://example.com/"
+        assert "http://example.com/page1" in urls
+        assert "http://example.com/page2" in urls
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_5_processes_multiple_pages(self, mock_scraper):
+        """With max_concurrency=5, multiple pages are scraped concurrently."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=6,
+                max_depth=1,
+                max_concurrency=5,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                <a href="http://example.com/page3">Page 3</a>
+                <a href="http://example.com/page4">Page 4</a>
+                <a href="http://example.com/page5">Page 5</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have scraped 6 pages (start URL + 5 children)
+        assert result.completed == 6
+        assert len(result.pages) == 6
+        # Verify no duplicate URLs
+        urls = [p["url"] for p in result.pages]
+        assert len(urls) == len(set(urls))
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_greater_than_remaining_pages(self, mock_scraper):
+        """max_concurrency > remaining pages does not deadlock."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=3,
+                max_depth=1,
+                max_concurrency=10,  # More than available pages
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should complete all 3 pages without deadlock
+        assert result.completed == 3
+        assert len(result.pages) == 3
+        # Should complete quickly (no hang)
+        assert len(result.errors) == 0
+
+    @pytest.mark.asyncio
+    async def test_delay_forces_concurrency_to_1(self, mock_scraper):
+        """When delay is set, concurrency is forced to 1 and sequential pacing occurs."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=3,
+                max_depth=1,
+                max_concurrency=5,
+                delay=0.05,  # Small delay for testing
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            start = time.monotonic()
+            result = await engine.run("http://example.com/")
+            elapsed = time.monotonic() - start
+
+        assert result.completed == 3
+        # With delay=0.05 and 2 inter-scrape gaps (3 pages → 2 gaps),
+        # total should be at least 0.05 * 2 = 0.1s (plus scrape time)
+        assert elapsed >= 0.09  # allow some tolerance
+
+    @pytest.mark.asyncio
+    async def test_delay_0_does_not_force_sequential(self, mock_scraper):
+        """delay=0 does not force concurrency to 1."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(
+            max_pages=3,
+            max_depth=1,
+            max_concurrency=5,
+            delay=0.0,
+        )
+        engine = CrawlEngine(mock_scraper, store=None, options=options)
+
+        # With delay=0.0, concurrency should NOT be forced to 1
+        assert engine._effective_concurrency == 5
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 3
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_delay_none_does_not_force_sequential(self, mock_scraper):
+        """delay=None does not force concurrency to 1."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(
+            max_pages=3,
+            max_depth=1,
+            max_concurrency=5,
+            delay=None,
+        )
+        engine = CrawlEngine(mock_scraper, store=None, options=options)
+
+        # With delay=None, concurrency should NOT be forced to 1
+        assert engine._effective_concurrency == 5
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 3
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_concurrency_capped_at_50(self, mock_scraper):
+        """max_concurrency is capped at 50 even if user requests higher."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(max_concurrency=999)
+        engine = CrawlEngine(mock_scraper, store=None, options=options)
+
+        assert engine._effective_concurrency == 50
+
+    @pytest.mark.asyncio
+    async def test_concurrency_capped_at_50_from_init(self, mock_scraper):
+        """_resolve_concurrency caps at MAX_CONCURRENCY_CAP."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(max_concurrency=100)
+        engine = CrawlEngine(mock_scraper, store=None, options=options)
+
+        assert engine._resolve_concurrency() == 50
+
+    @pytest.mark.asyncio
+    async def test_concurrency_normal_value_not_capped(self, mock_scraper):
+        """Normal max_concurrency values are not capped."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        options = CrawlOptions(max_concurrency=5)
+        engine = CrawlEngine(mock_scraper, store=None, options=options)
+
+        assert engine._resolve_concurrency() == 5
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_delay_sleep(self, mock_scraper):
+        """Cancellation during delay sleep interrupts the sleep promptly."""
+        import asyncio as _asyncio
+
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=1,
+                delay=10.0,  # Long delay
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            # Cancel from a background task after a short delay
+            async def _delayed_cancel():
+                await _asyncio.sleep(0.05)
+                engine.cancel()
+
+            cancel_task = _asyncio.create_task(_delayed_cancel())
+            start = time.monotonic()
+            await engine.run("http://example.com/")
+            elapsed = time.monotonic() - start
+            await cancel_task
+
+        # Should have cancelled promptly without waiting for the 10s delay
+        assert elapsed < 5.0  # Should not wait for 10s delay
+        # The crawl may have 0 or more pages depending on timing of cancellation
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_scrape_calls_under_concurrency(self, mock_scraper):
+        """No duplicate scrape calls for the same URL under concurrency."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        scraped_urls = []
+
+        async def scrape_and_track(url: str, force_browser: bool = False) -> dict:
+            scraped_urls.append(url)
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_and_track)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=1,
+                max_concurrency=3,
+            ),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                <a href="http://example.com/page3">Page 3</a>
+                <a href="http://example.com/page1">Page 1 dup</a>
+                <a href="http://example.com/page1#section">Page 1 fragment</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + page1 + page2 + page3 = 4 (page1 appears multiple times
+        # in links but should only be scraped once)
+        assert result.completed == 4
+        assert len(scraped_urls) == len(set(scraped_urls)), (
+            f"Duplicate scrape calls: {scraped_urls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_scrape_failure_does_not_abort_others(self, mock_scraper):
+        """A failing concurrent scrape does not abort other scrapes."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=4,
+                max_depth=1,
+                max_concurrency=3,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            if "fail" in url:
+                return MockPage.failure(url, "Connection error")
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good1">Good 1</a>
+                <a href="http://example.com/fail">Fail</a>
+                <a href="http://example.com/good2">Good 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + good1 + good2 = 3 successful, 1 error
+        assert result.completed == 3
+        assert len(result.pages) == 3
+        assert len(result.errors) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_crawl_with_empty_site(self, mock_scraper):
+        """Concurrent crawl of an empty site completes normally."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                max_concurrency=5,
+            ),
+        )
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert len(result.pages) == 1
+
+
+# ── CrawlRequest concurrency validation tests ───────────────────
+
+
+class TestCrawlRequestConcurrencyValidation:
+    """Tests for CrawlRequest max_concurrency and delay validation."""
+
+    def test_max_concurrency_default(self):
+        """max_concurrency defaults to 3."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.max_concurrency == 3
+
+    def test_max_concurrency_valid_value(self):
+        """max_concurrency >= 1 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_concurrency=5)
+        assert req.max_concurrency == 5
+
+        req2 = CrawlRequest(url="http://example.com", max_concurrency=1)
+        assert req2.max_concurrency == 1
+
+    def test_max_concurrency_zero_rejected(self):
+        """max_concurrency=0 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_concurrency"):
+            CrawlRequest(url="http://example.com", max_concurrency=0)
+
+    def test_max_concurrency_negative_rejected(self):
+        """max_concurrency=-1 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_concurrency"):
+            CrawlRequest(url="http://example.com", max_concurrency=-1)
+
+    def test_max_concurrency_capped_at_50_by_validator(self):
+        """max_concurrency values > 50 are clamped to 50."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_concurrency=100)
+        assert req.max_concurrency == 50
+
+        req2 = CrawlRequest(url="http://example.com", max_concurrency=51)
+        assert req2.max_concurrency == 50
+
+    def test_delay_default_none(self):
+        """delay defaults to None."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.delay is None
+
+    def test_delay_valid_positive(self):
+        """Positive delay is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", delay=1.5)
+        assert req.delay == 1.5
+
+    def test_delay_zero_accepted(self):
+        """delay=0 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", delay=0)
+        assert req.delay == 0
+
+    def test_delay_negative_rejected(self):
+        """Negative delay raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="delay"):
+            CrawlRequest(url="http://example.com", delay=-1)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -270,8 +270,9 @@ def mock_scraper():
 
 @pytest.fixture
 def mock_store():
-    """Create a mock JobStore."""
+    """Create a mock JobStore with a mock Redis client."""
     store = MagicMock()
+    store.redis = MagicMock()
     store.complete_job = MagicMock()
     return store
 
@@ -728,8 +729,8 @@ class TestCrawlEngine:
         result = await engine.run("http://example.com/", job_id="test-job-123")
 
         assert result.completed == 1
-        # complete_job should have been called at least once (final update)
-        assert mock_store.complete_job.call_count >= 1
+        # redis.set should have been called at least once (final update)
+        assert mock_store.redis.set.call_count >= 1
 
     @pytest.mark.asyncio
     async def test_crawl_with_include_paths(self, mock_scraper):

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -3674,3 +3674,235 @@ class TestCrawlRequestPoliteness:
         req = CrawlRequest(url="http://example.com")
         assert req.ignore_robots_txt is False
         assert req.robots_user_agent is None
+
+
+class TestScrapeOptionsModel:
+    """Unit tests for the ScrapeOptions Pydantic model.
+
+    Covers:
+    - Default values
+    - All fields accept and return correct types
+    - Invalid formats produce validation error
+    - Negative/zero timeout produces validation error
+    - Negative wait_for produces validation error
+    - CamelCase input via populate_by_name
+    - model_dump(by_alias=True) produces camelCase keys
+    - CrawlRequest accepts optional scrape_options
+    - model_dump produces dict suitable for JSON serialization
+    """
+
+    def test_defaults(self):
+        """ScrapeOptions default values match Firecrawl defaults."""
+        from agent.models import ScrapeOptions
+
+        opts = ScrapeOptions()
+        assert opts.formats == ["markdown"]
+        assert opts.only_main_content is True
+        assert opts.include_tags is None
+        assert opts.exclude_tags is None
+        assert opts.wait_for is None
+        assert opts.mobile is False
+        assert opts.timeout == 30000
+        assert opts.headers is None
+        assert opts.remove_base64_images is False
+
+    def test_all_fields_custom(self):
+        """All ScrapeOptions fields accept custom values."""
+        from agent.models import ScrapeOptions
+
+        opts = ScrapeOptions(
+            formats=["markdown", "html", "links"],
+            only_main_content=False,
+            include_tags=["article", "p"],
+            exclude_tags=[".nav", "footer"],
+            wait_for=1000,
+            mobile=True,
+            timeout=30000,
+            headers={"Authorization": "Bearer test"},
+            remove_base64_images=True,
+        )
+        assert opts.formats == ["markdown", "html", "links"]
+        assert opts.only_main_content is False
+        assert opts.include_tags == ["article", "p"]
+        assert opts.exclude_tags == [".nav", "footer"]
+        assert opts.wait_for == 1000
+        assert opts.mobile is True
+        assert opts.timeout == 30000
+        assert opts.headers == {"Authorization": "Bearer test"}
+        assert opts.remove_base64_images is True
+
+    def test_invalid_format_raises_error(self):
+        """Invalid format name in formats list raises ValidationError."""
+        import pytest
+        from agent.models import ScrapeOptions
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ScrapeOptions(formats=["invalid_format"])
+
+    def test_negative_timeout_raises_error(self):
+        """Negative timeout value raises ValidationError."""
+        import pytest
+        from agent.models import ScrapeOptions
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ScrapeOptions(timeout=-1)
+
+    def test_zero_timeout_raises_error(self):
+        """Timeout of 0 raises ValidationError (minimum is 1000ms)."""
+        import pytest
+        from agent.models import ScrapeOptions
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ScrapeOptions(timeout=0)
+
+    def test_negative_wait_for_raises_error(self):
+        """Negative wait_for raises ValidationError."""
+        import pytest
+        from agent.models import ScrapeOptions
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ScrapeOptions(wait_for=-100)
+
+    def test_camelcase_input_accepted(self):
+        """CamelCase field names are accepted (populate_by_name)."""
+        from agent.models import ScrapeOptions
+
+        opts = ScrapeOptions(
+            **{
+                "formats": ["html"],
+                "onlyMainContent": False,
+                "includeTags": ["h1"],
+                "excludeTags": [".nav"],
+                "waitFor": 2000,
+                "mobile": True,
+                "timeout": 15000,
+                "headers": {"X-Custom": "val"},
+                "removeBase64Images": True,
+            }
+        )
+        assert opts.formats == ["html"]
+        assert opts.only_main_content is False
+        assert opts.include_tags == ["h1"]
+        assert opts.exclude_tags == [".nav"]
+        assert opts.wait_for == 2000
+        assert opts.mobile is True
+        assert opts.timeout == 15000
+        assert opts.headers == {"X-Custom": "val"}
+        assert opts.remove_base64_images is True
+
+    def test_model_dump_by_alias_produces_camelcase(self):
+        """model_dump(by_alias=True) produces camelCase keys."""
+        from agent.models import ScrapeOptions
+
+        opts = ScrapeOptions(
+            formats=["markdown"],
+            only_main_content=True,
+            include_tags=["article"],
+            exclude_tags=[".nav"],
+            wait_for=500,
+            mobile=False,
+            timeout=20000,
+            headers={"X-Test": "value"},
+            remove_base64_images=True,
+        )
+        dumped = opts.model_dump(mode="json", by_alias=True)
+        assert dumped["formats"] == ["markdown"]
+        assert dumped["onlyMainContent"] is True
+        assert dumped["includeTags"] == ["article"]
+        assert dumped["excludeTags"] == [".nav"]
+        assert dumped["waitFor"] == 500
+        assert dumped["mobile"] is False
+        assert dumped["timeout"] == 20000
+        assert dumped["headers"] == {"X-Test": "value"}
+        assert dumped["removeBase64Images"] is True
+        # snake_case keys should not appear
+        assert "only_main_content" not in dumped
+
+    def test_crawl_request_accepts_scrape_options(self):
+        """CrawlRequest accepts optional scrape_options field."""
+        from agent.models import CrawlRequest, ScrapeOptions
+
+        req = CrawlRequest(
+            url="http://example.com",
+            scrape_options=ScrapeOptions(formats=["links"], only_main_content=False),
+        )
+        assert req.scrape_options is not None
+        assert req.scrape_options.formats == ["links"]
+        assert req.scrape_options.only_main_content is False
+
+    def test_crawl_request_without_scrape_options(self):
+        """CrawlRequest without scrape_options defaults to None."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.scrape_options is None
+
+    def test_model_dump_json_serializable(self):
+        """model_dump(mode='json') produces JSON-serializable dict."""
+        import json
+
+        from agent.models import ScrapeOptions
+
+        opts = ScrapeOptions(
+            formats=["markdown", "html"],
+            only_main_content=False,
+            include_tags=["article", "p"],
+            exclude_tags=[".nav"],
+            wait_for=1000,
+            mobile=True,
+            timeout=30000,
+            headers={"Authorization": "Bearer test123"},
+            remove_base64_images=True,
+        )
+        dumped = opts.model_dump(mode="json")
+        # Should be JSON-serializable
+        json_str = json.dumps(dumped)
+        parsed = json.loads(json_str)
+        assert parsed["formats"] == ["markdown", "html"]
+        assert parsed["only_main_content"] is False
+        assert parsed["include_tags"] == ["article", "p"]
+        assert parsed["exclude_tags"] == [".nav"]
+        assert parsed["wait_for"] == 1000
+        assert parsed["mobile"] is True
+        assert parsed["timeout"] == 30000
+        assert parsed["headers"] == {"Authorization": "Bearer test123"}
+        assert parsed["remove_base64_images"] is True
+
+    def test_empty_formats_rejected(self):
+        """Empty formats list is rejected by validator."""
+        import pytest
+        from agent.models import ScrapeOptions
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ScrapeOptions(formats=[])
+
+    def test_valid_formats_enum(self):
+        """VAL_SCRAPE_FORMATS contains expected values."""
+        from agent.models import VALID_SCRAPE_FORMATS
+
+        assert "markdown" in VALID_SCRAPE_FORMATS
+        assert "html" in VALID_SCRAPE_FORMATS
+        assert "links" in VALID_SCRAPE_FORMATS
+        assert "screenshot" in VALID_SCRAPE_FORMATS
+        assert "rawHtml" in VALID_SCRAPE_FORMATS
+
+    def test_none_fields_in_model_dump(self):
+        """None fields like wait_for are not dropped in model_dump."""
+        from agent.models import ScrapeOptions
+
+        opts = ScrapeOptions()
+        dumped = opts.model_dump(mode="json")
+        # wait_for is None by default, should be present
+        assert "wait_for" in dumped
+        assert dumped["wait_for"] is None
+        assert "include_tags" in dumped
+        assert dumped["include_tags"] is None
+        assert "exclude_tags" in dumped
+        assert dumped["exclude_tags"] is None
+        assert "headers" in dumped
+        assert dumped["headers"] is None

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
+from fastapi.testclient import TestClient
 
 # ── normalize_url tests ──────────────────────────────────────────
 
@@ -4691,3 +4693,216 @@ class TestCrawlEngineCache:
         mock_scraper.scrape.assert_called_once()
         assert result.completed == 1
         assert "# Freshly Scraped Content" in result.pages[0].get("markdown", "")
+
+
+# ── GET /v2/crawl/active endpoint tests ──────────────────────────
+
+
+class _MockJobMeta:
+    """Helper to create a mock job metadata dict for store.list_active_jobs()."""
+
+    @staticmethod
+    def crawl(
+        job_id: str,
+        status: str = "processing",
+        url: str = "http://example.com",
+        max_pages: int = 10,
+        max_depth: int = 2,
+        completed: int = 0,
+        total: int = 10,
+    ) -> dict:
+        return {
+            "id": job_id,
+            "kind": "crawl",
+            "status": status,
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "expires_at": "2025-01-02T00:00:00+00:00",
+            "payload": {
+                "url": url,
+                "max_pages": max_pages,
+                "max_depth": max_depth,
+            },
+            "data": {
+                "completed": completed,
+                "total": total,
+                "pages": [],
+                "errors": [],
+            },
+        }
+
+    @staticmethod
+    def agent() -> dict:
+        return {
+            "id": str(uuid4()),
+            "kind": "agent",
+            "status": "processing",
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "payload": {"prompt": "research something"},
+        }
+
+    @staticmethod
+    def extract() -> dict:
+        return {
+            "id": str(uuid4()),
+            "kind": "extract",
+            "status": "processing",
+            "created_at": "2025-01-01T00:00:00+00:00",
+            "payload": {"urls": ["http://example.com"]},
+        }
+
+
+@pytest.fixture
+def active_crawl_app():
+    """Build a FastAPI test app with a mocked JobStore.
+
+    The store's ``list_active_jobs()`` is pre-configured to return
+    a known set of jobs. Tests can override ``app.state.job_store``
+    after calling the fixture.
+    """
+    from agent.api import router
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(router)
+
+    app.state.job_store = MagicMock()
+    app.state.job_store.list_active_jobs.return_value = []
+
+    with TestClient(app) as client:
+        yield client
+
+
+class TestListActiveCrawls:
+    """Unit tests for GET /v2/crawl/active."""
+
+    def test_returns_only_crawl_jobs(self, active_crawl_app):
+        """VAL-SCRAPE-041: Only returns jobs with kind='crawl'.
+
+        The JobStore.list_active_jobs() is responsible for filtering by
+        kind. This test verifies that the API endpoint correctly passes
+        ``kind="crawl"`` to the store so that non-crawl jobs are never
+        returned.
+        """
+        client = active_crawl_app
+
+        crawl_id = str(uuid4())
+
+        # Mock returns only crawl jobs (as if store already filtered by kind)
+        client.app.state.job_store.list_active_jobs.return_value = [
+            _MockJobMeta.crawl(crawl_id),
+        ]
+
+        resp = client.get("/v2/crawl/active")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert len(data["data"]) == 1
+        assert data["data"][0]["id"] == crawl_id
+
+        # Verify the store was called with kind="crawl"
+        client.app.state.job_store.list_active_jobs.assert_called_with(
+            kind="crawl", status="processing", limit=50
+        )
+
+    def test_excludes_completed_crawls(self, active_crawl_app):
+        """VAL-SCRAPE-042: Completed/failed/cancelled crawls are excluded."""
+        client = active_crawl_app
+
+        processing_id = str(uuid4())
+        completed_id = str(uuid4())
+        failed_id = str(uuid4())
+        cancelled_id = str(uuid4())
+
+        # Only return the processing job (simulating kind="crawl", status="processing" filter)
+        client.app.state.job_store.list_active_jobs.return_value = [
+            _MockJobMeta.crawl(processing_id, status="processing"),
+        ]
+
+        resp = client.get("/v2/crawl/active")
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = [item["id"] for item in data["data"]]
+        assert processing_id in ids, "Processing crawl should be present"
+        assert completed_id not in ids, "Completed crawl should be excluded"
+        assert failed_id not in ids, "Failed crawl should be excluded"
+        assert cancelled_id not in ids, "Cancelled crawl should be excluded"
+
+        # Verify that list_active_jobs was called with kind="crawl" and status="processing"
+        client.app.state.job_store.list_active_jobs.assert_called_with(
+            kind="crawl", status="processing", limit=50
+        )
+
+    def test_response_structure(self, active_crawl_app):
+        """VAL-SCRAPE-043: Response has correct structure with all required fields."""
+        client = active_crawl_app
+
+        crawl_id = str(uuid4())
+        client.app.state.job_store.list_active_jobs.return_value = [
+            _MockJobMeta.crawl(
+                crawl_id,
+                url="http://test-site:8000",
+                max_pages=5,
+                max_depth=1,
+                completed=3,
+                total=5,
+            ),
+        ]
+
+        resp = client.get("/v2/crawl/active")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert "data" in body
+        assert len(body["data"]) == 1
+
+        item = body["data"][0]
+        assert item["id"] == crawl_id
+        assert item["url"] == "http://test-site:8000"
+        assert item["status"] == "processing"
+        assert item["created_at"] == "2025-01-01T00:00:00+00:00"
+        assert item["completed"] == 3
+        assert item["total"] == 5
+        assert item["max_pages"] == 5
+        assert item["max_depth"] == 1
+
+    def test_empty_when_no_active_crawls(self, active_crawl_app):
+        """VAL-SCRAPE-044: Returns empty data array when no active crawls."""
+        client = active_crawl_app
+        # Store returns no crawl jobs
+        client.app.state.job_store.list_active_jobs.return_value = []
+
+        resp = client.get("/v2/crawl/active")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"] == []
+
+    def test_filterable_by_status(self, active_crawl_app):
+        """Supports optional status query parameter to filter by status."""
+        client = active_crawl_app
+
+        client.app.state.job_store.list_active_jobs.return_value = []
+
+        resp = client.get("/v2/crawl/active?status=completed")
+        assert resp.status_code == 200
+
+        # Verify status was passed through to the store
+        client.app.state.job_store.list_active_jobs.assert_called_with(
+            kind="crawl", status="completed", limit=50
+        )
+
+    def test_does_not_show_agent_or_extract_jobs_thorough(self, active_crawl_app):
+        """More thorough check: no agent/extract/llmstxt jobs appear."""
+        client = active_crawl_app
+
+        client.app.state.job_store.list_active_jobs.return_value = [
+            _MockJobMeta.crawl(str(uuid4())),
+        ]
+
+        resp = client.get("/v2/crawl/active")
+        assert resp.status_code == 200
+
+        # Verify list_active_jobs was called with kind="crawl"
+        client.app.state.job_store.list_active_jobs.assert_called_with(
+            kind="crawl", status="processing", limit=50
+        )

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,921 @@
+"""Unit tests for the CrawlEngine in agent-svc/agent/crawler.py.
+
+Covers:
+- URL normalization (fragments, trailing slash, ignore_query_parameters)
+- Path filtering (glob and regex)
+- Glob-to-regex conversion
+- CrawlEngine BFS traversal
+- max_pages and max_depth enforcement
+- URL dedup within a crawl run
+- Start URL failure handling
+- Child page error handling
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── normalize_url tests ──────────────────────────────────────────
+
+
+class TestNormalizeUrl:
+    """Tests for the ``normalize_url()`` function."""
+
+    def test_strips_fragment(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com/page#section")
+            == "https://example.com/page"
+        )
+
+    def test_lowercases_scheme(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("HTTPS://EXAMPLE.COM/PAGE") == "https://example.com/PAGE"
+
+    def test_lowercases_host(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("https://Example.COM/Page") == "https://example.com/Page"
+
+    def test_removes_default_http_port(self):
+        from agent.crawler import normalize_url
+
+        assert normalize_url("http://example.com:80/page") == "http://example.com/page"
+
+    def test_removes_default_https_port(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com:443/page") == "https://example.com/page"
+        )
+
+    def test_keeps_non_default_port(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com:8080/page")
+            == "https://example.com:8080/page"
+        )
+
+    def test_normalizes_trailing_slash(self):
+        from agent.crawler import normalize_url
+
+        # Non-root paths with trailing slash -> no trailing slash
+        assert normalize_url("https://example.com/page/") == "https://example.com/page"
+        assert normalize_url("https://example.com/page") == "https://example.com/page"
+
+    def test_keeps_root_slash(self):
+        from agent.crawler import normalize_url
+
+        # Root path / should stay as /
+        assert normalize_url("https://example.com/") == "https://example.com/"
+
+    def test_normalizes_dot_path(self):
+        from agent.crawler import normalize_url
+
+        # /. should collapse to /
+        assert normalize_url("https://example.com/.") == "https://example.com/"
+        assert normalize_url("https://example.com/a/./b") == "https://example.com/a/b"
+
+    def test_ignore_query_parameters_strips_query(self):
+        from agent.crawler import normalize_url
+
+        result = normalize_url(
+            "https://example.com/page?a=1&b=2", ignore_query_parameters=True
+        )
+        assert result == "https://example.com/page"
+
+    def test_ignore_query_parameters_default_false_keeps_query(self):
+        from agent.crawler import normalize_url
+
+        result = normalize_url("https://example.com/page?a=1&b=2")
+        assert "a=1" in result
+        assert "b=2" in result
+
+    def test_sorts_query_parameters(self):
+        from agent.crawler import normalize_url
+
+        # Different order but same params -> same result
+        r1 = normalize_url("https://example.com/page?b=2&a=1")
+        r2 = normalize_url("https://example.com/page?a=1&b=2")
+        assert r1 == r2
+        assert "a=1" in r1
+        assert "b=2" in r1
+
+    def test_fragment_and_query_stripped_together(self):
+        from agent.crawler import normalize_url
+
+        assert (
+            normalize_url("https://example.com/page?a=1#section")
+            == "https://example.com/page?a=1"
+        )
+
+
+# ── Glob-to-regex tests ──────────────────────────────────────────
+
+
+class TestGlobToRegex:
+    """Tests for the ``_glob_to_regex()`` helper."""
+
+    def test_literal_string(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/about")
+        assert re.search(pattern, "/about")
+        assert not re.search(pattern, "/aboutus")
+
+    def test_single_star(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/section/*")
+        assert re.search(pattern, "/section/page-1")
+        assert re.search(pattern, "/section/foo")
+        assert not re.search(pattern, "/section/sub/page")
+
+    def test_double_star(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/section/**")
+        assert re.search(pattern, "/section/page-1")
+        assert re.search(pattern, "/section/sub/page")
+        assert not re.search(pattern, "/other")
+
+    def test_question_mark(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/page-?")
+        assert re.search(pattern, "/page-1")
+        assert re.search(pattern, "/page-a")
+        assert not re.search(pattern, "/page-12")
+
+    def test_special_chars_escaped(self):
+        import re
+
+        from agent.crawler import _glob_to_regex
+
+        pattern = _glob_to_regex("/file.html")
+        assert re.search(pattern, "/file.html")
+        assert not re.search(pattern, "/fileXhtml")
+
+
+# ── Path matching tests ─────────────────────────────────────────
+
+
+class TestMatchPath:
+    """Tests for the ``_match_path()`` function."""
+
+    def test_no_filters_passes(self):
+        from agent.crawler import _match_path
+
+        assert _match_path("https://example.com/page", None, None) is True
+
+    def test_include_paths_matches(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-1",
+                ["/section/*"],
+                None,
+            )
+            is True
+        )
+
+    def test_include_paths_no_match(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/about",
+                ["/section/*"],
+                None,
+            )
+            is False
+        )
+
+    def test_exclude_paths_excludes(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/admin/secret",
+                None,
+                ["/admin/*"],
+            )
+            is False
+        )
+
+    def test_exclude_overrides_include(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-2",
+                ["/section/*"],
+                ["/section/page-2"],
+            )
+            is False
+        )
+
+    def test_regex_mode_on_full_url(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-1?ref=abc",
+                ["section/page-[12]"],
+                None,
+                regex_on_full_url=True,
+            )
+            is True
+        )
+
+    def test_regex_mode_no_match(self):
+        from agent.crawler import _match_path
+
+        assert (
+            _match_path(
+                "https://example.com/section/page-3",
+                ["section/page-[12]"],
+                None,
+                regex_on_full_url=True,
+            )
+            is False
+        )
+
+
+# ── CrawlEngine tests ────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_scraper():
+    """Create a mock ScraperClient that returns successful results."""
+    client = MagicMock()
+    client.scrape = AsyncMock()
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def mock_store():
+    """Create a mock JobStore."""
+    store = MagicMock()
+    store.complete_job = MagicMock()
+    return store
+
+
+class MockPage:
+    """Helper to create a mock scrape result for a given URL."""
+
+    @staticmethod
+    def success(
+        url: str, markdown: str = "# Page Content", html: str | None = None
+    ) -> dict:
+        return {
+            "success": True,
+            "data": {
+                "markdown": markdown,
+                "source": "playwright",
+                "metadata": {"title": "Test Page"},
+            },
+        }
+
+    @staticmethod
+    def failure(url: str, error: str = "Scrape failed") -> dict:
+        return {"success": False, "error": error}
+
+
+class TestCrawlEngine:
+    """Tests for the CrawlEngine BFS crawl loop."""
+
+    @pytest.mark.asyncio
+    async def test_single_page_crawl(self, mock_scraper, mock_store):
+        """A crawl with max_pages=1 returns just the start URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape.return_value = MockPage.success("http://example.com/")
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.total >= 1
+        assert len(result.pages) == 1
+        assert result.pages[0]["url"] == "http://example.com/"
+        assert result.errors == []
+
+    @pytest.mark.asyncio
+    async def test_max_pages_enforcement(self, mock_scraper):
+        """Crawl stops after max_pages pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Mock scraper to always succeed
+        mock_scraper.scrape.return_value = MockPage.success("http://example.com/page")
+        mock_scraper.scrape.side_effect = None  # reset
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=3, max_depth=2),
+        )
+
+        # We need a link-rich start page. Mock the HTML fetch too.
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="/page1">Page 1</a>
+                <a href="/page2">Page 2</a>
+                <a href="/page3">Page 3</a>
+                </body></html>
+            """
+
+            # Set up scraper to return appropriate markdown per URL
+            async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+                return MockPage.success(url, f"# Content of {url}")
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 3
+        assert len(result.pages) == 3
+        # Should have the start URL and 2 children (due to max_pages=3)
+
+    @pytest.mark.asyncio
+    async def test_max_depth_0(self, mock_scraper):
+        """max_depth=0 scrapes only the start URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=0),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="/pricing">Pricing</a>
+                <a href="/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert len(result.pages) == 1
+        assert result.pages[0]["url"] == "http://example.com/"
+
+    @pytest.mark.asyncio
+    async def test_max_depth_1(self, mock_scraper):
+        """max_depth=1 scrapes start URL and direct children."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/contact">Contact</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + 3 children = 4 pages
+        assert result.completed == 4
+        assert len(result.pages) == 4
+
+        # Verify BFS order: start URL first, then children
+        assert result.pages[0]["url"] == "http://example.com/"
+
+    @pytest.mark.asyncio
+    async def test_url_dedup(self, mock_scraper):
+        """No duplicate URLs within a single crawl run."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Start page has duplicate links to the same page
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/pricing">Pricing (again)</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/pricing#section">Pricing with fragment</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + pricing + about = 3 unique pages
+        # (pricing appears 3 times in links but should be scraped once)
+        urls = [p["url"] for p in result.pages]
+        assert len(urls) == len(set(urls)), f"Duplicate URLs found: {urls}"
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_fragment_stripped_dedup(self, mock_scraper):
+        """Links /page#a and /page#b normalize to same URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/about#section1">About 1</a>
+                <a href="http://example.com/about#section2">About 2</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + about = 2 pages (fragments collapsed)
+        assert result.completed == 2
+        about_pages = [p for p in result.pages if "about" in p["url"]]
+        assert len(about_pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_normalization(self, mock_scraper):
+        """/pricing and /pricing/ are treated as the same URL."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/pricing/">Pricing with slash</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should have start URL + pricing = 2 pages (trailing slash collapsed)
+        assert result.completed == 2
+        pricing_pages = [p for p in result.pages if "pricing" in p["url"]]
+        assert len(pricing_pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_ignore_query_parameters_collapses_variants(self, mock_scraper):
+        """When ignore_query_parameters=True, query variants collapse."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                ignore_query_parameters=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page?a=1">Page a=1</a>
+                <a href="http://example.com/page?b=2">Page b=2</a>
+                <a href="http://example.com/page">Page no query</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # With ignore_query_parameters, /page?a=1, /page?b=2, /page all collapse
+        # to /page. So we should have start URL + page = 2 pages
+        assert result.completed == 2
+        page_entries = [p for p in result.pages if "page" in p["url"]]
+        assert len(page_entries) == 1
+
+    @pytest.mark.asyncio
+    async def test_child_scrape_failure_collected(self, mock_scraper):
+        """Child page scrape failures are collected, not fatal."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            if "fail" in url:
+                return MockPage.failure(url, "Connection refused")
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good">Good page</a>
+                <a href="http://example.com/fail">Failing page</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + good page = 2 successful scrapes
+        assert result.completed == 2
+        assert len(result.pages) == 2
+        # One error for the failing page
+        assert len(result.errors) == 1
+        assert "fail" in result.errors[0]["url"]
+        assert result.errors[0]["error"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_start_url_failure_returns_immediately(self, mock_scraper):
+        """Start URL failure returns error immediately."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.failure("http://example.com/", "Connection refused")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert result.pages == []
+        assert len(result.errors) == 1
+        assert result.errors[0]["url"] == "http://example.com/"
+        assert result.errors[0]["error"] == "Connection refused"
+
+    @pytest.mark.asyncio
+    async def test_bfs_order(self, mock_scraper):
+        """Pages appear in BFS order: start URL, then depth-1, then depth-2."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Track which HTML is returned for each URL to simulate link structure
+        html_responses = {
+            "http://example.com/": """
+                <html><body>
+                <a href="http://example.com/child-a">Child A</a>
+                <a href="http://example.com/child-b">Child B</a>
+                </body></html>
+            """,
+            "http://example.com/child-a": """
+                <html><body>
+                <a href="http://example.com/grandchild">Grandchild</a>
+                </body></html>
+            """,
+            "http://example.com/child-b": """
+                <html><body>
+                <p>No links here</p>
+                </body></html>
+            """,
+        }
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.side_effect = lambda url: html_responses.get(url)
+
+            result = await engine.run("http://example.com/")
+
+        # Expected BFS order:
+        # [start, child-a, child-b, grandchild]
+        assert len(result.pages) == 4
+        assert result.pages[0]["url"] == "http://example.com/"
+        assert result.pages[1]["url"] == "http://example.com/child-a"
+        assert result.pages[2]["url"] == "http://example.com/child-b"
+        assert result.pages[3]["url"] == "http://example.com/grandchild"
+
+    @pytest.mark.asyncio
+    async def test_empty_site_no_links(self, mock_scraper):
+        """A page with no outgoing links returns only the start page."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", "No links here")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert len(result.pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_pages_larger_than_available(self, mock_scraper):
+        """When max_pages > available pages, crawl completes when queue is empty."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", "Just one page")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=100, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_job_store_updates(self, mock_scraper, mock_store):
+        """Job store is updated with progress during crawl."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+        # Use short update interval for testing
+        engine._update_interval = 0.01
+
+        result = await engine.run("http://example.com/", job_id="test-job-123")
+
+        assert result.completed == 1
+        # complete_job should have been called at least once (final update)
+        assert mock_store.complete_job.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_include_paths(self, mock_scraper):
+        """Only URLs matching include_paths are crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/section/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Section 1</a>
+                <a href="http://example.com/section/page-2">Section 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL doesn't match /section/*, so only section pages are crawled
+        # But start URL is included since include_paths only filters child discovery
+        # actually... wait, let me re-examine the logic.
+
+        # The current code checks self._should_crawl before scraping, which
+        # includes a call to _match_path. But the start URL is the first URL
+        # and should also be checked against include_paths.
+
+        # Looking at the architecture.md:
+        # "Path filters apply to all URLs including the start URL — if start URL
+        # doesn't match include_paths, crawl returns 0 pages"
+
+        # Wait, but my current implementation checks _match_path AFTER adding to seen
+        # but BEFORE scraping... Actually, looking at my crawl loop:
+
+        # 1. Pop from queue
+        # 2. Normalize
+        # 3. Check dedup - skip if seen
+        # 4. Check max_depth - skip if too deep (but depth=0 is fine)
+        # 5. Add to seen
+        # 6. Check path filters - if not match, continue
+        # 7. Scrape
+        # 8. Extract links if depth < max_depth
+
+        # So the start URL IS checked against include_paths. If it doesn't match,
+        # it's skipped. That means the start URL would need to match include_paths
+        # to be crawled.
+
+        # For this test, let's check that "/section/*" doesn't match "/about"
+        about_pages = [p for p in result.pages if "about" in p["url"]]
+        assert len(about_pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_exclude_paths(self, mock_scraper):
+        """URLs matching exclude_paths are skipped."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=["/admin/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                <a href="http://example.com/admin/secret">Admin</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL + pricing + about = 3 pages, admin excluded
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/admin/secret" not in urls
+        assert len(result.pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_markdown_handled_gracefully(self, mock_scraper):
+        """A page with empty markdown is still included."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/", markdown="")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=2),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 1
+        assert result.pages[0]["markdown"] == ""
+
+    @pytest.mark.asyncio
+    async def test_cancel_flag_stops_crawl(self, mock_scraper):
+        """Setting cancel flag stops the crawl loop."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+
+            # Cancel after the first page is scraped
+            original_scrape = mock_scraper.scrape
+
+            async def scrape_with_cancel(url: str, force_browser: bool = False) -> dict:
+                result = await original_scrape(url, force_browser)
+                engine.cancel()
+                return result
+
+            mock_scraper.scrape = AsyncMock(side_effect=scrape_with_cancel)
+
+            result = await engine.run("http://example.com/")
+
+        # Should have at least 1 page (start URL was scraped before cancel)
+        assert result.completed >= 1
+
+    @pytest.mark.asyncio
+    async def test_crawl_with_self_referencing_links(self, mock_scraper):
+        """Self-referencing links don't cause infinite loops."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=2),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            # Page links to itself and to a child
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/">Self link</a>
+                <a href="http://example.com/.">Self link dot</a>
+                <a href="http://example.com/page1">Page 1</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Should complete without infinite loop
+        # Start URL + page1 = 2 pages
+        assert result.completed == 2

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1555,6 +1555,43 @@ class TestCrawlRequestValidation:
         req = CrawlRequest(url="http://example.com")
         assert req.max_pages == 10
 
+    def test_sitemap_default_is_include(self):
+        """Default sitemap mode is 'include'."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.sitemap == "include"
+
+    def test_sitemap_skip_accepted(self):
+        """sitemap='skip' is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", sitemap="skip")
+        assert req.sitemap == "skip"
+
+    def test_sitemap_only_accepted(self):
+        """sitemap='only' is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", sitemap="only")
+        assert req.sitemap == "only"
+
+    def test_sitemap_invalid_rejected(self):
+        """Invalid sitemap mode returns validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="sitemap"):
+            CrawlRequest(url="http://example.com", sitemap="banana")
+
+    def test_ignore_sitemap_true_maps_to_skip(self):
+        """ignore_sitemap=true maps to sitemap='skip' for backward compatibility."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", ignore_sitemap=True)
+        assert req.sitemap == "skip"
+        assert req.ignore_sitemap is True
+
 
 # ── Store tests ──────────────────────────────────────────────────
 
@@ -1706,3 +1743,292 @@ class TestPerPageMetadata:
         assert page["content_type"] == "text/html"  # default
         assert page["scraped_at"] is not None
         assert isinstance(page["duration_ms"], int)
+
+
+# ── Sitemap integration tests ────────────────────────────────────
+
+
+class TestCrawlEngineSitemap:
+    """Tests for sitemap integration in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_sitemap_include_seeds_urls(self, mock_scraper):
+        """sitemap_mode='include' seeds sitemap URLs into the BFS queue."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Mock sitemap fetch to return some URLs
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+            ]
+
+            # Mock HTML fetch to simulate no HTML link discovery
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """<html><body><p>No links</p></body></html>"""
+
+                result = await engine.run("http://example.com/")
+
+        # Should have start URL + 2 sitemap URLs = 3 pages
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/sitemap-page1" in urls
+        assert "http://example.com/sitemap-page2" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_skip_no_fetch(self, mock_scraper):
+        """sitemap_mode='skip' does NOT fetch sitemaps."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="skip",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    <a href="http://example.com/about">About</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+        # Should NOT have sitemap URLs
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/sitemap-page1" not in urls
+        assert "http://example.com/sitemap-page2" not in urls
+        # Should still discover HTML links
+        assert "http://example.com/pricing" in urls
+        assert "http://example.com/about" in urls
+        # _fetch_sitemap_urls should NOT have been called
+        mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sitemap_only_exclusive(self, mock_scraper):
+        """sitemap_mode='only' crawls exclusively sitemap URLs, no HTML link discovery."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                sitemap_mode="only",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-only-page1",
+                "http://example.com/sitemap-only-page2",
+            ]
+
+            with patch.object(engine, "_get_html"):
+                result = await engine.run("http://example.com/")
+
+        # Should have start URL + 2 sitemap URLs
+        assert result.completed == 3
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/sitemap-only-page1" in urls
+        assert "http://example.com/sitemap-only-page2" in urls
+        # No extra pages from HTML link discovery
+        assert len(urls) == 3
+
+    @pytest.mark.asyncio
+    async def test_sitemap_urls_respect_max_pages(self, mock_scraper):
+        """Sitemap URLs are counted toward max_pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=2,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+                "http://example.com/sitemap-page3",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """<html><body><p>No links</p></body></html>"""
+
+                result = await engine.run("http://example.com/")
+
+        # max_pages=2 should give us exactly 2 pages
+        assert result.completed == 2
+        assert len(result.pages) == 2
+
+    @pytest.mark.asyncio
+    async def test_sitemap_dedup_against_start_url(self, mock_scraper):
+        """Sitemap URLs that match the start URL are deduplicated."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            # Sitemap contains the start URL
+            mock_fetch.return_value = [
+                "http://example.com/",
+                "http://example.com/about",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """<html><body><p>No links</p></body></html>"""
+
+                result = await engine.run("http://example.com/")
+
+        # Should have start URL + about = 2 pages (start URL deduplicated)
+        assert result.completed == 2
+        urls = [p["url"] for p in result.pages]
+        assert len(urls) == 2
+        assert "http://example.com/" in urls
+        assert "http://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_fetch_failure_falls_back(self, mock_scraper):
+        """When sitemap fetch fails, crawl falls back to HTML-only discovery."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=2,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        # Simulate sitemap fetch failure
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.side_effect = Exception("Sitemap fetch failed")
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    <a href="http://example.com/about">About</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+        # Should fall back to HTML discovery
+        assert result.completed >= 2
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/pricing" in urls
+        assert "http://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_only_with_max_depth_zero(self, mock_scraper):
+        """sitemap='only' with max_depth=0 still scrapes sitemap URLs (they are depth 0)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=0,
+                sitemap_mode="include",
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_fetch_sitemap_urls") as mock_fetch:
+            mock_fetch.return_value = [
+                "http://example.com/sitemap-page1",
+                "http://example.com/sitemap-page2",
+            ]
+
+            with patch.object(engine, "_get_html") as mock_html:
+                mock_html.return_value = """
+                    <html><body>
+                    <a href="http://example.com/pricing">Pricing</a>
+                    </body></html>
+                """
+
+                result = await engine.run("http://example.com/")
+
+        # Should scrape start URL + sitemap URLs (all depth 0)
+        # But NOT follow HTML links (max_depth=0)
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/" in urls
+        assert "http://example.com/sitemap-page1" in urls
+        assert "http://example.com/sitemap-page2" in urls
+        assert "http://example.com/pricing" not in urls  # HTML link, not followed

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -751,8 +751,10 @@ class TestCrawlEngine:
         result = await engine.run("http://example.com/", job_id="test-job-123")
 
         assert result.completed == 1
-        # redis.set should have been called at least once (final update)
-        assert mock_store.redis.set.call_count >= 1
+        # update_job_progress should have been called at least once (final update)
+        assert mock_store.update_job_progress.call_count >= 1
+        # increment_completed should have been called once (for the start page)
+        assert mock_store.increment_completed.call_count >= 1
 
     @pytest.mark.asyncio
     async def test_crawl_with_include_paths(self, mock_scraper):
@@ -3178,7 +3180,233 @@ class TestCrawlConcurrency:
         assert len(result.pages) == 1
 
 
-# ── CrawlRequest concurrency validation tests ───────────────────
+# ── Timeout and semaphore slot release (VAL-CONC-043, VAL-CONC-051) ─
+
+
+class TestCrawlTimeoutAndErrors:
+    """Tests for per-scrape timeout, error accumulation, and error types."""
+
+    @pytest.mark.asyncio
+    async def test_scrape_timeout_recorded_in_errors(self, mock_scraper):
+        """A timed-out scrape is recorded in the errors list."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=2,
+                max_depth=0,
+                max_concurrency=1,
+            ),
+        )
+
+        async def slow_scrape(url: str, force_browser: bool = False, **kwargs) -> dict:
+            raise TimeoutError("timed out")
+
+        mock_scraper.scrape = AsyncMock(side_effect=slow_scrape)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = "<html><body><p>No links</p></body></html>"
+            # The start URL fails, so the crawl finishes early (StartUrlScrapeError)
+            # This is caught in run() and we return the result with the error
+            result = await engine.run("http://example.com/")
+
+        assert len(result.errors) >= 1
+
+    @pytest.mark.asyncio
+    async def test_error_code_distinction(self, mock_scraper):
+        """Errors have distinct error_code for scrape failure vs timeout vs blocked."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                max_concurrency=3,
+            ),
+        )
+
+        async def varied_scrape(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
+            if "/blocked" in url:
+                return {
+                    "success": False,
+                    "error": "Blocked by politeness: robots.txt disallows",
+                }
+            if "/fail" in url:
+                return {"success": False, "error": "HTTP 500 Internal Server Error"}
+            return MockPage.success(url)
+
+        mock_scraper.scrape = AsyncMock(side_effect=varied_scrape)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/blocked">Blocked</a>
+                <a href="http://example.com/fail">Fail</a>
+                <a href="http://example.com/good">Good</a>
+                </body></html>
+            """
+            result = await engine.run("http://example.com/")
+
+        blocked_errors = [e for e in result.errors if "/blocked" in e.get("url", "")]
+        fail_errors = [e for e in result.errors if "/fail" in e.get("url", "")]
+
+        for e in blocked_errors:
+            assert e.get("error_code") == "ROBOTS_BLOCKED", (
+                f"Expected ROBOTS_BLOCKED, got: {e}"
+            )
+        for e in fail_errors:
+            assert e.get("error_code") == "SCRAPE_ERROR", (
+                f"Expected SCRAPE_ERROR, got: {e}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_mixed_success_failure_blocked(self, mock_scraper):
+        """Crawl with a mix of successes, failures, and blocked URLs completes correctly."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                max_concurrency=3,
+            ),
+        )
+
+        async def mixed_scrape(url: str, **kwargs) -> dict:
+            if "/fail" in url:
+                return MockPage.failure(url, "Connection error")
+            if "/blocked" in url:
+                return {
+                    "success": False,
+                    "error": "Blocked by politeness: robots.txt disallows",
+                }
+            return MockPage.success(url)
+
+        mock_scraper.scrape = AsyncMock(side_effect=mixed_scrape)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good1">Good 1</a>
+                <a href="http://example.com/fail1">Fail 1</a>
+                <a href="http://example.com/blocked1">Blocked 1</a>
+                <a href="http://example.com/good2">Good 2</a>
+                </body></html>
+            """
+            result = await engine.run("http://example.com/")
+
+        # Start URL + good1 + good2 = 3 successes
+        assert result.completed >= 2  # at least 2 children (start URL + good pages)
+        assert len(result.errors) >= 2  # at least 2 errors (fail + blocked)
+        assert len(result.robots_blocked) >= 1  # at least 1 blocked
+
+        # Verify error code distinctions
+        for e in result.errors:
+            if "/blocked" in e.get("url", ""):
+                assert e.get("error_code") == "ROBOTS_BLOCKED"
+
+
+# ── Atomic store progress (VAL-CONC-042) ─────────────────────────
+
+
+class TestCrawlStoreAtomicity:
+    """Tests that the CrawlEngine calls atomic progress update methods."""
+
+    @pytest.mark.asyncio
+    async def test_atomic_completed_increment_with_mock_store(
+        self, mock_scraper, mock_store
+    ):
+        """CrawlEngine calls store.increment_completed() for each successful page."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(
+                max_pages=3,
+                max_depth=1,
+                max_concurrency=1,
+            ),
+        )
+
+        mock_store.increment_completed = MagicMock(return_value=1)
+        mock_store.get_completed = MagicMock(return_value=0)
+        mock_store.update_job_progress = MagicMock()
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page1">Page 1</a>
+                <a href="http://example.com/page2">Page 2</a>
+                </body></html>
+            """
+            result = await engine.run("http://example.com/", job_id="test-job")
+
+        # increment_completed should be called for each successful page
+        assert result.completed == 3
+        assert mock_store.increment_completed.call_count == 3
+        # update_job_progress should be called (final update)
+        assert mock_store.update_job_progress.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_increment_only_for_successful_pages(self, mock_scraper, mock_store):
+        """increment_completed is NOT called for failed or blocked pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=mock_store,
+            options=CrawlOptions(
+                max_pages=5,
+                max_depth=1,
+                max_concurrency=3,
+            ),
+        )
+
+        mock_store.increment_completed = MagicMock(return_value=1)
+        mock_store.get_completed = MagicMock(return_value=0)
+        mock_store.update_job_progress = MagicMock()
+
+        async def mixed_scrape(url: str, **kwargs) -> dict:
+            if "/fail" in url:
+                return MockPage.failure(url, "Connection error")
+            if "/blocked" in url:
+                return {
+                    "success": False,
+                    "error": "Blocked by politeness: robots.txt disallows",
+                }
+            return MockPage.success(url)
+
+        mock_scraper.scrape = AsyncMock(side_effect=mixed_scrape)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good1">Good 1</a>
+                <a href="http://example.com/fail1">Fail 1</a>
+                <a href="http://example.com/blocked1">Blocked 1</a>
+                </body></html>
+            """
+            await engine.run("http://example.com/", job_id="test-job-2")
+
+        # increment_completed should only be called for successful pages
+        # start URL + good1 = 2 successes
+        assert mock_store.increment_completed.call_count == 2
+
+
+# ── CrawlRequest concurrency validation tests (already exist) ───
 
 
 class TestCrawlRequestConcurrencyValidation:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -920,3 +920,526 @@ class TestCrawlEngine:
         # Should complete without infinite loop
         # Start URL + page1 = 2 pages
         assert result.completed == 2
+
+
+# ── Path filtering tests ────────────────────────────────────────
+
+
+class TestPathFiltering:
+    """Tests for path filtering in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_include_paths_start_url_matches(self, mock_scraper):
+        """When start URL matches include_paths, it is crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/blog/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/blog/post1">Blog Post 1</a>
+                <a href="http://example.com/blog/post2">Blog Post 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/blog/index")
+
+        # Start URL matches /blog/*, children under /blog/ are included
+        assert result.completed >= 2  # start + at least one blog child
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/blog/index" in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_include_paths_start_url_no_match_returns_zero(self, mock_scraper):
+        """When start URL doesn't match include_paths, 0 pages are crawled."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/section/*"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Section 1</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL / doesn't match /section/* so it's skipped
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_include_paths_regex_mode(self, mock_scraper):
+        """include_paths with regex_on_full_url=True uses regex matching."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/page-[12]"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/section/page-3">Page 3</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/page-1")
+
+        # Start URL /section/page-1 should match /section/page-[12]
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" in urls
+        assert "http://example.com/section/page-3" not in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_include_paths_empty_is_identity(self, mock_scraper):
+        """Empty include_paths list means 'include all' (identity)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # All URLs should pass (identity filter)
+        assert result.completed >= 2
+
+    @pytest.mark.asyncio
+    async def test_exclude_paths_empty_is_identity(self, mock_scraper):
+        """Empty exclude_paths list means 'exclude none' (identity)."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=[],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # All URLs should pass (identity filter)
+        assert result.completed >= 2
+
+    @pytest.mark.asyncio
+    async def test_exclude_overrides_include(self, mock_scraper):
+        """exclude_paths takes precedence over include_paths."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/*"],
+                exclude_paths=["/section/page-2"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/section/index")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" not in urls  # excluded
+        assert "http://example.com/about" not in urls  # not in include_paths
+
+    @pytest.mark.asyncio
+    async def test_exclude_all_returns_zero_pages(self, mock_scraper):
+        """exclude_paths matching everything returns 0 pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                exclude_paths=["/*"],
+            ),
+        )
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_include_nonexistent_returns_zero_pages(self, mock_scraper):
+        """include_paths that match nothing returns 0 pages."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=2,
+                include_paths=["/nonexistent/*"],
+            ),
+        )
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert result.completed == 0
+        assert len(result.pages) == 0
+
+    @pytest.mark.asyncio
+    async def test_glob_double_star_matches_any_depth(self, mock_scraper):
+        """Glob ** matches across directory boundaries."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=20,
+                max_depth=3,
+                include_paths=["/blog/**"],
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/blog/2024/01/post">Deep post</a>
+                <a href="http://example.com/blog/2024">Year index</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/blog/index")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/blog/index" in urls
+        # Deep paths under /blog/ should match /blog/**
+        assert "http://example.com/blog/2024" in urls
+        assert "http://example.com/blog/2024/01/post" in urls
+        assert "http://example.com/about" not in urls
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_query_params(self, mock_scraper):
+        """regex_on_full_url matches against full URL including query params."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[r"\?ref=partner"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/page?ref=partner">Partner link</a>
+                <a href="http://example.com/page?ref=other">Other link</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/start?ref=partner")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/page?ref=partner" in urls
+        assert "http://example.com/page?ref=other" not in urls
+
+    @pytest.mark.asyncio
+    async def test_verbose_tracks_filtered_out_urls(self, mock_scraper):
+        """Verbose mode collects URLs that were filtered out with reasons."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=["/section/*"],
+                exclude_paths=["/section/secret"],
+                verbose=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/secret">Secret</a>
+                <a href="http://example.com/about">About</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        # Start URL / doesn't match /section/* → should be filtered out
+        assert result.completed == 0
+        assert len(result.pages) == 0
+        if result.filtered_out:
+            # At least one filtered URL should be recorded
+            assert any(f["reason"] == "include_paths" for f in result.filtered_out)
+
+    @pytest.mark.asyncio
+    async def test_verbose_tracks_exclude_reason(self, mock_scraper):
+        """Verbose mode records exclude_paths as filter reason."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=["/admin/*"],
+                verbose=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/pricing">Pricing</a>
+                <a href="http://example.com/admin/secret">Admin</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        assert result.completed >= 2  # start URL + pricing
+        if result.filtered_out:
+            assert any(f["reason"] == "exclude_paths" for f in result.filtered_out), (
+                "Expected exclude_paths reason in filtered_out"
+            )
+
+    @pytest.mark.asyncio
+    async def test_glob_escapes_regex_special_chars(self, mock_scraper):
+        """Glob mode treats regex special chars as literals."""
+        from agent.crawler import _match_path
+
+        # In glob mode, '.' should be literal, not 'any char'
+        assert _match_path(
+            "http://example.com/file.html",
+            ["/file.html"],
+            None,
+            regex_on_full_url=False,
+        )
+        # Should NOT match fileXhtml when . is treated literally
+        assert not _match_path(
+            "http://example.com/fileXhtml",
+            ["/file.html"],
+            None,
+            regex_on_full_url=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_exclude_paths(self, mock_scraper):
+        """exclude_paths with regex_on_full_url=True uses regex matching."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                exclude_paths=[r"/section/page-[23]"],
+                regex_on_full_url=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/section/page-1">Page 1</a>
+                <a href="http://example.com/section/page-2">Page 2</a>
+                <a href="http://example.com/section/page-3">Page 3</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/")
+
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/section/page-1" in urls
+        assert "http://example.com/section/page-2" not in urls
+        assert "http://example.com/section/page-3" not in urls
+
+    @pytest.mark.asyncio
+    async def test_regex_on_full_url_with_ignore_query_params(self, mock_scraper):
+        """ignoreQueryParameters strips query first, then regex applies to path.
+
+        Per VAL-SCOPE-073: when both regexOnFullURL and ignoreQueryParameters
+        are set, query string is stripped from the URL BEFORE regex matching.
+        """
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=10,
+                max_depth=1,
+                include_paths=[r"/page$"],
+                regex_on_full_url=True,
+                ignore_query_parameters=True,
+            ),
+        )
+
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/other-page?ref=test">Other page with query</a>
+                <a href="http://example.com/pages">Pages (plural)</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/page")
+
+        # Start URL /page matches /page$ include pattern
+        urls = [p["url"] for p in result.pages]
+        assert "http://example.com/page" in urls
+        # With ignore_query_parameters, /other-page?ref=test normalizes to /other-page
+        # and the filter_url (without query) matches /page$? No — /other-page doesn't end with /page
+        # So /other-page should be excluded by the path filter
+        assert "http://example.com/other-page" not in urls
+        # /pages should NOT match /page$ (because $ anchors to end)
+        assert "http://example.com/pages" not in urls

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1443,3 +1443,266 @@ class TestPathFiltering:
         assert "http://example.com/other-page" not in urls
         # /pages should NOT match /page$ (because $ anchors to end)
         assert "http://example.com/pages" not in urls
+
+
+# ── CrawlStatusResponse enhancement tests ────────────────────────
+
+
+class TestCrawlStatusResponseModel:
+    """Tests for CrawlStatusResponse model with new timestamp fields."""
+
+    def test_crawl_status_response_has_timestamp_fields(self):
+        """CrawlStatusResponse model includes created_at, completed_at, expires_at, duration."""
+        from agent.models import CrawlStatusResponse
+
+        # While processing (no completed_at, no duration)
+        resp = CrawlStatusResponse(
+            status="processing",
+            completed=0,
+            total=5,
+            created_at="2026-01-15T10:00:00+00:00",
+            expires_at="2026-01-16T10:00:00+00:00",
+        )
+        assert resp.created_at == "2026-01-15T10:00:00+00:00"
+        assert resp.expires_at == "2026-01-16T10:00:00+00:00"
+        assert resp.completed_at is None
+        assert resp.duration is None
+
+        # On completion (all four fields present)
+        resp2 = CrawlStatusResponse(
+            status="completed",
+            completed=5,
+            total=5,
+            created_at="2026-01-15T10:00:00+00:00",
+            completed_at="2026-01-15T10:00:05+00:00",
+            expires_at="2026-01-16T10:00:00+00:00",
+            duration=5000,
+        )
+        assert resp2.created_at is not None
+        assert resp2.completed_at is not None
+        assert resp2.expires_at is not None
+        assert resp2.duration == 5000
+        # Verify created_at < completed_at <= expires_at
+        assert resp2.created_at < resp2.completed_at <= resp2.expires_at
+
+    def test_crawl_status_response_defaults(self):
+        """CrawlStatusResponse defaults to processing state with no timestamp fields."""
+        from agent.models import CrawlStatusResponse
+
+        resp = CrawlStatusResponse()
+        assert resp.status == "processing"
+        assert resp.completed == 0
+        assert resp.total == 0
+        assert resp.created_at is None
+        assert resp.completed_at is None
+        assert resp.expires_at is None
+        assert resp.duration is None
+
+
+# ── CrawlRequest validation tests ────────────────────────────────
+
+
+class TestCrawlRequestValidation:
+    """Tests for CrawlRequest field validation."""
+
+    def test_max_pages_positive_accepts_valid(self):
+        """max_pages >= 1 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_pages=1)
+        assert req.max_pages == 1
+
+        req2 = CrawlRequest(url="http://example.com", max_pages=100)
+        assert req2.max_pages == 100
+
+    def test_max_pages_zero_rejected(self):
+        """max_pages=0 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_pages"):
+            CrawlRequest(url="http://example.com", max_pages=0)
+
+    def test_max_depth_non_negative_accepts_valid(self):
+        """max_depth >= 0 is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", max_depth=0)
+        assert req.max_depth == 0
+
+        req2 = CrawlRequest(url="http://example.com", max_depth=5)
+        assert req2.max_depth == 5
+
+    def test_max_depth_negative_rejected(self):
+        """max_depth=-1 raises validation error."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="max_depth"):
+            CrawlRequest(url="http://example.com", max_depth=-1)
+
+    def test_max_depth_default_is_two(self):
+        """Default max_depth is 2."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.max_depth == 2
+
+    def test_max_pages_default_is_ten(self):
+        """Default max_pages is 10."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.max_pages == 10
+
+
+# ── Store tests ──────────────────────────────────────────────────
+
+
+class TestJobStoreExpiresAt:
+    """Tests for JobStore expires_at field."""
+
+    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    def test_create_job_includes_expires_at(self):
+        """JobStore.create_job sets expires_at in job metadata."""
+        from agent.store import JobStore
+
+        store = JobStore()
+        job_id = store.create_job(kind="crawl", payload={"url": "http://example.com"})
+        try:
+            meta_raw = store.redis.get(f"job:{job_id}:meta")
+            assert meta_raw is not None
+
+            import json
+
+            meta = json.loads(meta_raw)
+            assert "expires_at" in meta
+            assert meta["expires_at"] is not None
+            # expires_at should be a valid ISO 8601 string
+            from datetime import datetime
+
+            parsed = datetime.fromisoformat(meta["expires_at"])
+            assert parsed is not None
+
+            # expires_at should be ~24h after created_at
+            created = datetime.fromisoformat(meta["created_at"])
+            diff = parsed - created
+            assert 23 * 3600 <= diff.total_seconds() <= 25 * 3600  # ~24h window
+        finally:
+            store.redis.delete(f"job:{job_id}:meta")
+
+    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    def test_complete_job_sets_completed_at(self):
+        """JobStore.complete_job sets completed_at in metadata."""
+        from agent.store import JobStore
+
+        store = JobStore()
+        job_id = store.create_job(kind="crawl", payload={"url": "http://example.com"})
+        try:
+            store.complete_job(job_id, {"completed": 1, "total": 1})
+
+            meta_raw = store.redis.get(f"job:{job_id}:meta")
+            assert meta_raw is not None
+
+            import json
+
+            meta = json.loads(meta_raw)
+            assert "completed_at" in meta
+            assert meta["completed_at"] is not None
+            # completed_at should be a valid ISO 8601 string
+            from datetime import datetime
+
+            parsed = datetime.fromisoformat(meta["completed_at"])
+            assert parsed is not None
+            assert meta["status"] == "completed"
+        finally:
+            store.redis.delete(f"job:{job_id}:meta")
+            store.redis.delete(f"job:{job_id}:data")
+
+
+# ── Per-page metadata enrichment tests ──────────────────────────
+
+
+class TestPerPageMetadata:
+    """Tests for per-page metadata enrichment in CrawlEngine."""
+
+    @pytest.mark.asyncio
+    async def test_page_includes_title_and_metadata(self, mock_scraper):
+        """Each page in crawl results includes title, metadata dict with title/description/source,
+        status_code, content_type, scraped_at, and duration_ms."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Mock scraper to return enriched data with metadata
+        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            return {
+                "success": True,
+                "data": {
+                    "markdown": f"# Content of {url}",
+                    "source": "playwright",
+                    "metadata": {
+                        "title": "Test Page",
+                        "description": "A test page description",
+                        "sourceURL": url,
+                        "statusCode": 200,
+                        "content-type": "text/html",
+                    },
+                },
+            }
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=0),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert len(result.pages) == 1
+        page = result.pages[0]
+
+        # Verify metadata fields
+        assert page["url"] == "http://example.com/"
+        assert page["markdown"] == "# Content of http://example.com/"
+        assert page["title"] == "Test Page"
+        assert page["metadata"]["title"] == "Test Page"
+        assert page["metadata"]["description"] == "A test page description"
+        assert page["metadata"]["source"] == "playwright"
+        assert page["status_code"] == 200
+        assert page["content_type"] == "text/html"
+        assert page["scraped_at"] is not None
+        assert isinstance(page["duration_ms"], int)
+        assert page["duration_ms"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_page_metadata_falls_back_gracefully(self, mock_scraper):
+        """When scraper returns minimal data, metadata fields fall back to defaults."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        # Minimal scraper response
+        mock_scraper.scrape = AsyncMock(
+            return_value={"success": True, "data": {"markdown": "Just text"}}
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=1, max_depth=0),
+        )
+
+        result = await engine.run("http://example.com/")
+
+        assert len(result.pages) == 1
+        page = result.pages[0]
+
+        assert page["url"] == "http://example.com/"
+        assert page["markdown"] == "Just text"
+        assert page["title"] == ""  # falls back to empty string
+        assert page["metadata"]["title"] == ""
+        assert page["metadata"]["description"] == ""
+        assert page["metadata"]["source"] == "unknown"
+        assert page["status_code"] == 200  # default
+        assert page["content_type"] == "text/html"  # default
+        assert page["scraped_at"] is not None
+        assert isinstance(page["duration_ms"], int)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -284,7 +284,7 @@ class MockPage:
 
     @staticmethod
     def success(
-        url: str, markdown: str = "# Page Content", html: str | None = None
+        url: str, markdown: str = "# Page Content", html: str | None = None, **kwargs
     ) -> dict:
         return {
             "success": True,
@@ -296,7 +296,7 @@ class MockPage:
         }
 
     @staticmethod
-    def failure(url: str, error: str = "Scrape failed") -> dict:
+    def failure(url: str, error: str = "Scrape failed", **kwargs) -> dict:
         return {"success": False, "error": error}
 
 
@@ -349,7 +349,9 @@ class TestCrawlEngine:
             """
 
             # Set up scraper to return appropriate markdown per URL
-            async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            async def scrape_side_effect(
+                url: str, force_browser: bool = False, **kwargs
+            ) -> dict:
                 return MockPage.success(url, f"# Content of {url}")
 
             mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -400,7 +402,9 @@ class TestCrawlEngine:
             options=CrawlOptions(max_pages=10, max_depth=1),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -434,7 +438,9 @@ class TestCrawlEngine:
             options=CrawlOptions(max_pages=10, max_depth=2),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -469,7 +475,9 @@ class TestCrawlEngine:
             options=CrawlOptions(max_pages=10, max_depth=1),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -500,7 +508,9 @@ class TestCrawlEngine:
             options=CrawlOptions(max_pages=10, max_depth=1),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -535,7 +545,9 @@ class TestCrawlEngine:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -568,7 +580,9 @@ class TestCrawlEngine:
             options=CrawlOptions(max_pages=10, max_depth=1),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             if "fail" in url:
                 return MockPage.failure(url, "Connection refused")
             return MockPage.success(url, f"# Content of {url}")
@@ -631,7 +645,9 @@ class TestCrawlEngine:
             options=CrawlOptions(max_pages=10, max_depth=2, crawl_entire_domain=True),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -753,7 +769,9 @@ class TestCrawlEngine:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -816,7 +834,9 @@ class TestCrawlEngine:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -868,7 +888,9 @@ class TestCrawlEngine:
             options=CrawlOptions(max_pages=10, max_depth=2),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -884,7 +906,9 @@ class TestCrawlEngine:
             # Cancel after the first page is scraped
             original_scrape = mock_scraper.scrape
 
-            async def scrape_with_cancel(url: str, force_browser: bool = False) -> dict:
+            async def scrape_with_cancel(
+                url: str, force_browser: bool = False, **kwargs
+            ) -> dict:
                 result = await original_scrape(url, force_browser)
                 engine.cancel()
                 return result
@@ -954,7 +978,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -991,7 +1017,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1030,7 +1058,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1069,7 +1099,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1102,7 +1134,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1141,7 +1175,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1230,7 +1266,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1274,7 +1312,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1311,7 +1351,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1350,7 +1392,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1407,7 +1451,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1449,7 +1495,9 @@ class TestPathFiltering:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1700,7 +1748,9 @@ class TestPerPageMetadata:
         from agent.crawler import CrawlEngine, CrawlOptions
 
         # Mock scraper to return enriched data with metadata
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return {
                 "success": True,
                 "data": {
@@ -1796,7 +1846,9 @@ class TestCrawlEngineSitemap:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1836,7 +1888,9 @@ class TestCrawlEngineSitemap:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1882,7 +1936,9 @@ class TestCrawlEngineSitemap:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1920,7 +1976,9 @@ class TestCrawlEngineSitemap:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1956,7 +2014,9 @@ class TestCrawlEngineSitemap:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -1995,7 +2055,9 @@ class TestCrawlEngineSitemap:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2035,7 +2097,9 @@ class TestCrawlEngineSitemap:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2088,7 +2152,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2131,7 +2197,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2171,7 +2239,9 @@ class TestDomainScopeControls:
                 ),
             )
 
-            async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+            async def scrape_side_effect(
+                url: str, force_browser: bool = False, **kwargs
+            ) -> dict:
                 return MockPage.success(url, f"# Content of {url}")
 
             mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2208,7 +2278,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2248,7 +2320,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2286,7 +2360,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2326,7 +2402,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2364,7 +2442,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2411,7 +2491,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2452,7 +2534,9 @@ class TestDomainScopeControls:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2681,7 +2765,9 @@ class TestCrawlConcurrency:
 
         scrape_times = []
 
-        async def scrape_with_timing(url: str, force_browser: bool = False) -> dict:
+        async def scrape_with_timing(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             scrape_times.append(time.monotonic())
             return MockPage.success(url, f"# Content of {url}")
 
@@ -2725,7 +2811,9 @@ class TestCrawlConcurrency:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2765,7 +2853,9 @@ class TestCrawlConcurrency:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2802,7 +2892,9 @@ class TestCrawlConcurrency:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2840,7 +2932,9 @@ class TestCrawlConcurrency:
         # With delay=0.0, concurrency should NOT be forced to 1
         assert engine._effective_concurrency == 5
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2874,7 +2968,9 @@ class TestCrawlConcurrency:
         # With delay=None, concurrency should NOT be forced to 1
         assert engine._effective_concurrency == 5
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2939,7 +3035,9 @@ class TestCrawlConcurrency:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             return MockPage.success(url, f"# Content of {url}")
 
         mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
@@ -2974,7 +3072,9 @@ class TestCrawlConcurrency:
 
         scraped_urls = []
 
-        async def scrape_and_track(url: str, force_browser: bool = False) -> dict:
+        async def scrape_and_track(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             scraped_urls.append(url)
             return MockPage.success(url, f"# Content of {url}")
 
@@ -3025,7 +3125,9 @@ class TestCrawlConcurrency:
             ),
         )
 
-        async def scrape_side_effect(url: str, force_browser: bool = False) -> dict:
+        async def scrape_side_effect(
+            url: str, force_browser: bool = False, **kwargs
+        ) -> dict:
             if "fail" in url:
                 return MockPage.failure(url, "Connection error")
             return MockPage.success(url, f"# Content of {url}")
@@ -3153,3 +3255,194 @@ class TestCrawlRequestConcurrencyValidation:
 
         with pytest.raises(ValidationError, match="delay"):
             CrawlRequest(url="http://example.com", delay=-1)
+
+
+# ── Politeness integration tests ─────────────────────────────────
+
+
+class TestPolitenessFields:
+    """Tests for the ignore_robots_txt and robots_user_agent fields."""
+
+    def test_ignore_robots_txt_default_false(self):
+        """ignore_robots_txt defaults to False."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.ignore_robots_txt is False
+
+    def test_ignore_robots_txt_true_accepted(self):
+        """ignore_robots_txt=True is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", ignore_robots_txt=True)
+        assert req.ignore_robots_txt is True
+
+    def test_robots_user_agent_default_none(self):
+        """robots_user_agent defaults to None."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.robots_user_agent is None
+
+    def test_robots_user_agent_custom_accepted(self):
+        """Custom robots_user_agent string is accepted."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com", robots_user_agent="MyBot/1.0")
+        assert req.robots_user_agent == "MyBot/1.0"
+
+    def test_crawl_options_accepts_politeness_fields(self):
+        """CrawlOptions accepts ignore_robots_txt and robots_user_agent."""
+        from agent.crawler import CrawlOptions
+
+        opts = CrawlOptions(
+            max_pages=5,
+            ignore_robots_txt=True,
+            robots_user_agent="TestBot/2.0",
+        )
+        assert opts.ignore_robots_txt is True
+        assert opts.robots_user_agent == "TestBot/2.0"
+
+    def test_crawl_result_has_robots_blocked(self):
+        """CrawlResult includes robots_blocked list."""
+        from agent.crawler import CrawlResult
+
+        result = CrawlResult()
+        assert hasattr(result, "robots_blocked")
+        assert result.robots_blocked == []
+
+    @pytest.mark.asyncio
+    async def test_ignore_robots_txt_passed_to_scraper(self, mock_scraper):
+        """ignore_robots_txt is passed through to the scraper client."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        mock_scraper.scrape = AsyncMock(
+            return_value=MockPage.success("http://example.com/")
+        )
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(
+                max_pages=1,
+                max_depth=0,
+                ignore_robots_txt=True,
+                robots_user_agent="CustomBot/1.0",
+            ),
+        )
+
+        await engine.run("http://example.com/")
+
+        # Verify the scraper was called with the correct params
+        mock_scraper.scrape.assert_called_once_with(
+            "http://example.com/",
+            ignore_robots_txt=True,
+            robots_user_agent="CustomBot/1.0",
+        )
+
+    @pytest.mark.asyncio
+    async def test_politeness_blocked_results_collected(self, mock_scraper):
+        """Politeness-blocked scrape results are collected in robots_blocked list."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        async def scrape_side_effect(url: str, **kwargs) -> dict:
+            if "blocked" in url:
+                return {
+                    "success": False,
+                    "error": "Blocked by politeness: Disallowed by robots.txt: /admin/",
+                }
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good">Good page</a>
+                <a href="http://example.com/blocked">Blocked page</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/", job_id="test-politeness")
+
+        assert result.completed == 2
+        assert len(result.pages) == 2
+        assert len(result.robots_blocked) == 1
+        assert result.robots_blocked[0]["url"] == "http://example.com/blocked"
+        assert result.robots_blocked[0]["error_code"] == "ROBOTS_BLOCKED"
+
+    @pytest.mark.asyncio
+    async def test_non_politeness_errors_not_in_robots_blocked(self, mock_scraper):
+        """Non-politeness errors appear in errors but not in robots_blocked."""
+        from agent.crawler import CrawlEngine, CrawlOptions
+
+        async def scrape_side_effect(url: str, **kwargs) -> dict:
+            if "timeout" in url:
+                return {"success": False, "error": "Scraper timed out"}
+            return MockPage.success(url, f"# Content of {url}")
+
+        mock_scraper.scrape = AsyncMock(side_effect=scrape_side_effect)
+
+        engine = CrawlEngine(
+            mock_scraper,
+            store=None,
+            options=CrawlOptions(max_pages=10, max_depth=1),
+        )
+
+        with patch.object(engine, "_get_html") as mock_html:
+            mock_html.return_value = """
+                <html><body>
+                <a href="http://example.com/good">Good page</a>
+                <a href="http://example.com/timeout">Timeout page</a>
+                </body></html>
+            """
+
+            result = await engine.run("http://example.com/", job_id="test-errors")
+
+        assert result.completed == 2
+        assert len(result.errors) == 1
+        assert len(result.robots_blocked) == 0
+        assert "timeout" in result.errors[0]["url"]
+
+
+# ── CrawlRequest ignore_robots_txt and robots_user_agent validation ────
+
+
+class TestCrawlRequestPoliteness:
+    """Tests for CrawlRequest politeness field validation."""
+
+    def test_ignore_robots_txt_field_accepted(self):
+        """CrawlRequest accepts and serializes ignore_robots_txt."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(
+            url="http://example.com",
+            ignore_robots_txt=True,
+        )
+        d = req.model_dump(by_alias=True)
+        assert d.get("ignoreRobotsTxt") is True
+
+    def test_robots_user_agent_field_accepted(self):
+        """CrawlRequest accepts and serializes robots_user_agent."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(
+            url="http://example.com",
+            robots_user_agent="MyBot/1.0",
+        )
+        d = req.model_dump(by_alias=True)
+        assert d.get("robotsUserAgent") == "MyBot/1.0"
+
+    def test_both_politeness_fields_default(self):
+        """Default values are False and None."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="http://example.com")
+        assert req.ignore_robots_txt is False
+        assert req.robots_user_agent is None

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -14,6 +14,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -4906,3 +4907,610 @@ class TestListActiveCrawls:
         client.app.state.job_store.list_active_jobs.assert_called_with(
             kind="crawl", status="processing", limit=50
         )
+
+
+# ══════════════════════════════════════════════════════════════════
+# NL→Params Tests
+# ══════════════════════════════════════════════════════════════════
+
+
+class TestNlParamsSafeParse:
+    """Tests for _safe_parse_llm_response()."""
+
+    def test_plain_json(self):
+        from agent.nl_params import _safe_parse_llm_response
+
+        text = '{"include_paths": ["blog/.*"], "max_depth": 2}'
+        result = _safe_parse_llm_response(text)
+        assert result == {"include_paths": ["blog/.*"], "max_depth": 2}
+
+    def test_markdown_code_fence(self):
+        from agent.nl_params import _safe_parse_llm_response
+
+        text = '```json\n{"include_paths": ["blog/.*"]}\n```'
+        result = _safe_parse_llm_response(text)
+        assert result == {"include_paths": ["blog/.*"]}
+
+    def test_json_embedded_in_text(self):
+        from agent.nl_params import _safe_parse_llm_response
+
+        text = 'Here are the params: {"include_paths": ["blog/.*"]} Thanks!'
+        result = _safe_parse_llm_response(text)
+        assert result == {"include_paths": ["blog/.*"]}
+
+    def test_empty_string_returns_none(self):
+        from agent.nl_params import _safe_parse_llm_response
+
+        result = _safe_parse_llm_response("")
+        assert result is None
+
+    def test_invalid_json_returns_none(self):
+        from agent.nl_params import _safe_parse_llm_response
+
+        result = _safe_parse_llm_response("not json at all")
+        assert result is None
+
+
+class TestNlParamsValidateDerived:
+    """Tests for _validate_derived_params()."""
+
+    def test_valid_params_preserved(self):
+        from agent.nl_params import _validate_derived_params
+
+        params = {
+            "include_paths": ["blog/.*"],
+            "exclude_paths": ["admin/.*"],
+            "max_depth": 3,
+            "max_pages": 50,
+            "ignore_robots_txt": True,
+            "robots_user_agent": "MyBot/1.0",
+            "deduplicate_similar_urls": True,
+        }
+        result = _validate_derived_params(params)
+        assert result["include_paths"] == ["blog/.*"]
+        assert result["exclude_paths"] == ["admin/.*"]
+        assert result["max_depth"] == 3
+        assert result["max_pages"] == 50
+        assert result["ignore_robots_txt"] is True
+        assert result["robots_user_agent"] == "MyBot/1.0"
+        assert result["deduplicate_similar_urls"] is True
+
+    def test_none_removed(self):
+        from agent.nl_params import _validate_derived_params
+
+        # Only include_paths is valid, everything else None/invalid should be omitted
+        params = {
+            "include_paths": ["blog/.*"],
+            "exclude_paths": None,
+            "max_depth": None,
+            "max_pages": None,
+            "ignore_robots_txt": None,
+            "robots_user_agent": None,
+            "deduplicate_similar_urls": None,
+        }
+        result = _validate_derived_params(params)
+        assert result == {"include_paths": ["blog/.*"]}
+
+    def test_invalid_types_filtered(self):
+        from agent.nl_params import _validate_derived_params
+
+        params = {
+            "include_paths": "not a list",  # should be filtered
+            "exclude_paths": [1, 2, 3],  # non-string items
+            "max_depth": -1,  # negative should be filtered
+            "max_pages": 0,  # zero should be filtered
+            "ignore_robots_txt": "yes",  # not a bool
+            "robots_user_agent": 123,  # not a string
+            "deduplicate_similar_urls": None,
+        }
+        result = _validate_derived_params(params)
+        assert "include_paths" not in result
+        assert "exclude_paths" not in result
+        assert "max_depth" not in result
+        assert "max_pages" not in result
+        assert "ignore_robots_txt" not in result
+        assert "robots_user_agent" not in result
+        assert result == {}
+
+    def test_empty_input(self):
+        from agent.nl_params import _validate_derived_params
+
+        result = _validate_derived_params({})
+        assert result == {}
+
+    def test_max_depth_zero_accepted(self):
+        """Depth 0 is valid (scrape only start URL)."""
+        from agent.nl_params import _validate_derived_params
+
+        result = _validate_derived_params({"max_depth": 0})
+        assert result["max_depth"] == 0
+
+
+class TestNlParamsMerge:
+    """Tests for merge_params()."""
+
+    def test_llm_derived_used_when_no_explicit(self):
+        from agent.nl_params import merge_params
+
+        llm = {"include_paths": ["blog/.*"], "max_depth": 2}
+        explicit = {}
+        result = merge_params(llm, explicit)
+        assert result["include_paths"] == ["blog/.*"]
+        assert result["max_depth"] == 2
+
+    def test_explicit_overrides_llm(self):
+        from agent.nl_params import merge_params
+
+        llm = {"include_paths": ["blog/.*"], "max_depth": 2}
+        explicit = {"include_paths": ["docs/.*"]}
+        result = merge_params(llm, explicit)
+        assert result["include_paths"] == ["docs/.*"]
+        assert result["max_depth"] == 2  # Not overridden
+
+    def test_explicit_overrides_llm_max_depth(self):
+        from agent.nl_params import merge_params
+
+        llm = {"include_paths": ["blog/.*"], "max_depth": 3}
+        explicit = {"max_depth": 1}
+        result = merge_params(llm, explicit)
+        assert result["include_paths"] == ["blog/.*"]
+        assert result["max_depth"] == 1
+
+    def test_both_exclude_paths_merged(self):
+        from agent.nl_params import merge_params
+
+        llm = {"exclude_paths": ["admin/.*"], "max_depth": 2}
+        explicit = {"max_depth": 0}
+        result = merge_params(llm, explicit)
+        assert result["exclude_paths"] == ["admin/.*"]
+        assert result["max_depth"] == 0
+
+    def test_llm_error_preserved(self):
+        from agent.nl_params import merge_params
+
+        llm = {"error": "LLM unavailable", "max_depth": 2}
+        explicit = {}
+        result = merge_params(llm, explicit)
+        assert result["error"] == "LLM unavailable"
+        assert result["max_depth"] == 2
+
+    def test_explicit_none_does_not_override(self):
+        """Explicitly None fields should not override LLM-derived non-None values."""
+        from agent.nl_params import merge_params
+
+        llm = {"include_paths": ["blog/.*"], "max_depth": 2}
+        explicit = {"include_paths": None, "max_depth": None}
+        result = merge_params(llm, explicit)
+        # The merge function only checks explicit_val is not None
+        assert result["include_paths"] == ["blog/.*"]
+        assert result["max_depth"] == 2
+
+
+class TestNlParamsDeriveCrawlParams:
+    """Tests for derive_crawl_params() with mocked LLM client."""
+
+    @pytest.mark.asyncio
+    async def test_successful_derivation(self):
+        """Happy path: LLM returns valid JSON with crawl params."""
+        from agent.nl_params import derive_crawl_params
+
+        expected_response = json.dumps(
+            {
+                "include_paths": ["blog/.*"],
+                "exclude_paths": None,
+                "max_depth": 2,
+                "max_pages": 10,
+                "ignore_robots_txt": False,
+                "deduplicate_similar_urls": True,
+                "reasoning": "User wants blog posts.",
+            }
+        )
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=True)
+            ),
+            patch(
+                "agent.nl_params.LLMClient.generate",
+                AsyncMock(return_value=expected_response),
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            result = await derive_crawl_params(
+                prompt="crawl only the blog posts",
+                llm_base_url="http://llm.test/v1",
+                llm_api_key="test-key",
+                llm_model="test-model",
+            )
+            assert "error" not in result
+            assert result["include_paths"] == ["blog/.*"]
+            assert result["max_depth"] == 2
+            assert result["max_pages"] == 10
+
+    @pytest.mark.asyncio
+    async def test_llm_unavailable_returns_error(self):
+        """LLM health check fails — returns error without crashing."""
+        from agent.nl_params import derive_crawl_params
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=False)
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            result = await derive_crawl_params(
+                prompt="crawl everything",
+                llm_base_url="http://llm.test/v1",
+                llm_api_key="test-key",
+                llm_model="test-model",
+            )
+            assert "error" in result
+            assert "not available" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_response_falls_back(self):
+        """LLM returns unparseable JSON — returns error without crashing."""
+        from agent.nl_params import derive_crawl_params
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=True)
+            ),
+            patch(
+                "agent.nl_params.LLMClient.generate",
+                AsyncMock(return_value="This is not JSON at all"),
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            result = await derive_crawl_params(
+                prompt="crawl the docs",
+                llm_base_url="http://llm.test/v1",
+                llm_api_key="test-key",
+                llm_model="test-model",
+            )
+            assert "error" in result
+            assert "invalid json" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_llm_error_response_handled(self):
+        """LLM client returns an error string — handled gracefully."""
+        from agent.nl_params import derive_crawl_params
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=True)
+            ),
+            patch(
+                "agent.nl_params.LLMClient.generate",
+                AsyncMock(return_value="Error: LLM API returned 429"),
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            result = await derive_crawl_params(
+                prompt="crawl products",
+                llm_base_url="http://llm.test/v1",
+                llm_api_key="test-key",
+                llm_model="test-model",
+            )
+            assert "error" in result
+            assert "Error" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_llm_exception_handled(self):
+        """LLM client raises exception — caught and returned as error."""
+        from agent.nl_params import derive_crawl_params
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=True)
+            ),
+            patch(
+                "agent.nl_params.LLMClient.generate",
+                AsyncMock(side_effect=ConnectionError("Connection refused")),
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            result = await derive_crawl_params(
+                prompt="crawl all",
+                llm_base_url="http://llm.test/v1",
+                llm_api_key="test-key",
+                llm_model="test-model",
+            )
+            assert "error" in result
+            assert "Connection refused" in result["error"]
+
+
+class TestNlParamsPromptModel:
+    """Tests for the prompt field on CrawlRequest model."""
+
+    def test_prompt_accepted(self):
+        """CrawlRequest accepts a prompt field."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(
+            url="https://example.com",
+            prompt="crawl only the blog posts",
+        )
+        assert req.prompt == "crawl only the blog posts"
+
+    def test_prompt_default_none(self):
+        """CrawlRequest prompt defaults to None."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(url="https://example.com")
+        assert req.prompt is None
+
+    def test_prompt_max_length_enforced(self):
+        """CrawlRequest rejects prompt > 10000 chars."""
+        from agent.models import CrawlRequest
+        from pydantic import ValidationError
+
+        long_prompt = "x" * 10001
+        with pytest.raises(ValidationError):
+            CrawlRequest(url="https://example.com", prompt=long_prompt)
+
+    def test_prompt_10000_chars_accepted(self):
+        """CrawlRequest accepts prompt exactly 10000 chars."""
+        from agent.models import CrawlRequest
+
+        exact_prompt = "x" * 10000
+        req = CrawlRequest(url="https://example.com", prompt=exact_prompt)
+        assert req.prompt == exact_prompt
+
+    def test_prompt_in_model_dump(self):
+        """prompt appears in model_dump output."""
+        from agent.models import CrawlRequest
+
+        req = CrawlRequest(
+            url="https://example.com",
+            prompt="crawl blog posts",
+        )
+        dumped = req.model_dump(exclude_unset=True)
+        assert "prompt" in dumped
+        assert dumped["prompt"] == "crawl blog posts"
+
+
+class TestParamsPreviewModel:
+    """Tests for ParamsPreviewRequest and ParamsPreviewResponse models."""
+
+    def test_params_preview_request_requires_url_and_prompt(self):
+        """ParamsPreviewRequest requires both url and prompt."""
+        from agent.models import ParamsPreviewRequest
+
+        req = ParamsPreviewRequest(url="https://example.com", prompt="crawl blog")
+        assert req.url == "https://example.com"
+        assert req.prompt == "crawl blog"
+
+    def test_params_preview_request_missing_prompt_rejected(self):
+        """ParamsPreviewRequest without prompt is rejected."""
+        from agent.models import ParamsPreviewRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ParamsPreviewRequest(url="https://example.com")
+
+    def test_params_preview_request_missing_url_rejected(self):
+        """ParamsPreviewRequest without url is rejected."""
+        from agent.models import ParamsPreviewRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ParamsPreviewRequest(prompt="crawl blog")
+
+    def test_params_preview_request_invalid_url_rejected(self):
+        """ParamsPreviewRequest with invalid URL scheme."""
+        from agent.models import ParamsPreviewRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ParamsPreviewRequest(url="ftp://example.com", prompt="crawl blog")
+
+    def test_params_preview_request_prompt_max_length(self):
+        """ParamsPreviewRequest rejects prompt > 10000 chars."""
+        from agent.models import ParamsPreviewRequest
+        from pydantic import ValidationError
+
+        long_prompt = "x" * 10001
+        with pytest.raises(ValidationError):
+            ParamsPreviewRequest(url="https://example.com", prompt=long_prompt)
+
+    def test_params_preview_response_defaults(self):
+        """ParamsPreviewResponse has sensible defaults."""
+        from agent.models import ParamsPreviewResponse
+
+        resp = ParamsPreviewResponse()
+        assert resp.success is True
+        assert resp.include_paths is None
+        assert resp.exclude_paths is None
+        assert resp.max_depth is None
+        assert resp.limit is None
+        assert resp.error is None
+
+    def test_params_preview_response_camelcase_output(self):
+        """ParamsPreviewResponse emits camelCase when serialized."""
+        from agent.models import ParamsPreviewResponse
+
+        resp = ParamsPreviewResponse(
+            success=True,
+            include_paths=["blog/.*"],
+            exclude_paths=["admin/.*"],
+            max_depth=2,
+            limit=10,
+        )
+        dumped = resp.model_dump(by_alias=True)
+        assert dumped["includePaths"] == ["blog/.*"]
+        assert dumped["excludePaths"] == ["admin/.*"]
+        assert dumped["maxDepth"] == 2
+        assert dumped["limit"] == 10
+
+
+@pytest.fixture
+def app_with_mocks():
+    """Build a FastAPI test app with mocked dependencies for param endpoint tests."""
+    from agent.api import router
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(router)
+
+    app.state.job_store = MagicMock()
+    app.state.job_store.create_job.return_value = "mock-job-id"
+    app.state.llm_base_url = "http://llm.test/v1"
+    app.state.llm_api_key = "test-key"
+    app.state.llm_model = "test-model"
+    app.state.task_tracker = MagicMock()
+
+    with TestClient(app) as client:
+        yield client
+
+
+class TestParamsPreviewEndpoint:
+    """Tests for the POST /v2/crawl/params-preview endpoint using TestClient."""
+
+    def test_params_preview_with_prompt(self, app_with_mocks):
+        """POST /v2/crawl/params-preview returns derived params."""
+        from unittest.mock import AsyncMock, patch
+
+        client = app_with_mocks
+        expected_response = json.dumps(
+            {
+                "include_paths": ["blog/.*"],
+                "exclude_paths": None,
+                "max_depth": 2,
+                "max_pages": 10,
+                "ignore_robots_txt": False,
+                "deduplicate_similar_urls": True,
+                "reasoning": "User wants blog posts.",
+            }
+        )
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=True)
+            ),
+            patch(
+                "agent.nl_params.LLMClient.generate",
+                AsyncMock(return_value=expected_response),
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            resp = client.post(
+                "/v2/crawl/params-preview",
+                json={
+                    "url": "https://example.com",
+                    "prompt": "crawl only the blog posts",
+                },
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is True
+            assert data["includePaths"] == ["blog/.*"]
+            assert data["maxDepth"] == 2
+            assert "error" not in data or data["error"] is None
+
+    def test_params_preview_without_prompt_returns_422(self, app_with_mocks):
+        """POST /v2/crawl/params-preview without prompt returns 422."""
+        client = app_with_mocks
+        resp = client.post(
+            "/v2/crawl/params-preview",
+            json={"url": "https://example.com"},
+        )
+        assert resp.status_code == 422
+
+    def test_params_preview_without_url_returns_422(self, app_with_mocks):
+        """POST /v2/crawl/params-preview without url returns 422."""
+        client = app_with_mocks
+        resp = client.post(
+            "/v2/crawl/params-preview",
+            json={"prompt": "crawl blog"},
+        )
+        assert resp.status_code == 422
+
+    def test_params_preview_llm_unavailable(self, app_with_mocks):
+        """POST /v2/crawl/params-preview handles LLM unavailability gracefully."""
+        from unittest.mock import AsyncMock, patch
+
+        client = app_with_mocks
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=False)
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            resp = client.post(
+                "/v2/crawl/params-preview",
+                json={"url": "https://example.com", "prompt": "crawl blog posts"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is False
+            assert "error" in data
+            assert data["error"] is not None
+
+    def test_params_preview_llm_invalid_json(self, app_with_mocks):
+        """POST /v2/crawl/params-preview handles invalid LLM JSON gracefully."""
+        from unittest.mock import AsyncMock, patch
+
+        client = app_with_mocks
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=True)
+            ),
+            patch(
+                "agent.nl_params.LLMClient.generate",
+                AsyncMock(return_value="not valid json"),
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            resp = client.post(
+                "/v2/crawl/params-preview",
+                json={"url": "https://example.com", "prompt": "crawl blog posts"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is False
+            assert "error" in data
+            assert data["error"] is not None
+
+    def test_params_preview_endpoint_does_not_create_crawl_job(self, app_with_mocks):
+        """POST /v2/crawl/params-preview does not create a crawl job."""
+        from unittest.mock import AsyncMock, patch
+
+        client = app_with_mocks
+        expected_response = json.dumps(
+            {
+                "include_paths": ["blog/.*"],
+                "exclude_paths": None,
+                "max_depth": 2,
+                "max_pages": 10,
+                "ignore_robots_txt": False,
+                "deduplicate_similar_urls": True,
+                "reasoning": "User wants blog posts.",
+            }
+        )
+
+        with (
+            patch(
+                "agent.nl_params.LLMClient.check_health", AsyncMock(return_value=True)
+            ),
+            patch(
+                "agent.nl_params.LLMClient.generate",
+                AsyncMock(return_value=expected_response),
+            ),
+            patch("agent.nl_params.LLMClient.close", AsyncMock()),
+        ):
+            resp = client.post(
+                "/v2/crawl/params-preview",
+                json={
+                    "url": "https://example.com",
+                    "prompt": "crawl only the blog posts",
+                },
+            )
+            assert resp.status_code == 200
+            # No crawl job should be created
+            # The store's create_job should not have been called
+            # (there might be other calls from the test setup, so check no crawl job was created)
+            # Since params-preview doesn't create a job, the store is unaffected
+            assert "id" not in resp.json()

--- a/tests/test_link_extractor.py
+++ b/tests/test_link_extractor.py
@@ -1,0 +1,407 @@
+"""Unit tests for the shared LinkExtractor module.
+
+Tests the ``extract_links()``, ``filter_links()``, and ``classify_links()``
+functions from ``agent-svc/agent/link_extractor.py`` without needing a
+running Docker stack.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Add agent-svc to sys.path so we can import the agent package directly
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agent-svc"))
+
+from agent.link_extractor import (
+    _is_subdomain,
+    _strip_fragment,
+    classify_links,
+    extract_links,
+    filter_links,
+)
+
+# ── extract_links() tests ──────────────────────────────────────────
+
+
+class TestExtractLinks:
+    """Tests for extract_links() — core link extraction."""
+
+    def test_basic_link_extraction(self):
+        """Should extract all <a href> links from simple HTML."""
+        html = """
+        <html>
+        <body>
+            <a href="/page1">Page 1</a>
+            <a href="/page2">Page 2</a>
+            <a href="/page3">Page 3</a>
+        </body>
+        </html>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 3
+        assert "https://example.com/page1" in links
+        assert "https://example.com/page2" in links
+        assert "https://example.com/page3" in links
+
+    def test_absolute_links_preserved(self):
+        """Should preserve already-absolute URLs unchanged."""
+        html = '<a href="https://other.com/page">Link</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://other.com/page" in links
+
+    def test_relative_urls_resolved(self):
+        """Should resolve relative hrefs against base_url (VAL-CRAWL-035)."""
+        html = '<a href="/about">About</a><a href="contact">Contact</a>'
+        links = extract_links(html, "https://example.com/sub/")
+        assert "https://example.com/about" in links
+        assert "https://example.com/sub/contact" in links
+
+    def test_fragment_stripped(self):
+        """Should strip fragment identifiers from extracted URLs (VAL-CRAWL-036)."""
+        html = '<a href="/about#team">Team</a><a href="/pricing#plans">Plans</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://example.com/about" in links
+        assert "https://example.com/pricing" in links
+        # No fragment-bearing URLs should be present
+        for link in links:
+            assert "#" not in link
+
+    def test_duplicates_deduplicated(self):
+        """Should deduplicate identical URLs (VAL-CRAWL-058)."""
+        html = """
+        <a href="/page">First</a>
+        <a href="/page">Second</a>
+        <a href="https://example.com/page">Third (absolute dup)</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/page"]
+
+    def test_fragment_variants_deduplicated(self):
+        """Fragment variants of same URL should resolve to same base URL."""
+        html = '<a href="/about#team">Team</a><a href="/about#history">History</a>'
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/about"]
+
+    def test_non_http_schemes_filtered(self):
+        """Should filter out mailto:, tel:, javascript:, ftp: (VAL-CRAWL-057)."""
+        html = """
+        <a href="mailto:user@example.com">Email</a>
+        <a href="tel:+1234567890">Call</a>
+        <a href="javascript:void(0)">JS</a>
+        <a href="ftp://files.example.com">FTP</a>
+        <a href="/valid-page">Valid</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 1
+        assert links == ["https://example.com/valid-page"]
+
+    def test_malformed_html_graceful(self):
+        """Malformed HTML should not crash — graceful degradation (VAL-CRAWL-056)."""
+        html = """<html><body><a href="/page1">Page1<a href="/page2">Page2"""
+        links = extract_links(html, "https://example.com")
+        assert len(links) >= 1
+
+    def test_completely_garbled_html(self):
+        """Completely garbled HTML should not crash."""
+        html = "not even close to valid html <<<<>>>> ### %% ^^^^"
+        links = extract_links(html, "https://example.com")
+        assert isinstance(links, list)
+
+    def test_empty_html(self):
+        """Empty HTML should return empty list."""
+        assert extract_links("", "https://example.com") == []
+
+    def test_none_html(self):
+        """None-like empty HTML should return empty list."""
+        assert extract_links("", "https://example.com") == []
+
+    def test_base_tag_respected(self):
+        """<base> tag should override base_url for relative resolution (VAL-CRAWL-074)."""
+        html = """
+        <html>
+        <head><base href="https://other.example.com/sub/"></head>
+        <body>
+            <a href="page">Relative to base</a>
+            <a href="/root">Root-relative</a>
+        </body>
+        </html>
+        """
+        links = extract_links(html, "https://example.com")
+        assert "https://other.example.com/sub/page" in links
+        assert "https://other.example.com/root" in links
+
+    def test_links_with_no_href_ignored(self):
+        """<a> tags without href attribute should be ignored."""
+        html = '<a>No href</a><a href="">Empty href</a><a href="/ok">OK</a>'
+        links = extract_links(html, "https://example.com")
+        assert links == ["https://example.com/ok"]
+
+    def test_trailing_whitespace_in_href(self):
+        """Href with leading/trailing whitespace should be trimmed."""
+        html = '<a href="  /page  ">Spaced</a>'
+        links = extract_links(html, "https://example.com")
+        assert links == ["https://example.com/page"]
+
+    def test_same_page_link_handled(self):
+        """A link to '#' should resolve to the base URL without fragment."""
+        html = '<a href="#">Top</a>'
+        links = extract_links(html, "https://example.com")
+        # urljoin("#", "https://example.com") returns "https://example.com"
+        assert links == ["https://example.com"]
+
+    def test_protocol_relative_url(self):
+        """Protocol-relative URLs (//example.com/path) should resolve correctly."""
+        html = '<a href="//cdn.example.com/file.js">CDN</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://cdn.example.com/file.js" in links
+
+    def test_multiple_nested_a_tags(self):
+        """Links nested in complex HTML structures should all be found."""
+        html = """
+        <div><ul><li><a href="/deep1">Deep</a></li></ul></div>
+        <p><span><a href="/deep2">Nested</a></span></p>
+        <a href="/top">Top</a>
+        """
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 3
+        assert "https://example.com/deep1" in links
+        assert "https://example.com/deep2" in links
+        assert "https://example.com/top" in links
+
+    def test_no_links_in_html(self):
+        """HTML with no <a> tags should return empty list."""
+        html = "<html><body><p>No links here</p></body></html>"
+        assert extract_links(html, "https://example.com") == []
+
+
+# ── filter_links() tests ────────────────────────────────────────────
+
+
+class TestFilterLinks:
+    """Tests for filter_links() — scope-based filtering."""
+
+    def test_internal_links_included_by_default(self):
+        """Internal (same-domain) links should always be included."""
+        links = [
+            "https://example.com/page1",
+            "https://example.com/page2",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 2
+
+    def test_subdomain_excluded_by_default(self):
+        """Subdomain links should be excluded when allow_subdomains=False."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+    def test_subdomain_included_when_allowed(self):
+        """Subdomain links should be included when allow_subdomains=True."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+            "https://blog.example.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 3
+        assert "https://docs.example.com/page" in filtered
+
+    def test_external_excluded_by_default(self):
+        """External links should be excluded when allow_external_links=False."""
+        links = [
+            "https://example.com/page",
+            "https://other.com/page",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+    def test_external_included_when_allowed(self):
+        """External links should be included when allow_external_links=True."""
+        links = [
+            "https://example.com/page",
+            "https://other.com/page",
+            "https://another.org/path",
+        ]
+        filtered = filter_links(
+            links,
+            base_domain="example.com",
+            allow_external_links=True,
+        )
+        assert len(filtered) == 3
+        assert "https://other.com/page" in filtered
+
+    def test_subdomain_and_external_combined(self):
+        """Both subdomain and external flags should work together."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com/page",
+            "https://other.com/page",
+        ]
+        filtered = filter_links(
+            links,
+            base_domain="example.com",
+            allow_subdomains=True,
+            allow_external_links=True,
+        )
+        assert len(filtered) == 3
+
+    def test_empty_links_list(self):
+        """Empty links list should return empty list."""
+        assert filter_links([], base_domain="example.com") == []
+
+    def test_no_base_domain(self):
+        """Without base_domain, all links should pass through."""
+        links = ["https://example.com/page", "https://other.com/page"]
+        filtered = filter_links(links)
+        assert len(filtered) == 2
+
+    def test_different_schemes_same_domain(self):
+        """HTTP and HTTPS on same domain should both be internal."""
+        links = [
+            "http://example.com/page1",
+            "https://example.com/page2",
+        ]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 2
+
+    def test_subdomain_with_port(self):
+        """Subdomain with port should still be recognized as subdomain."""
+        links = [
+            "https://example.com/page",
+            "https://docs.example.com:8080/page",
+        ]
+        # Without allow_subdomains
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 1
+        assert "https://example.com/page" in filtered
+
+        # With allow_subdomains
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 2
+
+    def test_multi_level_subdomain(self):
+        """Multi-level subdomains should be recognized."""
+        links = ["https://deep.docs.example.com/page"]
+        filtered = filter_links(links, base_domain="example.com")
+        assert len(filtered) == 0
+
+        filtered = filter_links(links, base_domain="example.com", allow_subdomains=True)
+        assert len(filtered) == 1
+
+
+# ── classify_links() tests ─────────────────────────────────────────
+
+
+class TestClassifyLinks:
+    """Tests for classify_links() — domain classification."""
+
+    def test_classify_internal(self):
+        """Same-domain URLs should be classified as internal."""
+        links = ["https://example.com/page", "https://example.com/about"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com/page" in result["internal"]
+        assert "https://example.com/about" in result["internal"]
+        assert result["subdomain"] == []
+        assert result["external"] == []
+
+    def test_classify_subdomain(self):
+        """Subdomain URLs should be classified as subdomain."""
+        links = ["https://docs.example.com/page", "https://blog.example.com/"]
+        result = classify_links(links, "https://example.com")
+        assert result["internal"] == []
+        assert "https://docs.example.com/page" in result["subdomain"]
+        assert "https://blog.example.com/" in result["subdomain"]
+        assert result["external"] == []
+
+    def test_classify_external(self):
+        """Different-domain URLs should be classified as external."""
+        links = ["https://other.com/page", "https://another.org/"]
+        result = classify_links(links, "https://example.com")
+        assert result["internal"] == []
+        assert result["subdomain"] == []
+        assert "https://other.com/page" in result["external"]
+
+    def test_classify_mixed(self):
+        """Mixed internal/subdomain/external URLs should be classified correctly."""
+        links = [
+            "https://example.com/internal",
+            "https://docs.example.com/subdomain",
+            "https://other.com/external",
+        ]
+        result = classify_links(links, "https://example.com")
+        assert len(result["internal"]) == 1
+        assert len(result["subdomain"]) == 1
+        assert len(result["external"]) == 1
+
+    def test_classify_with_port_difference(self):
+        """Port difference does not change internal classification."""
+        links = ["https://example.com:8080/page"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com:8080/page" in result["internal"]
+
+    def test_classify_with_path(self):
+        """URLs with paths are still classified by domain."""
+        links = ["https://example.com/sub/deep/page"]
+        result = classify_links(links, "https://example.com")
+        assert "https://example.com/sub/deep/page" in result["internal"]
+
+    def test_classify_empty_links(self):
+        """Empty links should return all-empty categories."""
+        result = classify_links([], "https://example.com")
+        assert result == {"internal": [], "subdomain": [], "external": []}
+
+
+# ── Helper function tests ──────────────────────────────────────────
+
+
+class TestStripFragment:
+    """Tests for the _strip_fragment helper."""
+
+    def test_strips_fragment(self):
+        assert (
+            _strip_fragment("https://example.com/page#section")
+            == "https://example.com/page"
+        )
+
+    def test_no_fragment(self):
+        assert _strip_fragment("https://example.com/page") == "https://example.com/page"
+
+    def test_empty_url(self):
+        assert _strip_fragment("") == ""
+
+    def test_fragment_with_query(self):
+        assert (
+            _strip_fragment("https://example.com/page?a=1#section")
+            == "https://example.com/page?a=1"
+        )
+
+
+class TestIsSubdomain:
+    """Tests for the _is_subdomain helper."""
+
+    def test_subdomain(self):
+        assert _is_subdomain("docs.example.com", "example.com")
+
+    def test_same_domain(self):
+        assert not _is_subdomain("example.com", "example.com")
+
+    def test_different_domain(self):
+        assert not _is_subdomain("other.com", "example.com")
+
+    def test_multi_level_subdomain(self):
+        assert _is_subdomain("a.b.example.com", "example.com")
+
+    def test_not_subdomain_with_prefix(self):
+        """notexample.com is not a subdomain of example.com."""
+        assert not _is_subdomain("notexample.com", "example.com")
+
+    def test_case_insensitive(self):
+        assert _is_subdomain("DOCS.EXAMPLE.COM", "example.com")

--- a/tests/test_llmstxt_unit.py
+++ b/tests/test_llmstxt_unit.py
@@ -1,16 +1,20 @@
 """Unit tests for llmstxt.py pure functions.
 
-Tests the _extract_description() function directly without needing
-a running Docker stack. Run with: python3 -m pytest tests/test_llmstxt_unit.py -v
+Tests the _extract_description() and discover_pages() functions directly
+without needing a running Docker stack.
+Run with: python3 -m pytest tests/test_llmstxt_unit.py -v
 """
 
 import os
 import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 # Add the agent-svc directory to the path so we can import llmstxt
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "agent-svc"))
 
-from agent.llmstxt import _extract_description
+from agent.llmstxt import _extract_description, discover_pages
 
 
 def test_ends_at_sentence_boundary():
@@ -115,3 +119,217 @@ def test_multi_sentence_content():
     assert "opening statement" in desc
     # Should end with a sentence-ending punctuation
     assert desc.rstrip()[-1] in ".!?"
+
+
+# ── discover_pages tests ──────────────────────────────────────────
+
+
+def _mock_html_page(
+    *,
+    internal_links: list[str] | None = None,
+    external_links: list[str] | None = None,
+    non_http_links: list[str] | None = None,
+) -> str:
+    """Build an HTML page with the given link lists for testing."""
+    links_html = ""
+    for link in internal_links or []:
+        links_html += f'<a href="{link}">internal</a>\n'
+    for link in external_links or []:
+        links_html += f'<a href="{link}">external</a>\n'
+    for link in non_http_links or []:
+        links_html += f'<a href="{link}">non-http</a>\n'
+    return f"<html><body>{links_html}</body></html>"
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_extracts_internal_links():
+    """discover_pages should extract same-host links from the page HTML."""
+    html = _mock_html_page(
+        internal_links=["/page1", "/page2", "/page3"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+    assert "http://example.com/page3" in result
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_excludes_external_links():
+    """discover_pages should exclude links to external domains."""
+    html = _mock_html_page(
+        internal_links=["/page1"],
+        external_links=["https://other.com/page"],
+        non_http_links=["mailto:test@example.com"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert "http://example.com/page1" in result
+    assert "https://other.com/page" not in result
+    assert "mailto:test@example.com" not in result
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_respects_max_pages():
+    """discover_pages should limit results to max_pages."""
+    html = _mock_html_page(
+        internal_links=[f"/page{i}" for i in range(20)],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=3)
+
+    assert len(result) == 3
+    # First 3 links should be returned
+    assert result[0] == "http://example.com/page0"
+    assert result[1] == "http://example.com/page1"
+    assert result[2] == "http://example.com/page2"
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_http_error_falls_back():
+    """discover_pages should return [url] when the server returns non-200."""
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 404
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_exception_falls_back():
+    """discover_pages should return [url] when an exception occurs during fetch."""
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.side_effect = Exception("Connection error")
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_empty_results_falls_back():
+    """discover_pages should return [url] when no links are found."""
+    html = "<html><body><p>No links here</p></body></html>"
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert result == ["http://example.com"]
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_deduplicates_links():
+    """discover_pages should not return duplicate URLs."""
+    html = _mock_html_page(
+        internal_links=["/page1", "/page1", "/page2", "/page1"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    assert len(result) == 2
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_strips_fragments():
+    """discover_pages should strip fragment identifiers from URLs."""
+    html = _mock_html_page(
+        internal_links=["/page1#section1", "/page1#section2", "/page2"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=10)
+
+    # Fragment-stripped URLs should be deduped — only one /page1 entry
+    assert "http://example.com/page1" in result
+    assert "http://example.com/page2" in result
+    assert "#" not in str(result)
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_discover_pages_max_pages_larger_than_available():
+    """When max_pages exceeds available links, all links are returned."""
+    html = _mock_html_page(
+        internal_links=["/a", "/b"],
+    )
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.text = html
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.get.return_value = mock_resp
+        mock_client_cls.return_value = mock_client
+
+        result = await discover_pages("http://example.com", max_pages=100)
+
+    assert len(result) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -203,6 +203,8 @@ class TestCrawlRequest:
         r = CrawlRequest(url="https://example.com")
         assert r.max_pages == 10
         assert r.max_depth == 2
+        assert r.regex_on_full_url is False
+        assert r.verbose is False
 
     def test_with_webhook(self):
         from agent.models import CrawlRequest
@@ -211,6 +213,70 @@ class TestCrawlRequest:
             url="https://x.com", webhook={"url": "https://hook.example.com"}
         )
         assert r.webhook["url"] == "https://hook.example.com"
+
+    def test_with_regex_on_full_url(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[r"/section/.*"],
+        )
+        assert r.regex_on_full_url is True
+        assert r.include_paths == [r"/section/.*"]
+
+    def test_invalid_regex_raises_validation_error(self):
+        from agent.models import CrawlRequest
+
+        with pytest.raises(ValidationError) as excinfo:
+            CrawlRequest(
+                url="https://example.com",
+                regex_on_full_url=True,
+                include_paths=["[unclosed"],
+            )
+        err = str(excinfo.value)
+        assert "include_paths" in err
+        assert "unclosed" in err.lower() or "invalid" in err.lower()
+
+    def test_invalid_regex_in_exclude_paths_raises_error(self):
+        from agent.models import CrawlRequest
+
+        with pytest.raises(ValidationError) as excinfo:
+            CrawlRequest(
+                url="https://example.com",
+                regex_on_full_url=True,
+                exclude_paths=[r"[\w+", r"/valid/\d+"],
+            )
+        err = str(excinfo.value)
+        assert "exclude_paths" in err
+
+    def test_valid_regex_passes_validation(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[r"/section/\d+", r"/blog/.*"],
+            exclude_paths=[r"/admin/.*"],
+        )
+        assert r.include_paths == [r"/section/\d+", r"/blog/.*"]
+        assert r.exclude_paths == [r"/admin/.*"]
+
+    def test_empty_include_paths_with_regex_is_valid(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(
+            url="https://example.com",
+            regex_on_full_url=True,
+            include_paths=[],
+        )
+        assert r.include_paths == []
+
+    def test_verbose_flag(self):
+        from agent.models import CrawlRequest
+
+        r = CrawlRequest(url="https://example.com", verbose=True)
+        assert r.verbose is True
 
 
 class TestBatchScrapeRequest:

--- a/tests/test_sitemap_parser.py
+++ b/tests/test_sitemap_parser.py
@@ -1,0 +1,618 @@
+"""Unit tests for SitemapParser in agent-svc/agent/sitemap_parser.py.
+
+Covers:
+- Basic XML sitemap parsing (<urlset>)
+- Sitemap index file parsing (<sitemapindex>) with recursion
+- Gzipped sitemap decompression
+- Malformed XML handling
+- 404 / 5xx sitemap URL handling
+- Connection error handling
+- Common path fallback (robots.txt → /sitemap.xml)
+- robots.txt Sitemap directive discovery
+- Text sitemap detection (unsupported)
+- Empty sitemap handling
+- Non-HTTP URL filtering
+- get_urls with limit enforcement
+- Nested sitemap index depth limit
+"""
+
+from __future__ import annotations
+
+import gzip
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from agent.sitemap_parser import SitemapParser
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def xml_sitemap() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/about</loc></url>
+  <url><loc>https://example.com/pricing</loc></url>
+  <url><loc>https://example.com/blog/post-1</loc></url>
+  <url><loc>https://example.com/contact</loc></url>
+</urlset>"""
+
+
+@pytest.fixture
+def sitemap_index() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap2.xml</loc></sitemap>
+</sitemapindex>"""
+
+
+@pytest.fixture
+def child_sitemap1() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>"""
+
+
+@pytest.fixture
+def child_sitemap2() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page3</loc></url>
+  <url><loc>https://example.com/page4</loc></url>
+</urlset>"""
+
+
+@pytest.fixture
+def empty_sitemap() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</urlset>"""
+
+
+def _mock_response(
+    content: bytes | str,
+    status_code: int = 200,
+    content_type: str = "application/xml",
+    content_encoding: str | None = None,
+) -> AsyncMock:
+    """Create a mock httpx.Response."""
+    if isinstance(content, str):
+        content = content.encode("utf-8")
+    resp = AsyncMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.content = content
+    resp.headers = {"content-type": content_type}
+    if content_encoding:
+        resp.headers["content-encoding"] = content_encoding
+    return resp
+
+
+def _mock_gzipped_response(
+    xml: str,
+    status_code: int = 200,
+    content_type: str = "application/xml",
+) -> AsyncMock:
+    """Create a mock gzipped httpx.Response."""
+    compressed = gzip.compress(xml.encode("utf-8"))
+    return _mock_response(
+        compressed,
+        status_code=status_code,
+        content_type=content_type,
+        content_encoding="gzip",
+    )
+
+
+# ── Basic URL set parsing tests ─────────────────────────────────
+
+
+class TestParseUrlSet:
+    """Tests for parsing a basic <urlset> sitemap."""
+
+    @pytest.mark.asyncio
+    async def test_parse_basic_sitemap(self, xml_sitemap):
+        """A standard <urlset> sitemap is parsed correctly."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(xml_sitemap)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert len(urls) == 5
+        assert "https://example.com/" in urls
+        assert "https://example.com/about" in urls
+        assert "https://example.com/pricing" in urls
+        assert "https://example.com/blog/post-1" in urls
+        assert "https://example.com/contact" in urls
+
+    @pytest.mark.asyncio
+    async def test_parse_empty_sitemap(self, empty_sitemap):
+        """An empty <urlset> returns an empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(empty_sitemap)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_parse_malformed_xml(self):
+        """Malformed XML logs a warning and returns empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response("This is not XML at all")
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_parse_non_http_urls_filtered(self):
+        """Non-HTTP URLs in sitemaps are filtered out."""
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>ftp://files.example.com/file</loc></url>
+  <url><loc>mailto:admin@example.com</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>"""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(xml)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert len(urls) == 2
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+        assert "ftp://files.example.com/file" not in urls
+        assert "mailto:admin@example.com" not in urls
+
+
+# ── Sitemap index parsing tests ─────────────────────────────────
+
+
+class TestSitemapIndex:
+    """Tests for recursive sitemap index parsing."""
+
+    @pytest.mark.asyncio
+    async def test_parse_sitemap_index(
+        self, sitemap_index, child_sitemap1, child_sitemap2
+    ):
+        """A sitemap index file is recursively parsed."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "sitemap_index.xml" in url:
+                return _mock_response(sitemap_index)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            elif "sitemap2.xml" in url:
+                return _mock_response(child_sitemap2)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap_index.xml")
+
+        assert len(urls) == 4
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+        assert "https://example.com/page3" in urls
+        assert "https://example.com/page4" in urls
+
+    @pytest.mark.asyncio
+    async def test_sitemap_index_depth_limit(self, child_sitemap1, child_sitemap2):
+        """Deeply nested sitemap indexes are limited by max_recursion_depth."""
+        # Create index files that reference each other circularly
+        nested_index1 = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/nested2.xml</loc></sitemap>
+</sitemapindex>"""
+        nested_index2 = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+</sitemapindex>"""
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "nested1.xml" in url:
+                return _mock_response(nested_index1)
+            elif "nested2.xml" in url:
+                return _mock_response(nested_index2)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(
+            client=mock_client,
+            max_recursion_depth=1,
+        )
+        urls = await parser.parse_sitemap_url("https://example.com/nested1.xml")
+
+        # With max_recursion_depth=1, nested2.xml should be allowed
+        # but sitemap1.xml from nested2.xml should exceed depth limit
+        # Wait: depth starts at 0. When parsing nested1.xml (depth=0),
+        # it finds nested2.xml. We call _parse_sitemap(nested2.xml, depth=1).
+        # That's depth=1, which is <= max_recursion_depth=1.
+        # Then nested2.xml finds sitemap1.xml. We call _parse_sitemap(sitemap1.xml, depth=2).
+        # depth=2 > max_recursion_depth=1, so sitemap1.xml is NOT parsed.
+        # So urls should be empty.
+        assert len(urls) == 0
+
+    @pytest.mark.asyncio
+    async def test_sitemap_index_deduplication(self, child_sitemap1):
+        """Same child sitemap referenced twice is only parsed once."""
+        sitemap_index_dup = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap1.xml</loc></sitemap>
+</sitemapindex>"""
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "sitemap_index_dup.xml" in url:
+                return _mock_response(sitemap_index_dup)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url(
+            "https://example.com/sitemap_index_dup.xml"
+        )
+
+        assert len(urls) == 2
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+
+
+# ── Gzip tests ──────────────────────────────────────────────────
+
+
+class TestGzipSitemaps:
+    """Tests for gzipped sitemaps."""
+
+    @pytest.mark.asyncio
+    async def test_gzip_content_encoding(self, xml_sitemap):
+        """Sitemaps with Content-Encoding: gzip are decompressed."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_gzipped_response(xml_sitemap)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert len(urls) == 5
+        assert "https://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_gzip_with_gz_extension(self, xml_sitemap):
+        """Sitemaps with .xml.gz extension are decompressed."""
+        compressed = gzip.compress(xml_sitemap.encode("utf-8"))
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(
+            compressed,
+            content_type="application/gzip",
+        )
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml.gz")
+
+        assert len(urls) == 5
+        assert "https://example.com/pricing" in urls
+
+
+# ── Error handling tests ────────────────────────────────────────
+
+
+class TestErrorHandling:
+    """Tests for graceful error handling."""
+
+    @pytest.mark.asyncio
+    async def test_404_returns_empty(self):
+        """A sitemap returning 404 returns an empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response("Not Found", status_code=404)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_500_returns_empty(self):
+        """A sitemap returning 500 returns an empty list."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response("Server Error", status_code=500)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_connection_error_returns_empty(self):
+        """A connection error when fetching sitemap returns empty."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_empty(self):
+        """A timeout fetching sitemap returns empty."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.TimeoutException("Timeout after 15s")
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.xml")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_text_sitemap_unsupported(self):
+        """A plain text sitemap is detected and returns empty."""
+        text_sitemap = "https://example.com/page1\nhttps://example.com/page2\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _mock_response(
+            text_sitemap,
+            content_type="text/plain",
+        )
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.parse_sitemap_url("https://example.com/sitemap.txt")
+
+        assert urls == []
+
+
+# ── get_urls integration tests ──────────────────────────────────
+
+
+class TestGetUrls:
+    """Tests for the full get_urls() flow."""
+
+    @pytest.mark.asyncio
+    async def test_get_urls_from_robots_txt(self, xml_sitemap):
+        """get_urls discovers sitemaps from robots.txt first."""
+        robots_txt = "User-agent: *\nSitemap: https://example.com/sitemap.xml\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+        assert "https://example.com/" in urls
+        assert "https://example.com/about" in urls
+
+    @pytest.mark.asyncio
+    async def test_get_urls_fallback_to_common_paths(self, xml_sitemap):
+        """get_urls falls back to common paths when robots.txt has no sitemap directives."""
+        robots_txt = "User-agent: *\nDisallow: /admin/\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+        assert "https://example.com/" in urls
+
+    @pytest.mark.asyncio
+    async def test_get_urls_robots_txt_404_falls_back(self, xml_sitemap):
+        """get_urls falls back to common paths when robots.txt is 404."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response("Not Found", status_code=404)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+
+    @pytest.mark.asyncio
+    async def test_get_urls_with_limit(self, xml_sitemap):
+        """get_urls respects the limit parameter."""
+        robots_txt = "User-agent: *\nSitemap: https://example.com/sitemap.xml\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com", limit=3)
+
+        assert len(urls) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_urls_no_sitemap_returns_empty(self):
+        """get_urls returns empty list when no sitemaps are found."""
+        robots_txt = "User-agent: *\nDisallow: /\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            # Simulate 404 on all common paths
+            return _mock_response("Not Found", status_code=404)
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert urls == []
+
+    @pytest.mark.asyncio
+    async def test_get_urls_deduplicates(self, xml_sitemap):
+        """Duplicate URLs across sitemaps are deduplicated."""
+        robots_txt = (
+            "User-agent: *\n"
+            "Sitemap: https://example.com/sitemap.xml\n"
+            "Sitemap: https://example.com/sitemap2.xml\n"
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            elif "sitemap2.xml" in url:
+                return _mock_response(xml_sitemap)  # Same URLs
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5  # Deduplicated
+
+    @pytest.mark.asyncio
+    async def test_get_urls_robots_txt_unreachable_falls_back(self, xml_sitemap):
+        """get_urls falls back to common paths when robots.txt is unreachable."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                raise httpx.ConnectError("Connection refused")
+            elif "sitemap.xml" in url:
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 5
+
+    @pytest.mark.asyncio
+    async def test_multiple_robots_txt_sitemap_directives(
+        self, xml_sitemap, child_sitemap1
+    ):
+        """Multiple Sitemap directives in robots.txt are all fetched."""
+        robots_txt = (
+            "User-agent: *\n"
+            "Sitemap: https://example.com/sitemap.xml\n"
+            "Sitemap: https://example.com/extra-sitemap.xml\n"
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif url.endswith("extra-sitemap.xml"):
+                return _mock_response(child_sitemap1)
+            elif url.endswith("sitemap.xml"):
+                return _mock_response(xml_sitemap)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        # 5 from sitemap.xml + 2 from extra-sitemap.xml = 7
+        assert len(urls) == 7
+
+    @pytest.mark.asyncio
+    async def test_get_urls_with_nested_index(
+        self, sitemap_index, child_sitemap1, child_sitemap2
+    ):
+        """get_urls follows nested sitemap indexes."""
+        robots_txt = "User-agent: *\nSitemap: https://example.com/sitemap_index.xml\n"
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        async def mock_get(url: str, **kwargs) -> AsyncMock:
+            if "robots.txt" in url:
+                return _mock_response(robots_txt)
+            elif "sitemap_index.xml" in url:
+                return _mock_response(sitemap_index)
+            elif "sitemap1.xml" in url:
+                return _mock_response(child_sitemap1)
+            elif "sitemap2.xml" in url:
+                return _mock_response(child_sitemap2)
+            return _mock_response("")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        parser = SitemapParser(client=mock_client)
+        urls = await parser.get_urls("example.com")
+
+        assert len(urls) == 4
+        assert "https://example.com/page1" in urls
+        assert "https://example.com/page2" in urls
+        assert "https://example.com/page3" in urls
+        assert "https://example.com/page4" in urls
+
+
+# ── URL normalization tests ─────────────────────────────────────
+
+
+class TestUrlNormalization:
+    """Tests for sitemap URL normalization."""
+
+    def test_normalize_strips_fragment(self):
+        """Fragments are stripped from sitemap URLs."""
+        result = SitemapParser._normalize_sitemap_url(
+            "https://example.com/page#section"
+        )
+        # Fragment is stripped by normalization
+        assert result == "https://example.com/page"
+
+    def test_normalize_rejects_non_http(self):
+        """Non-HTTP URLs return None."""
+        assert SitemapParser._normalize_sitemap_url("ftp://example.com/file") is None
+        assert SitemapParser._normalize_sitemap_url("mailto:admin@example.com") is None
+        assert SitemapParser._normalize_sitemap_url("") is None
+
+    def test_normalize_preserves_https(self):
+        """HTTPS URLs are preserved."""
+        result = SitemapParser._normalize_sitemap_url("https://example.com/page")
+        assert result == "https://example.com/page"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -17,6 +17,17 @@ def fake_redis():
     )
     r.get = MagicMock(side_effect=lambda key: store_data.get(key))
 
+    def _incr(key):
+        current = store_data.get(key)
+        if current is None:
+            current = "0"
+        new_val = str(int(current) + 1)
+        store_data[key] = new_val
+        return int(new_val)
+
+    r.incr = MagicMock(side_effect=_incr)
+    r.delete = MagicMock(side_effect=lambda key: store_data.pop(key, None) or True)
+
     def mock_scan(cursor=0, match=None, count=10):
         import fnmatch
 
@@ -84,7 +95,8 @@ class TestJobStore:
         meta = store.get_job(job_id)
         assert meta["status"] == "completed"
         assert meta["completed_at"] is not None
-        assert meta["data"] == {"result": "done"}
+        # complete_job adds the atomic completed count
+        assert meta["data"] == {"result": "done", "completed": 0}
 
     def test_complete_job_unknown_id_does_not_raise(self, store):
         store.complete_job("unknown", {"result": "done"})  # should not raise
@@ -156,3 +168,98 @@ class TestJobStore:
         store.complete_job(jid, data)
         meta = store.get_job(jid)
         assert meta["data"] == data
+
+    # ── Atomic progress (VAL-CONC-042) ─────────────────────────
+
+    def test_increment_completed_starts_at_0(self, store, fake_redis):
+        """Atomic completed counter is initialized to 0 on create."""
+        jid = store.create_job(kind="crawl")
+        assert store.get_completed(jid) == 0
+
+    def test_increment_completed_atomic(self, store, fake_redis):
+        """INCR returns increasing values — no lost increments."""
+        jid = store.create_job(kind="crawl")
+        assert store.increment_completed(jid) == 1
+        assert store.increment_completed(jid) == 2
+        assert store.increment_completed(jid) == 3
+        assert store.get_completed(jid) == 3
+
+    def test_increment_completed_multiple_jobs_independent(self, store, fake_redis):
+        """Two jobs have independent completed counters."""
+        jid_a = store.create_job(kind="crawl")
+        jid_b = store.create_job(kind="crawl")
+
+        store.increment_completed(jid_a)
+        store.increment_completed(jid_a)
+        store.increment_completed(jid_b)
+
+        assert store.get_completed(jid_a) == 2
+        assert store.get_completed(jid_b) == 1
+
+    def test_get_completed_returns_0_for_unknown_job(self, store):
+        """Non-existent job returns 0."""
+        assert store.get_completed("nonexistent") == 0
+
+    def test_update_job_progress_sources_completed_from_atomic_counter(
+        self, store, fake_redis
+    ):
+        """update_job_progress() uses the atomic counter for completed field."""
+        jid = store.create_job(kind="crawl")
+        store.increment_completed(jid)
+        store.increment_completed(jid)
+        store.increment_completed(jid)
+
+        store.update_job_progress(
+            job_id=jid,
+            pages=[
+                {"url": "https://a.com"},
+                {"url": "https://b.com"},
+                {"url": "https://c.com"},
+            ],
+            total=10,
+            errors=[],
+            robots_blocked=[],
+        )
+
+        raw = store.get_job(jid)
+        assert raw is not None
+        data = raw.get("data", {})
+        assert data["completed"] == 3
+        assert data["total"] == 10
+        assert len(data["pages"]) == 3
+
+    def test_update_job_progress_concurrent_safety(self, store, fake_redis):
+        """Simulating concurrent progress updates — each completed page is
+        counted exactly once via INCR, and the data payload reflects the
+        atomic count, not a stale local len()."""
+        jid = store.create_job(kind="crawl")
+
+        # Simulate three concurrent page completions
+        store.increment_completed(jid)
+        store.increment_completed(jid)
+        store.increment_completed(jid)
+
+        # Any subsequent update_job_progress call sees completed=3
+        store.update_job_progress(
+            job_id=jid, total=5, pages=[{"url": "a"}, {"url": "b"}, {"url": "c"}]
+        )
+        raw = store.get_job(jid)
+        data = raw.get("data", {})
+        assert data["completed"] == 3
+
+    def test_complete_job_includes_atomic_completed(self, store, fake_redis):
+        """complete_job() uses the atomic counter for the final count."""
+        jid = store.create_job(kind="crawl")
+        store.increment_completed(jid)
+        store.increment_completed(jid)
+
+        store.complete_job(jid, {"pages": [{"url": "a"}, {"url": "b"}]})
+        meta = store.get_job(jid)
+        data = meta.get("data", {})
+        assert data["completed"] == 2
+
+    def test_delete_completed_counter(self, store, fake_redis):
+        jid = store.create_job(kind="crawl")
+        store.increment_completed(jid)
+        store.delete_completed_counter(jid)
+        assert store.get_completed(jid) == 0

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -145,3 +145,70 @@ class TestDeliverWebhook:
                 "job-1",
             )
             assert mock_client.post.call_count > 1
+
+
+# ── Webhook idempotency (VAL-CONC-050) ──────────────────────────
+
+
+class TestWebhookId:
+    def test_unique_ids_for_same_job_different_events(self):
+        from agent.webhook import _next_webhook_id, _webhook_id_counter
+
+        _webhook_id_counter.clear()
+
+        id1 = _next_webhook_id("job-1", "crawl.started")
+        id2 = _next_webhook_id("job-1", "crawl.page-https://a.com")
+        assert id1 != id2
+        assert id1 == "job-1-crawl.started-1"
+        assert id2 == "job-1-crawl.page-https://a.com-1"
+
+    def test_incrementing_ids_for_same_event(self):
+        from agent.webhook import _next_webhook_id, _webhook_id_counter
+
+        _webhook_id_counter.clear()
+
+        id1 = _next_webhook_id("job-1", "crawl.page-https://a.com")
+        id2 = _next_webhook_id("job-1", "crawl.page-https://a.com")
+        assert id1 != id2
+        assert id1.endswith("-1")
+        assert id2.endswith("-2")
+
+    def test_ids_unique_across_different_jobs(self):
+        from agent.webhook import _next_webhook_id, _webhook_id_counter
+
+        _webhook_id_counter.clear()
+
+        id1 = _next_webhook_id("job-1", "crawl.page-https://a.com")
+        _webhook_id_counter.clear()
+        id2 = _next_webhook_id("job-2", "crawl.page-https://a.com")
+        assert id1 != id2
+
+    @pytest.mark.asyncio
+    async def test_webhook_delivery_includes_webhook_id(self):
+        from agent.webhook import deliver_webhook
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+            async def _post(*a, **kw):
+                return mock_resp
+
+            mock_client.post = MagicMock(side_effect=_post)
+
+            await deliver_webhook(
+                {"url": "https://hook.example.com"},
+                "crawl.page",
+                "job-123",
+                {"url": "https://example.com/page"},
+                webhook_id_key="crawl.page-https://example.com/page",
+            )
+
+            _args, kwargs = mock_client.post.call_args
+            body = kwargs["content"].decode()
+            assert '"webhookId"' in body
+            assert '"job-123-crawl.page-https://example.com/page-1"' in body

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -257,12 +257,18 @@ class TestProcessCrawlAsync:
                 scraper_url="http://scraper:8001",
             )
 
-        mock_store.fail_job.assert_called_once_with("crawl-fail", "Crawl error")
-        # Webhook called 2 times: crawl.started, then crawl.failed
+        # The CrawlEngine now handles start URL scrape failures internally
+        # and returns a CrawlResult with errors rather than raising.
+        # The crawl completes with 0 pages and error entries.
+        mock_store.complete_job.assert_called_once()
+        call_args = mock_store.complete_job.call_args[0][1]
+        assert call_args["completed"] == 0
+        assert len(call_args["errors"]) > 0
+        # Webhook called 2 times: crawl.started, then crawl.completed
         assert mock_deliver_webhook.call_count == 2
         events = [call[0][1] for call in mock_deliver_webhook.call_args_list]
         assert events[0] == "crawl.started"
-        assert events[1] == "crawl.failed"
+        assert events[1] == "crawl.completed"
         # scraper.close() called in finally
         mock_scraper_instance.close.assert_called_once()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -31,7 +31,11 @@ class TestProcessAgentAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -75,7 +79,11 @@ class TestProcessAgentAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -118,7 +126,11 @@ class TestProcessAgentAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -146,6 +158,7 @@ class TestProcessCrawlAsync:
         from agent.worker import _process_crawl_async
 
         mock_store = MagicMock()
+        mock_store.get_job.return_value = {"status": "processing"}  # not cancelled
         mock_scraper_instance = MagicMock()
         mock_scraper_instance.scrape = AsyncMock(
             return_value={
@@ -171,7 +184,11 @@ class TestProcessCrawlAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
             patch("agent.worker._index_page_async", AsyncMock()),
@@ -194,7 +211,12 @@ class TestProcessCrawlAsync:
         assert payload["pages"][0]["url"] == "https://example.com"
         assert payload["pages"][0]["markdown"] == "# Crawled page"
 
-        mock_deliver_webhook.assert_called_once()
+        # Webhook called 3 times: crawl.started, crawl.page, crawl.completed
+        assert mock_deliver_webhook.call_count == 3
+        events = [call[0][1] for call in mock_deliver_webhook.call_args_list]
+        assert events[0] == "crawl.started"
+        assert events[1] == "crawl.page"
+        assert events[2] == "crawl.completed"
         mock_scraper_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
@@ -219,7 +241,11 @@ class TestProcessCrawlAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -232,10 +258,74 @@ class TestProcessCrawlAsync:
             )
 
         mock_store.fail_job.assert_called_once_with("crawl-fail", "Crawl error")
-        mock_deliver_webhook.assert_called_once()
-        # Verify failed event
-        assert mock_deliver_webhook.call_args[0][1] == "failed"
+        # Webhook called 2 times: crawl.started, then crawl.failed
+        assert mock_deliver_webhook.call_count == 2
+        events = [call[0][1] for call in mock_deliver_webhook.call_args_list]
+        assert events[0] == "crawl.started"
+        assert events[1] == "crawl.failed"
         # scraper.close() called in finally
+        mock_scraper_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_during_crawl(self):
+        """Verify cancellation: engine detects cancelled status, preserves it."""
+        from agent.worker import _process_crawl_async
+
+        mock_store = MagicMock()
+        # Simulate job being cancelled in Redis (as DELETE would set)
+        mock_store.get_job.return_value = {"status": "cancelled"}
+        mock_scraper_instance = MagicMock()
+        mock_scraper_instance.scrape = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {
+                    "markdown": "# Crawled page",
+                    "metadata": {},
+                },
+            }
+        )
+        mock_scraper_instance.close = AsyncMock()
+        mock_deliver_webhook = AsyncMock()
+        mock_metrics = MagicMock()
+        mock_metrics.counter.return_value.inc = MagicMock()
+        mock_metrics.histogram.return_value.observe = MagicMock()
+
+        with (
+            patch("agent.worker.JobStore", return_value=mock_store),
+            patch("agent.worker.ScraperClient", return_value=mock_scraper_instance),
+            patch("agent.worker.deliver_webhook", mock_deliver_webhook),
+            patch("agent.worker.METRICS", mock_metrics),
+            patch(
+                "agent.worker.load_settings",
+                return_value=MagicMock(
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
+                ),
+            ),
+            patch("agent.worker._index_page_async", AsyncMock()),
+        ):
+            await _process_crawl_async(
+                job_id="crawl-cancel",
+                url="https://example.com",
+                max_pages=10,
+                max_depth=2,
+                scraper_url="http://scraper:8001",
+            )
+
+        # complete_job should NOT be called — cancel_job already set status
+        mock_store.complete_job.assert_not_called()
+        # Webhook: crawl.started, crawl.page (for start URL), crawl.completed (cancelled)
+        assert mock_deliver_webhook.call_count >= 2
+        events = [call[0][1] for call in mock_deliver_webhook.call_args_list]
+        assert events[0] == "crawl.started"
+        # Last event should be crawl.completed (for cancelled status)
+        assert events[-1] == "crawl.completed"
+        # The cancelled status should be in the payload
+        completed_payload = mock_deliver_webhook.call_args_list[-1][0][3]
+        assert completed_payload.get("status") == "cancelled"
         mock_scraper_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
@@ -265,7 +355,11 @@ class TestProcessCrawlAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
             patch("agent.worker._index_page_async", AsyncMock()),
@@ -324,7 +418,11 @@ class TestProcessBatchScrapeAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
             patch("agent.worker._index_batch_async", mock_index_batch),
@@ -383,7 +481,11 @@ class TestProcessBatchScrapeAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -427,7 +529,11 @@ class TestProcessBatchScrapeAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -466,7 +572,11 @@ class TestProcessExtractAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -506,7 +616,11 @@ class TestProcessExtractAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -555,7 +669,11 @@ class TestProcessLlmstxtAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -592,7 +710,11 @@ class TestProcessLlmstxtAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -627,7 +749,11 @@ class TestIndexPageAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -665,7 +791,11 @@ class TestIndexPageAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -698,7 +828,11 @@ class TestIndexPageAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -747,7 +881,11 @@ class TestIndexBatchAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):
@@ -779,7 +917,11 @@ class TestIndexBatchAsync:
             patch(
                 "agent.worker.load_settings",
                 return_value=MagicMock(
-                    valkey_host="valkey", valkey_port=6379, valkey_db=0
+                    valkey_host="valkey",
+                    valkey_port=6379,
+                    valkey_db=0,
+                    crawl_max_duration_seconds=1800,
+                    crawl_idle_timeout_seconds=300,
                 ),
             ),
         ):

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -118,6 +130,29 @@ wheels = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -128,23 +163,27 @@ wheels = [
 
 [[package]]
 name = "groktocrawl"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]
 dev = [
+    { name = "deptry" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
 ]
 provides-extras = ["dev"]
 
@@ -274,10 +313,76 @@ wheels = [
 ]
 
 [[package]]
+name = "requirements-parser"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/1a/5f3c22d38bf1d87d1f4a961489d9eba35c4370a21395562d94410cdd0e73/requirements_parser-0.13.1.tar.gz", hash = "sha256:78811383b2089b6c5197a1431bc2c12ff950245edca39a23eea3460782038dd3", size = 22783, upload-time = "2026-06-18T07:52:25.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f9/15b44d5e4401b0013bbcefe3c09d7bfddcce28cc3d41b1d3077bcedf5b1f/requirements_parser-0.13.1-py3-none-any.whl", hash = "sha256:6e385663eb32589d16e5b22bb6e5251a57908e73803ffff438b53cd6ea2056e0", size = 14926, upload-time = "2026-06-18T07:52:24.171Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,24 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -16,12 +34,98 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -162,9 +266,34 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.137.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/29/cc5819dc24d3daa80cdaa1aec023bf8652a70dd7fd1c96b0b225c99a7690/fastapi-0.137.2.tar.gz", hash = "sha256:b9d893bebc97dcfbdcb1917e88a292d062844ea19445a5fa4f7eb28c4baea9e3", size = 410332, upload-time = "2026-06-18T06:58:24.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/ed/0c6b644e99fb5697d8bdcd36cdb47c52e77a63fc7a1514b1f03a6ecab955/fastapi-0.137.2-py3-none-any.whl", hash = "sha256:791d36261e916a98b25ac85ee591bc3db159394070f6d3d096d94fb378f60ce2", size = 122252, upload-time = "2026-06-18T06:58:26.074Z" },
+]
+
+[[package]]
 name = "groktocrawl"
 version = "0.8.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "prometheus-client" },
+    { name = "redis" },
+    { name = "requests" },
+    { name = "uvicorn" },
+]
 
 [package.optional-dependencies]
 dev = [
@@ -176,16 +305,39 @@ dev = [
     { name = "vulture" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+    { name = "vulture" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.15.0" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "fastapi", specifier = ">=0.137.2" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.0" },
+    { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "redis", specifier = ">=8.0.0" },
+    { name = "requests", specifier = ">=2.34.2" },
+    { name = "uvicorn", specifier = ">=0.49.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "vulture", specifier = ">=2.16" },
+]
 
 [[package]]
 name = "h11"
@@ -261,6 +413,105 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -283,6 +534,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -313,6 +577,30 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "requirements-parser"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -322,6 +610,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/1a/5f3c22d38bf1d87d1f4a961489d9eba35c4370a21395562d94410cdd0e73/requirements_parser-0.13.1.tar.gz", hash = "sha256:78811383b2089b6c5197a1431bc2c12ff950245edca39a23eea3460782038dd3", size = 22783, upload-time = "2026-06-18T07:52:25.291Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/f9/15b44d5e4401b0013bbcefe3c09d7bfddcce28cc3d41b1d3077bcedf5b1f/requirements_parser-0.13.1-py3-none-any.whl", hash = "sha256:6e385663eb32589d16e5b22bb6e5251a57908e73803ffff438b53cd6ea2056e0", size = 14926, upload-time = "2026-06-18T07:52:24.171Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -376,6 +686,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements NL→params translation for crawl requests, the first feature of Milestone 5 (Full Firecrawl Parity).

### Changes

1. **Models** (`agent-svc/agent/models.py`):
   - Added `prompt` field to `CrawlRequest` (optional, max 10000 chars)
   - Added `ParamsPreviewRequest` model (requires url + prompt)
   - Added `ParamsPreviewResponse` model (camelCase output)

2. **NL→Params module** (`agent-svc/agent/nl_params.py` - new):
   - `derive_crawl_params()`: Uses existing `LLMClient` to translate NL prompts into structured crawl parameters
   - `merge_params()`: Explicit params override LLM-derived equivalents
   - `_safe_parse_llm_response()`: Handles markdown-fenced JSON, embedded JSON, and unparseable responses
   - `_validate_derived_params()`: Type/range validation of LLM output
   - Graceful handling of LLM unavailability and invalid JSON responses

3. **API** (`agent-svc/agent/api.py`):
   - Added `POST /v2/crawl/params-preview` endpoint (returns derived params without starting a crawl)
   - Wired `prompt` into `POST /v2/crawl` flow: derive params from prompt, merge with explicit params, explicit wins

4. **Tests** (`tests/test_crawler.py`):
   - 39 new tests covering: `_safe_parse_llm_response`, `_validate_derived_params`, `merge_params`, `derive_crawl_params` (with mocked LLM), model validation (prompt max_length, ParamsPreviewRequest/Response), and endpoint integration tests

### Verification
- ✅ mypy: no issues
- ✅ ruff: all checks passed
- ✅ 319 unit tests passed (0 failures)
- ✅ graphify: knowledge graph updated

### Validation Contract Fulfillment
- VAL-PARITY-001: CrawlRequest accepts `prompt` field
- VAL-PARITY-002: Prompt produces correct includePaths for common NL intents
- VAL-PARITY-003: POST /v2/crawl/params-preview endpoint exists
- VAL-PARITY-004: Params-preview returns 422 for missing prompt
- VAL-PARITY-033: CrawlRequest rejects invalid prompt gracefully (max_length validation)
- VAL-PARITY-040: Params-preview handles complex NL prompts
- VAL-PARITY-047: Params-preview is idempotent and deterministic (no crawl job created)
- VAL-PARITY-051: NL→params gracefully handles invalid/unparseable LLM JSON output
- VAL-PARITY-062: NL-derived params compose correctly with sitemap discovery