### PR TITLE
ci: prune untagged container images after push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,6 +100,24 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Prune untagged versions
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          PACKAGE_NAME=$(echo "${{ matrix.image }}" | sed 's|.*/||')
+          echo "Pruning untagged versions of $PACKAGE_NAME"
+          gh api \
+            --method GET \
+            "/orgs/${{ env.REGISTRY_OWNER }}/packages/container/$PACKAGE_NAME/versions?per_page=100" \
+            --jq '.[] | select(.metadata.container.tags == null or .metadata.container.tags == []) | .id' \
+            | while read version_id; do
+              echo "  Deleting version $version_id"
+              gh api --method DELETE \
+                "/orgs/${{ env.REGISTRY_OWNER }}/packages/container/$PACKAGE_NAME/versions/$version_id" --silent
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   integration-tests:
     name: Integration Tests
     needs: build-and-push


### PR DESCRIPTION
## Summary

Adds a cleanup step to the Docker Build & Publish workflow that deletes untagged (orphan) image versions immediately after each successful push to ghcr.io.

## Why

Every merge to main moves the `latest`/`unstable` tags to the new image, but the previous version stays on ghcr.io as an untagged orphan — still consuming storage. With 5 services × every push to main, these accumulate quickly against the 0.5 GB Actions storage pool (shared between Actions artifacts, cache, and ghcr.io images).

## What changed

- `.github/workflows/docker.yml` — new `Prune untagged versions` step after the build step, gated to run only on pushes (not PRs). Extracts the package name from the matrix image path and deletes any versions with no tags.

Closes #...