### PR TITLE
ci: skip droid-review on Dependabot PRs

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -35,7 +35,7 @@ jobs:
 
   droid-review:
     needs: assess-depth
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.actor != 'app/dependabot'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Dependabot-triggered workflows don't receive organization secrets (FACTORY_API_KEY comes through empty), so droid-review fails unnecessarily on automated version bumps like #321.

Skip the job entirely when `github.actor` is `app/dependabot`.

Closes the failing CI on dependabot PRs without needing to risk `pull_request_target` for secret access.