### PR TITLE
fix: Tier 1 (llms.txt) should only fire for root URLs

### DIFF
--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -11,6 +11,7 @@ lives in ``fetch_quality.py``. Cache functions live in ``cache.py``.
 import asyncio
 import logging
 import os
+from urllib.parse import urlparse
 
 import httpx
 
@@ -410,8 +411,9 @@ async def smart_scrape(
                 if _quality_acceptable(cached):
                     return cached
 
-        # Tier 1: /llms.txt
-        if not probe.get("shielded") and not probe.get("is_binary"):
+        # Tier 1: /llms.txt — only for site root URLs
+        is_root = urlparse(url).path in ("", "/")
+        if is_root and not probe.get("shielded") and not probe.get("is_binary"):
             _proceed, blocked = await _politeness_check_and_delay(
                 url,
                 ignore_robots_txt=ignore_robots_txt,


### PR DESCRIPTION
## Summary

Tier 1 (`fetch_via_llms_txt`) was returning the site-wide `/llms.txt` content for **every sub-page**, not just the root URL. For sites with an llms.txt, every page returned identical content, triggering the content dedup to mark them all as duplicates. Result: crawl returns 1 page instead of the full site.

### Fix

Gate Tier 1 behind a root-URL check in `smart_scrape()`. The llms.txt is a site overview — it's the correct response for `GET /`, but not for `GET /article/`.

```python
is_root = urlparse(url).path in ("", "/")
if is_root and not probe.get("shielded") and not probe.get("is_binary"):
```

Sub-pages now fall through to Tier 2 (content negotiation) and Tier 3 (Playwright), which return the actual page content.

### Testing

- Pre-commit hooks: ruff lint, ruff format, trailing whitespace, EOF fixer, gitleaks — all pass
- Change is a 2-line guard + import, no new dependencies

### Related

Closes #316
