### PR TITLE
fix(ci): install jinja2 for portal tests and fix gitleaks ignore line

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          docker compose exec -T agent-svc pip install pytest pytest-timeout -q
+          docker compose exec -T agent-svc pip install pytest pytest-timeout jinja2 -q
           docker compose exec -T \
             -e PYTHONPATH=/app/agent-svc:/app/scraper-svc:/app/search-svc:/app/llm-svc:/app/parse-svc:/app/portal-svc:/app/browser-svc:/app \
             -e SCRAPER_BASE_URL=http://scraper-svc:8001 \

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,2 @@
 # Pre-existing documentation placeholder secrets in README examples
-README.md:curl-auth-header:346
+README.md:curl-auth-header:345


### PR DESCRIPTION
## Summary

Two CI fixes:

1. **Integration tests failing** — `test_portal.py` imports `portal.app` which uses `Jinja2Templates`. When tests run inside the `agent-svc` container, `jinja2` isn't installed (it's a `portal-svc` dependency). Caused a `ModuleNotFoundError` collection error that aborted the whole test run with `-x`.

   Fix: add `jinja2` to the `pip install` line in the integration test step.

2. **gitleaks false positive** — The `.gitleaksignore` entry pointed to line 346, but gitleaks matches line 345 (the `curl` line containing `Authorization`).

   Fix: update `.gitleaksignore` to use the correct fingerprint.

## Files Changed

- `.github/workflows/docker.yml` — add `jinja2` to pip install
- `.gitleaksignore` — fix line number from 346 to 345