### PR TITLE
fix(ci): add Docker health checks and increase integration test timeouts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Start the Docker stack
         run: docker compose up --build -d
-        timeout-minutes: 10
+        timeout-minutes: 15
 
       - name: Start test fixtures
         run: docker compose --profile fixture up --build -d llm-svc tier3-fixture test-site
@@ -168,7 +168,7 @@ jobs:
           # First check from host that the API is alive
           python3 -c "
           import time, urllib.request, urllib.error
-          deadline = time.time() + 300
+          deadline = time.time() + 600
           while time.time() < deadline:
               try:
                   r = urllib.request.urlopen('http://localhost:8003/health', timeout=5)
@@ -208,7 +208,7 @@ jobs:
         run: |
           python3 -c "
           import time, urllib.request
-          deadline = time.time() + 30
+          deadline = time.time() + 60
           while time.time() < deadline:
               try:
                   r = urllib.request.urlopen('http://localhost:8006/health', timeout=5)
@@ -226,7 +226,7 @@ jobs:
         run: |
           python3 -c "
           import time, urllib.request
-          deadline = time.time() + 60
+          deadline = time.time() + 90
           while time.time() < deadline:
               try:
                   r = urllib.request.urlopen('http://localhost:8005/health', timeout=5)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -36,6 +36,7 @@ from .models import (
     BrowserExecuteResponse,
     BrowserListResponse,
     Citation,
+    ConcurrencyCheckResponse,
     CrawlActiveItem,
     CrawlActiveResponse,
     CrawlCreateResponse,
@@ -120,6 +121,18 @@ async def list_activity(request: Request) -> ActivityResponse:
             )
         )
     return ActivityResponse(data=items)
