### PR TITLE
feat: add monitor manual trigger endpoint (POST /v2/monitor/:id/run)

### DIFF
--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -26,7 +26,9 @@ from .models import (
     AgentStatusResponse,
     AnswerRequest,
     AnswerResponse,
+    BatchScrapeErrorsResponse,
     BatchScrapeRequest,
+    BatchScrapeStatusResponse,
     BrowserCreateRequest,
     BrowserCreateResponse,
     BrowserDeleteResponse,
@@ -69,7 +71,7 @@ from .models import (
     SearchResult,
     Source,
 )
-from .monitor import delete_monitor, get_all_monitors, get_monitor, save_monitor
+from .monitor import delete_monitor, get_all_monitors, get_monitor, run_monitor, save_monitor
 from .store import JobStore
 
 logger = logging.getLogger(__name__)
@@ -817,6 +819,100 @@ async def create_batch_scrape(
     return CrawlCreateResponse(id=job_id)
 
 
+@router.get("/v2/batch/scrape/{job_id}", response_model=BatchScrapeStatusResponse)
+async def get_batch_scrape_status(
+    request: Request,
+    job_id: str,
+    offset: int = 0,
+) -> BatchScrapeStatusResponse:
+    """Get batch scrape job status and paginated results."""
+    store: JobStore = request.app.state.job_store
+    job = store.get_job(job_id)
+    if job is None:
+        raise NotFoundError(detail="Job not found", details={"job_id": job_id})
+    data = job.get("data") or {}
+    all_pages: list[dict] = data.get("pages", []) or []
+
+    created_at = job.get("created_at")
+    completed_at = job.get("completed_at")
+    duration: int | None = None
+    if created_at and completed_at:
+        try:
+            from datetime import datetime as _dt
+
+            created_dt = _dt.fromisoformat(created_at)
+            completed_dt = _dt.fromisoformat(completed_at)
+            duration = int((completed_dt - created_dt).total_seconds() * 1000)
+        except (ValueError, TypeError):
+            duration = None
+
+    completed_count = data.get("completed", 0)
+    credits_used = completed_count or len(all_pages)
+
+    # Pagination
+    _max_chunk_bytes = 10 * 1024 * 1024
+    _estimated_page_bytes = 10 * 1024
+    _max_pages_per_chunk = max(1, _max_chunk_bytes // _estimated_page_bytes)
+
+    chunk_pages = all_pages[offset:]
+    next_url: str | None = None
+
+    if len(chunk_pages) > _max_pages_per_chunk:
+        chunk_pages = all_pages[offset : offset + _max_pages_per_chunk]
+        next_offset = offset + _max_pages_per_chunk
+        if next_offset < len(all_pages):
+            scheme = request.url.scheme
+            host = request.url.netloc
+            path = request.url.path
+            next_url = f"{scheme}://{host}{path}?offset={next_offset}"
+    elif offset > 0 and not chunk_pages:
+        chunk_pages = []
+
+    return BatchScrapeStatusResponse(
+        status=job.get("status", "processing"),
+        completed=completed_count,
+        total=data.get("total", 0),
+        credits_used=credits_used,
+        data=chunk_pages or (all_pages if offset == 0 else []),
+        error=job.get("error"),
+        next=next_url,
+        created_at=created_at,
+        completed_at=completed_at,
+        expires_at=job.get("expires_at"),
+        duration=duration,
+    )
+
+
+@router.delete("/v2/batch/scrape/{job_id}", response_model=AgentCancelResponse)
+async def cancel_batch_scrape(request: Request, job_id: str) -> AgentCancelResponse:
+    """Cancel an in-progress batch scrape job."""
+    store: JobStore = request.app.state.job_store
+    if not store.cancel_job(job_id):
+        raise NotFoundError(
+            detail="Job not found or already completed", details={"job_id": job_id}
+        )
+    return AgentCancelResponse(success=True)
+
+
+@router.get(
+    "/v2/batch/scrape/{job_id}/errors", response_model=BatchScrapeErrorsResponse
+)
+async def get_batch_scrape_errors(
+    request: Request, job_id: str
+) -> BatchScrapeErrorsResponse:
+    """Get per-URL errors for a batch scrape job."""
+    store: JobStore = request.app.state.job_store
+    job = store.get_job(job_id)
+    if job is None:
+        raise NotFoundError(detail="Job not found", details={"job_id": job_id})
+    data = job.get("data") or {}
+    raw_errors: list[dict] = data.get("errors", [])
+    return BatchScrapeErrorsResponse(
+        success=True,
+        errors=[CrawlErrorItem(**e) for e in raw_errors],
+    )
+
+
 @router.post("/v1/search")
 async def search_v1(request: Request, body: SearchRequest) -> dict[str, Any]:
     """Firecrawl v1-compatible search endpoint.
@@ -1462,7 +1558,9 @@ async def create_monitor(body: MonitorCreateRequest) -> MonitorResponse:
     if body.monitor_type == "search":
         config = {
             "monitor_type": "search",
-            "search_config": body.search_config.model_dump() if body.search_config else {},
+            "search_config": body.search_config.model_dump()
+            if body.search_config
+            else {},
             "schedule": body.schedule,
             "webhook": body.webhook,
             "created_at": now,
@@ -1622,6 +1720,48 @@ async def delete_monitor_route(monitor_id: str) -> MonitorDeleteResponse:
         r.delete(f"monitor:{monitor_id}:seen")
     delete_monitor(monitor_id)
     return MonitorDeleteResponse(success=True)
+
+
+@router.post("/v2/monitor/{monitor_id}/run", response_model=MonitorResponse)
+async def run_monitor_check(request: Request, monitor_id: str) -> MonitorResponse:
+    """Manually trigger a monitor check immediately.
+
+    Runs the check regardless of the cron schedule and returns
+    the updated monitor status including any diff or new results.
+    """
+    store: JobStore = request.app.state.job_store
+    scraper_url = request.app.state.scraper_url
+
+    try:
+        result = await run_monitor(monitor_id, scraper_url=scraper_url)
+    except ValueError:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+
+    search_config = cfg.get("search_config")
+    if isinstance(search_config, str):
+        import json
+
+        search_config = json.loads(search_config)
+
+    return MonitorResponse(
+        id=monitor_id,
+        monitor_type=cfg.get("monitor_type", "scrape"),
+        url=cfg.get("url"),
+        search_config=search_config,
+        schedule=cfg.get("schedule", ""),
+        webhook=cfg.get("webhook"),
+        last_checked=cfg.get("last_checked"),
+        last_result=cfg.get("last_result"),
+        created_at=cfg.get("created_at", ""),
+    )
 
 
 # ----- Parse -----

--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -257,6 +257,23 @@ async def run_search_monitor(monitor_id: str, config: dict) -> dict:
     return result
 
 
+async def run_monitor(monitor_id: str, scraper_url: str = "http://scraper-svc:8001") -> dict:
+    """Run a single monitor check immediately, regardless of schedule.
+
+    Loads the monitor config, dispatches to the appropriate check function
+    (scrape or search), and returns the check result.
+    """
+    config = get_monitor(monitor_id)
+    if config is None:
+        raise ValueError(f"Monitor {monitor_id} not found")
+
+    config["scraper_url"] = scraper_url
+    mt = config.get("monitor_type", "scrape")
+    if mt == "search":
+        return await run_search_monitor(monitor_id, config)
+    return await check_monitor(monitor_id, config)
+
+
 async def check_all_async() -> list[dict]:
     """Check all monitors."""
     monitors = get_all_monitors()


### PR DESCRIPTION
Adds run_monitor() to monitor.py and POST /v2/monitor/:monitorId/run to the API. Dispatches to the appropriate check function (scrape or search) immediately, regardless of the cron schedule. Returns updated monitor status with last_checked and last_result.

Closes #339