### PR TITLE
feat: add monitor manual trigger endpoint (POST /v2/monitor/:id/run)

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -69,7 +69,7 @@ from .models import (
     SearchResult,
     Source,
 )
-from .monitor import delete_monitor, get_all_monitors, get_monitor, save_monitor
+from .monitor import delete_monitor, get_all_monitors, get_monitor, run_monitor, save_monitor
 from .store import JobStore
 
 logger = logging.getLogger(__name__)
@@ -1622,6 +1622,48 @@ async def delete_monitor_route(monitor_id: str) -> MonitorDeleteResponse:
         r.delete(f"monitor:{monitor_id}:seen")
     delete_monitor(monitor_id)
     return MonitorDeleteResponse(success=True)
+
+
+@router.post("/v2/monitor/{monitor_id}/run", response_model=MonitorResponse)
+async def run_monitor_check(request: Request, monitor_id: str) -> MonitorResponse:
+    """Manually trigger a monitor check immediately.
+
+    Runs the check regardless of the cron schedule and returns
+    the updated monitor status including any diff or new results.
+    """
+    store: JobStore = request.app.state.job_store
+    scraper_url = request.app.state.scraper_url
+
+    try:
+        result = await run_monitor(monitor_id, scraper_url=scraper_url)
+    except ValueError:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+
+    search_config = cfg.get("search_config")
+    if isinstance(search_config, str):
+        import json
+
+        search_config = json.loads(search_config)
+
+    return MonitorResponse(
+        id=monitor_id,
+        monitor_type=cfg.get("monitor_type", "scrape"),
+        url=cfg.get("url"),
+        search_config=search_config,
+        schedule=cfg.get("schedule", ""),
+        webhook=cfg.get("webhook"),
+        last_checked=cfg.get("last_checked"),
+        last_result=cfg.get("last_result"),
+        created_at=cfg.get("created_at", ""),
+    )
 
 
 # ----- Parse -----

--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -257,6 +257,23 @@ async def run_search_monitor(monitor_id: str, config: dict) -> dict:
     return result
 
 
+async def run_monitor(monitor_id: str, scraper_url: str = "http://scraper-svc:8001") -> dict:
+    """Run a single monitor check immediately, regardless of schedule.
+
+    Loads the monitor config, dispatches to the appropriate check function
+    (scrape or search), and returns the check result.
+    """
+    config = get_monitor(monitor_id)
+    if config is None:
+        raise ValueError(f"Monitor {monitor_id} not found")
+
+    config["scraper_url"] = scraper_url
+    mt = config.get("monitor_type", "scrape")
+    if mt == "search":
+        return await run_search_monitor(monitor_id, config)
+    return await check_monitor(monitor_id, config)
+
+
 async def check_all_async() -> list[dict]:
     """Check all monitors."""
     monitors = get_all_monitors()

--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -326,3 +326,4 @@ def check_all() -> None:
 
 if __name__ == "__main__":
     check_all()
+#CI trigger


### PR DESCRIPTION
Adds run_monitor() to monitor.py and POST /v2/monitor/:monitorId/run to the API. Dispatches to the appropriate check function (scrape or search) immediately, regardless of the cron schedule. Returns updated monitor status with last_checked and last_result.

Closes #339