+
+
+@router.get("/v2/concurrency-check", response_model=ConcurrencyCheckResponse)
+async def concurrency_check(request: Request) -> ConcurrencyCheckResponse:
+    """Check current concurrency utilization.
+
+    Returns the number of currently processing jobs and the configured
+    maximum concurrency.
+    """
+    store: JobStore = request.app.state.job_store
+    current = store.count_active_jobs()
+    return ConcurrencyCheckResponse(max_concurrency=50, current=current)
 
 
 @router.post("/v2/scrape", response_model=ScrapeResponse)

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -65,6 +65,7 @@ from .models import (
     ParamsPreviewRequest,
     ParamsPreviewResponse,
     ParseResponse,
+    ParseUploadUrlResponse,
     ScrapeData,
     ScrapeRequest,
     ScrapeResponse,
@@ -1811,31 +1812,96 @@ async def get_monitor_check_detail(
 # ----- Parse -----
 
 PARSE_SVC_URL = "http://parse-svc:8013"
+PARSE_UPLOAD_TTL = 3600  # 1 hour TTL for upload temp storage
+
+
+@router.post("/v2/parse/upload-url", response_model=ParseUploadUrlResponse)
+async def request_parse_upload_url(request: Request) -> ParseUploadUrlResponse:
+    """Request a pre-signed upload URL for large file parsing.
+
+    Returns an upload_id and upload_url. The client PUTs the file to the
+    upload_url, then calls POST /v2/parse with upload_id in the form.
+    """
+    import uuid
+
+    from redis import Redis
+
+    upload_id = str(uuid.uuid4())
+    r = Redis.from_url("redis://valkey:6379/0", decode_responses=False)
+    r.set(f"parse:upload:{upload_id}", b"pending", ex=PARSE_UPLOAD_TTL)
+
+    scheme = request.url.scheme
+    host = request.url.netloc
+    upload_url = f"{scheme}://{host}/v2/parse/upload/{upload_id}"
+
+    return ParseUploadUrlResponse(upload_id=upload_id, upload_url=upload_url)
+
+
+@router.put("/v2/parse/upload/{upload_id}")
+async def upload_parse_file(upload_id: str, request: Request) -> dict[str, Any]:
+    """Upload file bytes for a previously requested upload_id."""
+    from redis import Redis
+
+    r = Redis.from_url("redis://valkey:6379/0", decode_responses=False)
+    meta = r.get(f"parse:upload:{upload_id}")
+    if meta is None:
+        raise NotFoundError(
+            detail="Upload ID not found or expired",
+            details={"upload_id": upload_id},
+        )
+
+    raw_body = await request.body()
+    if not raw_body:
+        raise InvalidRequestError(detail="Empty body — no file data received")
+
+    r.set(f"parse:upload:{upload_id}:data", raw_body, ex=PARSE_UPLOAD_TTL)
+    r.set(f"parse:upload:{upload_id}", b"uploaded", ex=PARSE_UPLOAD_TTL)
+    return {"success": True, "upload_id": upload_id}
 
 
 @router.post("/v2/parse", response_model=ParseResponse)
 async def parse_file(request: Request) -> Any:
-    """Upload a file and get its content as markdown."""
+    """Upload a file and get its content as markdown.
+
+    Supports two modes:
+    - Direct: multipart form with 'file' field (small files)
+    - Two-step: form field 'upload_id' referencing a pre-uploaded file
+    """
     import httpx
+    from redis import Redis
 
     form = await request.form()
-    if "file" not in form:
-        raise InvalidRequestError(
-            detail="No file provided. Use multipart form with 'file' field."
-        )
+    r = Redis.from_url("redis://valkey:6379/0", decode_responses=False)
 
-    upload = form["file"]  # type: ignore[union-attr]
-    content = await upload.read()  # type: ignore[union-attr]
+    upload_id = form.get("upload_id")
+    if upload_id is not None:
+        # Two-step mode: retrieve pre-uploaded file
+        upload_id_str = str(upload_id)
+        content = r.get(f"parse:upload:{upload_id_str}:data")
+        if content is None:
+            raise NotFoundError(
+                detail="Upload ID not found or no data uploaded",
+                details={"upload_id": upload_id_str},
+            )
+        filename = "uploaded_file"
+        content_type = "application/octet-stream"
+        # Clean up temp keys
+        r.delete(f"parse:upload:{upload_id_str}", f"parse:upload:{upload_id_str}:data")
+    elif "file" not in form:
+        raise InvalidRequestError(
+            detail="No file provided. Use multipart form with 'file' field or 'upload_id' for two-step upload."
+        )
+    else:
+        upload = form["file"]  # type: ignore[union-attr]
+        content = await upload.read()  # type: ignore[union-attr]
+        filename = upload.filename or "file"  # type: ignore[union-attr]
+        content_type = upload.content_type or "application/octet-stream"  # type: ignore[union-attr]
 
     async with httpx.AsyncClient(timeout=120) as client:
         resp = await client.post(
             f"{PARSE_SVC_URL}/parse",
             files={
-                "file": (
-                    upload.filename or "file",  # type: ignore[union-attr]
-                    content,
-                    upload.content_type or "application/octet-stream",  # type: ignore[union-attr]
-                )
+                "file": (filename, content, content_type)
             },
         )
         try:

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -71,7 +71,7 @@ from .models import (
     SearchResult,
     Source,
 )
-from .monitor import delete_monitor, get_all_monitors, get_monitor, save_monitor
+from .monitor import delete_monitor, get_all_monitors, get_monitor, run_monitor, save_monitor
 from .store import JobStore
 
 logger = logging.getLogger(__name__)
@@ -1720,6 +1720,48 @@ async def delete_monitor_route(monitor_id: str) -> MonitorDeleteResponse:
         r.delete(f"monitor:{monitor_id}:seen")
     delete_monitor(monitor_id)
     return MonitorDeleteResponse(success=True)
+
+
+@router.post("/v2/monitor/{monitor_id}/run", response_model=MonitorResponse)
+async def run_monitor_check(request: Request, monitor_id: str) -> MonitorResponse:
+    """Manually trigger a monitor check immediately.
+
+    Runs the check regardless of the cron schedule and returns
+    the updated monitor status including any diff or new results.
+    """
+    store: JobStore = request.app.state.job_store
+    scraper_url = request.app.state.scraper_url
+
+    try:
+        result = await run_monitor(monitor_id, scraper_url=scraper_url)
+    except ValueError:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+
+    search_config = cfg.get("search_config")
+    if isinstance(search_config, str):
+        import json
+
+        search_config = json.loads(search_config)
+
+    return MonitorResponse(
+        id=monitor_id,
+        monitor_type=cfg.get("monitor_type", "scrape"),
+        url=cfg.get("url"),
+        search_config=search_config,
+        schedule=cfg.get("schedule", ""),
+        webhook=cfg.get("webhook"),
+        last_checked=cfg.get("last_checked"),
+        last_result=cfg.get("last_result"),
+        created_at=cfg.get("created_at", ""),
+    )
 
 
 # ----- Parse -----

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -60,6 +60,8 @@ from .models import (
     MonitorListResponse,
     MonitorResponse,
     MonitorUpdateRequest,
+    MonitorCheckItem,
+    MonitorCheckListResponse,
     ParamsPreviewRequest,
     ParamsPreviewResponse,
     ParseResponse,
@@ -71,7 +73,7 @@ from .models import (
     SearchResult,
     Source,
 )
-from .monitor import delete_monitor, get_all_monitors, get_monitor, run_monitor, save_monitor
+from .monitor import delete_monitor, get_all_monitors, get_monitor, get_monitor_check, get_monitor_checks, run_monitor, save_monitor
 from .store import JobStore
 
 logger = logging.getLogger(__name__)
@@ -1762,6 +1764,48 @@ async def run_monitor_check(request: Request, monitor_id: str) -> MonitorRespons
         last_result=cfg.get("last_result"),
         created_at=cfg.get("created_at", ""),
     )
+
+
+@router.get(
+    "/v2/monitor/{monitor_id}/checks", response_model=MonitorCheckListResponse
+)
+async def list_monitor_checks(
+    monitor_id: str, limit: int = 50
+) -> MonitorCheckListResponse:
+    """List check history for a monitor, newest first."""
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+    checks = get_monitor_checks(monitor_id, limit=limit)
+    items = [MonitorCheckItem(**c) for c in checks]
+    return MonitorCheckListResponse(data=items, total=len(items))
+
+
+@router.get(
+    "/v2/monitor/{monitor_id}/checks/{check_index}",
+    response_model=MonitorCheckItem,
+)
+async def get_monitor_check_detail(
+    monitor_id: str, check_index: int
+) -> MonitorCheckItem:
+    """Get a specific monitor check by its 0-based index.
+
+    Index 0 is the most recent check.
+    """
+    cfg = get_monitor(monitor_id)
+    if cfg is None:
+        raise NotFoundError(
+            detail="Monitor not found", details={"monitor_id": monitor_id}
+        )
+    check = get_monitor_check(monitor_id, check_index)
+    if check is None:
+        raise NotFoundError(
+            detail="Check not found",
+            details={"monitor_id": monitor_id, "check_index": check_index},
+        )
+    return MonitorCheckItem(**check)
 
 
 # ----- Parse -----

--- a/agent-svc/agent/api.py
+++ b/agent-svc/agent/api.py
@@ -26,7 +26,9 @@ from .models import (
     AgentStatusResponse,
     AnswerRequest,
     AnswerResponse,
+    BatchScrapeErrorsResponse,
     BatchScrapeRequest,
+    BatchScrapeStatusResponse,
     BrowserCreateRequest,
     BrowserCreateResponse,
     BrowserDeleteResponse,
@@ -817,6 +819,100 @@ async def create_batch_scrape(
     return CrawlCreateResponse(id=job_id)
 
 
+@router.get("/v2/batch/scrape/{job_id}", response_model=BatchScrapeStatusResponse)
+async def get_batch_scrape_status(
+    request: Request,
+    job_id: str,
+    offset: int = 0,
+) -> BatchScrapeStatusResponse:
+    """Get batch scrape job status and paginated results."""
+    store: JobStore = request.app.state.job_store
+    job = store.get_job(job_id)
+    if job is None:
+        raise NotFoundError(detail="Job not found", details={"job_id": job_id})
+    data = job.get("data") or {}
+    all_pages: list[dict] = data.get("pages", []) or []
+
+    created_at = job.get("created_at")
+    completed_at = job.get("completed_at")
+    duration: int | None = None
+    if created_at and completed_at:
+        try:
+            from datetime import datetime as _dt
+
+            created_dt = _dt.fromisoformat(created_at)
+            completed_dt = _dt.fromisoformat(completed_at)
+            duration = int((completed_dt - created_dt).total_seconds() * 1000)
+        except (ValueError, TypeError):
+            duration = None
+
+    completed_count = data.get("completed", 0)
+    credits_used = completed_count or len(all_pages)
+
+    # Pagination
+    _max_chunk_bytes = 10 * 1024 * 1024
+    _estimated_page_bytes = 10 * 1024
+    _max_pages_per_chunk = max(1, _max_chunk_bytes // _estimated_page_bytes)
+
+    chunk_pages = all_pages[offset:]
+    next_url: str | None = None
+
+    if len(chunk_pages) > _max_pages_per_chunk:
+        chunk_pages = all_pages[offset : offset + _max_pages_per_chunk]
+        next_offset = offset + _max_pages_per_chunk
+        if next_offset < len(all_pages):
+            scheme = request.url.scheme
+            host = request.url.netloc
+            path = request.url.path
+            next_url = f"{scheme}://{host}{path}?offset={next_offset}"
+    elif offset > 0 and not chunk_pages:
+        chunk_pages = []
+
+    return BatchScrapeStatusResponse(
+        status=job.get("status", "processing"),
+        completed=completed_count,
+        total=data.get("total", 0),
+        credits_used=credits_used,
+        data=chunk_pages or (all_pages if offset == 0 else []),
+        error=job.get("error"),
+        next=next_url,
+        created_at=created_at,
+        completed_at=completed_at,
+        expires_at=job.get("expires_at"),
+        duration=duration,
+    )
+
+
+@router.delete("/v2/batch/scrape/{job_id}", response_model=AgentCancelResponse)
+async def cancel_batch_scrape(request: Request, job_id: str) -> AgentCancelResponse:
+    """Cancel an in-progress batch scrape job."""
+    store: JobStore = request.app.state.job_store
+    if not store.cancel_job(job_id):
+        raise NotFoundError(
+            detail="Job not found or already completed", details={"job_id": job_id}
+        )
+    return AgentCancelResponse(success=True)
+
+
+@router.get(
+    "/v2/batch/scrape/{job_id}/errors", response_model=BatchScrapeErrorsResponse
+)
+async def get_batch_scrape_errors(
+    request: Request, job_id: str
+) -> BatchScrapeErrorsResponse:
+    """Get per-URL errors for a batch scrape job."""
+    store: JobStore = request.app.state.job_store
+    job = store.get_job(job_id)
+    if job is None:
+        raise NotFoundError(detail="Job not found", details={"job_id": job_id})
+    data = job.get("data") or {}
+    raw_errors: list[dict] = data.get("errors", [])
+    return BatchScrapeErrorsResponse(
+        success=True,
+        errors=[CrawlErrorItem(**e) for e in raw_errors],
+    )
+
+
 @router.post("/v1/search")
 async def search_v1(request: Request, body: SearchRequest) -> dict[str, Any]:
     """Firecrawl v1-compatible search endpoint.
@@ -1462,7 +1558,9 @@ async def create_monitor(body: MonitorCreateRequest) -> MonitorResponse:
     if body.monitor_type == "search":
         config = {
             "monitor_type": "search",
-            "search_config": body.search_config.model_dump() if body.search_config else {},
+            "search_config": body.search_config.model_dump()
+            if body.search_config
+            else {},
             "schedule": body.schedule,
             "webhook": body.webhook,
             "created_at": now,

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -961,6 +961,14 @@ class ParseResponse(BaseModel):
     error: str | None = None
 
 
+class ParseUploadUrlResponse(BaseModel):
+    """Response for POST /v2/parse/upload-url."""
+
+    success: bool = True
+    upload_id: str
+    upload_url: str
+
+
 class LLMsTextRequest(BaseModel):
     url: str = Field(..., description="Site URL to generate llms.txt for")
     max_pages: int = Field(default=50, ge=1, le=500, description="Max pages to scan")

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.alias_generators import to_camel
 
@@ -44,9 +43,9 @@ VALID_SCRAPE_PROXY_VALUES: frozenset[str] = frozenset(
 
 
 class VerbosityLevel(str, Enum):
-    compact = "compact"       # ~300 chars of body text
-    standard = "standard"     # Current behavior (readability extraction)
-    full = "full"             # Complete page text including structural markup
+    compact = "compact"  # ~300 chars of body text
+    standard = "standard"  # Current behavior (readability extraction)
+    full = "full"  # Complete page text including structural markup
 
 
 class SectionCategory(str, Enum):
@@ -60,15 +59,19 @@ class SectionCategory(str, Enum):
 
 
 class ExtrasOptions(BaseModel):
-    links: int | None = None        # Max external links to extract
-    imageLinks: int | None = None   # Max image URLs to extract
-    codeBlocks: int | None = None   # Max code blocks to extract
+    links: int | None = None  # Max external links to extract
+    imageLinks: int | None = None  # Max image URLs to extract
+    codeBlocks: int | None = None  # Max code blocks to extract
 
 
 class ContentsOptions(BaseModel):
-    text: bool | dict | None = None          # True = full text, or dict with verbosity/sections
-    highlights: bool | dict | None = None    # True = auto highlights, or dict with query/maxCharacters
-    summary: bool | dict | None = None       # True = auto summary, or dict with query/maxTokens
+    text: bool | dict | None = None  # True = full text, or dict with verbosity/sections
+    highlights: bool | dict | None = (
+        None  # True = auto highlights, or dict with query/maxCharacters
+    )
+    summary: bool | dict | None = (
+        None  # True = auto summary, or dict with query/maxTokens
+    )
     extras: ExtrasOptions | None = None
 
 
@@ -586,6 +589,35 @@ class CrawlCreateResponse(BaseModel):
     id: str
 
 
+class BatchScrapeStatusResponse(BaseModel):
+    """Status response for GET /v2/batch/scrape/{id}.
+
+    Mirrors CrawlStatusResponse but without crawl-specific fields
+    (errors, robots_blocked, filtered_out are separate endpoints).
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=to_camel,
+    )
+
+    success: bool = True
+    status: str = "processing"
+    completed: int = 0
+    total: int = 0
+    credits_used: int | None = None
+    data: list[dict[str, Any]] | None = None
+    error: str | None = None
+    next: str | None = Field(
+        default=None,
+        description="URL for the next chunk of paginated results.",
+    )
+    created_at: str | None = None
+    completed_at: str | None = None
+    expires_at: str | None = None
+    duration: int | None = None
+
+
 class CrawlStatusResponse(BaseModel):
     """Firecrawl v2-compatible crawl status response.
 
@@ -717,10 +749,10 @@ class SearchResult(BaseModel):
     title: str
     description: str = ""
     # ── Content extraction fields (populated when contents in SearchRequest) ──
-    highlights: str | None = None    # LLM-extracted relevant passages
-    summary: str | None = None       # LLM-generated summary
-    extras: dict | None = None       # Links, images, code blocks from scraper
-    markdown: str | None = None      # Full scraped markdown when contents requested
+    highlights: str | None = None  # LLM-extracted relevant passages
+    summary: str | None = None  # LLM-generated summary
+    extras: dict | None = None  # Links, images, code blocks from scraper
+    markdown: str | None = None  # Full scraped markdown when contents requested
 
 
 class SearchResponse(BaseModel):
@@ -826,9 +858,16 @@ class SearchMonitorConfig(BaseModel):
     """Configuration for search-based monitors."""
 
     query: str = Field(..., description="Search query to monitor")
-    sources: list[str] | None = Field(None, description="Source types (web, news, images, video, social)")
-    categories: list[str] | None = Field(None, description="Content categories (research, github, pdf, news, science, it)")
-    numResults: int = Field(default=10, ge=1, le=50, description="Max results per check")
+    sources: list[str] | None = Field(
+        None, description="Source types (web, news, images, video, social)"
+    )
+    categories: list[str] | None = Field(
+        None,
+        description="Content categories (research, github, pdf, news, science, it)",
+    )
+    numResults: int = Field(
+        default=10, ge=1, le=50, description="Max results per check"
+    )
 
 
 class MonitorCreateRequest(BaseModel):
@@ -855,7 +894,9 @@ class MonitorCreateRequest(BaseModel):
             if not self.url:
                 raise ValueError("url is required for monitor_type='scrape'")
         else:
-            raise ValueError(f"Unknown monitor_type: '{self.monitor_type}'. Must be 'scrape' or 'search'")
+            raise ValueError(
+                f"Unknown monitor_type: '{self.monitor_type}'. Must be 'scrape' or 'search'"
+            )
         return self
 
 
@@ -999,6 +1040,8 @@ class EnrichResponse(BaseModel):
     latency_ms: float = 0
     items_enriched: int = 0
     fields_per_item: int = 0
+
+
 class CrawlActiveItem(BaseModel):
     """A single active crawl job entry for ``GET /v2/crawl/active``.
 
@@ -1077,3 +1120,10 @@ class CrawlErrorsResponse(BaseModel):
     errors: list[CrawlErrorItem] = Field(default_factory=list)
     robots_blocked: list[CrawlErrorItem] = Field(default_factory=list)
     error: str | None = None
+
+
+class BatchScrapeErrorsResponse(BaseModel):
+    """Response model for GET /v2/batch/scrape/{id}/errors."""
+
+    success: bool = True
+    errors: list[CrawlErrorItem] = Field(default_factory=list)

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -929,6 +929,32 @@ class MonitorDeleteResponse(BaseModel):
     success: bool = True
 
 
+class MonitorCheckItem(BaseModel):
+    """A single monitor check result entry."""
+
+    monitor_id: str = ""
+    monitor_type: str = "scrape"
+    url: str | None = None
+    query: str | None = None
+    checked_at: str = ""
+    changed: bool = False
+    diff: str | None = None
+    previous_length: int | None = None
+    current_length: int | None = None
+    new_results: list[dict[str, Any]] | None = None
+    new_count: int | None = None
+    total_results: int | None = None
+    error: str | None = None
+
+
+class MonitorCheckListResponse(BaseModel):
+    """Response for GET /v2/monitor/{id}/checks."""
+
+    success: bool = True
+    data: list[MonitorCheckItem] = Field(default_factory=list)
+    total: int = 0
+
+
 class ParseResponse(BaseModel):
     success: bool
     data: dict[str, Any] | None = None

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -1044,6 +1044,14 @@ class ActivityResponse(BaseModel):
     data: list[ActivityItem] = Field(default_factory=list)
 
 
+class ConcurrencyCheckResponse(BaseModel):
+    """Response for GET /v2/concurrency-check."""
+
+    success: bool = True
+    max_concurrency: int = 50
+    current: int = 0
+
+
 class EnrichmentField(BaseModel):
     """A field to extract for each enrichment item."""
 

--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -274,6 +274,42 @@ async def run_monitor(monitor_id: str, scraper_url: str = "http://scraper-svc:80
     return await check_monitor(monitor_id, config)
 
 
+def get_monitor_checks(monitor_id: str, limit: int = 50) -> list[dict]:
+    """Get check history for a monitor, newest first.
+
+    Returns up to ``limit`` entries from the monitor's history list.
+    Each entry is a dict with check result fields (checked_at, changed,
+    diff, error, etc.).
+    """
+    r = _get_redis()
+    key = HISTORY_KEY.format(monitor_id)
+    raw = r.lrange(key, 0, limit - 1)
+    results = []
+    for entry in raw:
+        try:
+            results.append(json.loads(entry))
+        except json.JSONDecodeError:
+            continue
+    return results
+
+
+def get_monitor_check(monitor_id: str, check_index: int) -> dict | None:
+    """Get a single check result by its 0-based index in the history list.
+
+    Index 0 is the most recent check.
+    Returns None if the index is out of range or the monitor has no history.
+    """
+    r = _get_redis()
+    key = HISTORY_KEY.format(monitor_id)
+    raw = r.lindex(key, check_index)
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)  # type: ignore[no-any-return]
+    except json.JSONDecodeError:
+        return None
+
+
 async def check_all_async() -> list[dict]:
     """Check all monitors."""
     monitors = get_all_monitors()

--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -257,6 +257,23 @@ async def run_search_monitor(monitor_id: str, config: dict) -> dict:
     return result
 
 
+async def run_monitor(monitor_id: str, scraper_url: str = "http://scraper-svc:8001") -> dict:
+    """Run a single monitor check immediately, regardless of schedule.
+
+    Loads the monitor config, dispatches to the appropriate check function
+    (scrape or search), and returns the check result.
+    """
+    config = get_monitor(monitor_id)
+    if config is None:
+        raise ValueError(f"Monitor {monitor_id} not found")
+
+    config["scraper_url"] = scraper_url
+    mt = config.get("monitor_type", "scrape")
+    if mt == "search":
+        return await run_search_monitor(monitor_id, config)
+    return await check_monitor(monitor_id, config)
+
+
 async def check_all_async() -> list[dict]:
     """Check all monitors."""
     monitors = get_all_monitors()

--- a/agent-svc/agent/store.py
+++ b/agent-svc/agent/store.py
@@ -244,3 +244,37 @@ class JobStore:
             if cursor == 0:
                 break
         return active
+
+    def count_active_jobs(self, kind: str | None = None) -> int:
+        """Count the number of jobs currently in 'processing' status.
+
+        Uses the same SCAN-based approach as list_active_jobs but
+        only returns the count rather than the full metadata list.
+
+        Args:
+            kind: If set, only count jobs of this kind (``crawl``, ``agent``, etc.)
+
+        Returns:
+            Number of active processing jobs.
+        """
+        count = 0
+        cursor = 0
+        while True:
+            cursor, keys = self.redis.scan(cursor=cursor, match="job:*:meta", count=100)
+            if keys:
+                pipe = self.redis.pipeline()
+                for key in keys:
+                    pipe.get(key)
+                results = pipe.execute()
+                for raw in results:
+                    if raw is None:
+                        continue
+                    meta = json.loads(raw)
+                    if meta.get("status") != "processing":
+                        continue
+                    if kind is not None and meta.get("kind") != kind:
+                        continue
+                    count += 1
+            if cursor == 0:
+                break
+        return count

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -380,10 +380,41 @@ async def _process_batch_scrape_async(
     scraper = ScraperClient(scraper_url)
 
     async def work_fn() -> dict[str, Any]:
-        pages = []
-        _index_batch = []
+        pages: list[dict] = []
+        errors: list[dict] = []
+        _index_batch: list[dict] = []
+        total = len(urls)
         for url in urls:
-            result = await scraper.scrape(url)
+            # Check for cancellation between URLs
+            job_meta = store.get_job(job_id)
+            if job_meta and job_meta.get("status") == "cancelled":
+                logger.info(
+                    "Batch scrape %s cancelled after %d/%d URLs",
+                    job_id,
+                    len(pages),
+                    total,
+                )
+                break
+            try:
+                result = await scraper.scrape(url)
+            except Exception as e:
+                errors.append(
+                    {
+                        "url": url,
+                        "error": str(e),
+                        "error_type": "scrape_error",
+                        "error_code": "SCRAPE_ERROR",
+                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    }
+                )
+                store.update_job_progress(
+                    job_id,
+                    pages=list(pages),
+                    errors=list(errors),
+                    total=total,
+                )
+                continue
+
             if result.get("success"):
                 data = result["data"]
                 pages.append({"url": url, "markdown": data.get("markdown", "")})
@@ -391,7 +422,6 @@ async def _process_batch_scrape_async(
                 og = metadata.get("og") or {}
                 meta = metadata.get("meta") or {}
                 title = og.get("title") or meta.get("title") or data.get("title", "")
-                # Accumulate for batch indexing (ADR-0030) instead of per-page
                 _index_batch.append(
                     {
                         "url": url,
@@ -399,13 +429,38 @@ async def _process_batch_scrape_async(
                         "content": data.get("markdown", "")[:2000],
                     }
                 )
+                store.increment_completed(job_id)
+            else:
+                errors.append(
+                    {
+                        "url": url,
+                        "error": result.get("error", "Scrape failed"),
+                        "error_type": "scrape_error",
+                        "error_code": "SCRAPE_ERROR",
+                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    }
+                )
+
+            # Update progress after each URL for real-time status polling
+            store.update_job_progress(
+                job_id,
+                pages=list(pages),
+                errors=list(errors),
+                total=total,
+            )
+
         if _index_batch:
             if task_tracker is not None:
                 task_tracker.create_background_task(_index_batch_async(_index_batch))
             else:
                 asyncio.create_task(_index_batch_async(_index_batch))
-        payload = {"completed": len(pages), "total": len(urls), "pages": pages}
-        return payload
+
+        return {
+            "completed": store.get_completed(job_id),
+            "total": total,
+            "pages": pages,
+            "errors": errors,
+        }
 
     await _run_job_with_observability(
         job_id, "batch_scrape", store, webhook_config, work_fn, scraper.close

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -456,7 +456,7 @@ async def _process_batch_scrape_async(
                 asyncio.create_task(_index_batch_async(_index_batch))
 
         return {
-            "completed": store.get_completed(job_id),
+            "completed": len(pages),
             "total": total,
             "pages": pages,
             "errors": errors,

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -395,26 +395,8 @@ async def _process_batch_scrape_async(
                     total,
                 )
                 break
-            try:
-                result = await scraper.scrape(url)
-            except Exception as e:
-                errors.append(
-                    {
-                        "url": url,
-                        "error": str(e),
-                        "error_type": "scrape_error",
-                        "error_code": "SCRAPE_ERROR",
-                        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-                    }
-                )
-                store.update_job_progress(
-                    job_id,
-                    pages=list(pages),
-                    errors=list(errors),
-                    total=total,
-                )
-                continue
 
+            result = await scraper.scrape(url)
             if result.get("success"):
                 data = result["data"]
                 pages.append({"url": url, "markdown": data.get("markdown", "")})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,12 @@ services:
       - "8011:8011"
     profiles:
       - fixture
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8011/health', timeout=5)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   test-site:
     build:
@@ -60,6 +66,12 @@ services:
       - ENABLE_MARKDOWN=1
       - ENABLE_DYNAMIC=1
       - SITE_NAME=Fixture Site
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
 
   tier3-fixture:
     build:
@@ -74,6 +86,12 @@ services:
       - ENABLE_MARKDOWN=0
       - ENABLE_DYNAMIC=1
       - SITE_NAME=Tier 3 Fixture
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
 
   scraper-svc:
     build:
@@ -90,6 +108,12 @@ services:
       - VALKEY_HOST=valkey
       - VALKEY_PORT=6379
       - VALKEY_DB=0
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health', timeout=5)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   browser-svc:
     build:
@@ -97,6 +121,12 @@ services:
       dockerfile: browser-svc/Dockerfile
     image: ghcr.io/groktopus/groktocrawl-browser
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8012/health', timeout=5)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   flare-solverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
@@ -123,6 +153,12 @@ services:
       - EMBED_MODEL_NAME=${EMBED_MODEL_NAME:-BAAI/bge-m3}
       - EMBED_DIM=${EMBED_DIM:-1024}
       - ACTIVE_EMBED_MODEL=${ACTIVE_EMBED_MODEL:-v_bge-m3}
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; r=urllib.request.urlopen('http://localhost:8003/health', timeout=5); assert b'\"ok\"' in r.read()"]
+      interval: 15s
+      timeout: 10s
+      retries: 30
+      start_period: 30s
 
   qdrant:
     image: qdrant/qdrant:v1.18.2
@@ -133,6 +169,12 @@ services:
       - qdrant_data:/qdrant/storage
     environment:
       - MALLOC_CONF=retain:false
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:6333/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
 
   agent-svc:
     build:
@@ -150,9 +192,11 @@ services:
       slopsearx:
         condition: service_started
       scraper-svc:
-        condition: service_started
+        condition: service_healthy
       semantic-svc:
-        condition: service_started
+        condition: service_healthy
+      browser-svc:
+        condition: service_healthy
     environment:
       - VALKEY_URL=${VALKEY_URL:-redis://valkey:6379/0}
       - SEARXNG_URL=${SEARXNG_URL:-http://slopsearx:8080}
@@ -160,6 +204,12 @@ services:
       - SEMANTIC_URL=${SEMANTIC_URL:-http://semantic-svc:8003}
       - HOST=0.0.0.0
       - PORT=8080
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health', timeout=5)"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   ofelia:
     image: mcuadros/ofelia:latest
@@ -180,12 +230,24 @@ services:
       - "8082:8081"
     environment:
       - AGENT_BASE_URL=http://agent-svc:8080
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8081/health', timeout=5)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   parse-svc:
     build:
       context: .
       dockerfile: parse-svc/Dockerfile
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8013/health', timeout=5)"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
 volumes:
   valkey_data:


### PR DESCRIPTION
Integration tests consistently time out on GitHub Actions because services take too long to start, especially semantic-svc which downloads and loads the BAAI/bge-m3 embedding model.

**Changes:**

1. **Add Docker-native health checks** to all services (scraper-svc, browser-svc, semantic-svc, qdrant, agent-svc, portal-svc, parse-svc, llm-svc, test-site, tier3-fixture). This lets `docker compose` wait for services in parallel instead of sequential inline polls.

2. **Change `depends_on` conditions** on agent-svc from `service_started` to `service_healthy` for scraper-svc, semantic-svc, and browser-svc.

3. **Increase timeouts:**
   - Docker compose up: 10→15 minutes (build time for all images)
   - semantic-svc poll: 300→600 seconds (BAAI/bge-m3 model download/load)
   - tier3-fixture: 30→60 seconds
   - test-site: 60→90 seconds