### PR TITLE
feat: add batch-scrape CLI subcommand for /v2/batch/scrape endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to GroktoCrawl are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **CLI: `batch-scrape` subcommand.** `groktocrawl batch-scrape <job_id>` shows job status with paginated results; `--cancel` cancels an in-progress batch; `--errors` lists per-URL failures. Closes the last CLI-vs-API gap for batch scrape operations.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/groktocrawl
+++ b/groktocrawl
@@ -19,6 +19,7 @@ Commands:
   parse            Parse a document file (PDF, EPUB, DOCX, etc.) to markdown
   generate-llmstxt Generate an llms.txt for a website
   answer           Answer a question with grounded citations
+  batch-scrape     Manage batch scrape jobs (status, cancel, errors)
 Global flags:
   --server <url>   API URL (default: GROKTOCRAWL_API_URL env or http://localhost:8080)
   --json           Machine-readable JSON output
@@ -609,6 +610,15 @@ class Client:
 
     def get_active_crawls(self) -> dict[str, Any]:
         return self._request("GET", "/crawl/active")
+
+    def batch_status(self, job_id: str) -> dict[str, Any]:
+        return self._request("GET", f"/batch/scrape/{job_id}")
+
+    def cancel_batch(self, job_id: str) -> dict[str, Any]:
+        return self._request("DELETE", f"/batch/scrape/{job_id}")
+
+    def batch_errors(self, job_id: str) -> dict[str, Any]:
+        return self._request("GET", f"/batch/scrape/{job_id}/errors")
 
     def create_agent(
         self,
@@ -1713,6 +1723,77 @@ def cmd_active(client: Client, args: argparse.Namespace) -> None:
         print(f"  {job.get('id', '?')}  [{job.get('status', '?')}]")
 
 
+def cmd_batch_scrape(client: Client, args: argparse.Namespace) -> None:
+    """Show batch scrape job status, cancel, or list errors."""
+    if client.dry_run:
+        emit(
+            "[dry-run] Would check batch scrape",
+            {"dry_run": True, "command": "batch-scrape", "job_id": args.job_id},
+        )
+        return
+
+    try:
+        if args.cancel:
+            result = client.cancel_batch(args.job_id)
+            if JSON_OUTPUT:
+                emit("", result)
+            else:
+                log(f"Batch scrape {args.job_id} cancelled")
+            return
+
+        if args.errors:
+            result = client.batch_errors(args.job_id)
+            if JSON_OUTPUT:
+                emit("", result)
+            else:
+                errors = result.get("errors", [])
+                if not errors:
+                    log("No errors")
+                    return
+                print(f"Errors for batch scrape {args.job_id} ({len(errors)} total):\n")
+                for err in errors:
+                    url = err.get("url", "?")
+                    msg = err.get("error", "?")
+                    print(f"  {url}")
+                    print(f"    Error: {msg}")
+            return
+
+        # Default: show status
+        result = client.batch_status(args.job_id)
+    except ApiError as e:
+        die(str(e))
+
+    if JSON_OUTPUT:
+        emit("", result)
+        return
+
+    status = result.get("status", "unknown")
+    completed = result.get("completed", 0)
+    total = result.get("total", 0)
+    duration = result.get("duration")
+    created_at = result.get("created_at")
+    completed_at = result.get("completed_at")
+    credits = result.get("credits_used")
+    error = result.get("error")
+    has_more = result.get("next") is not None
+
+    print(f"Batch scrape {args.job_id}")
+    print(f"  Status:       {status}")
+    print(f"  Progress:     {completed}/{total} pages")
+    if credits is not None:
+        print(f"  Credits used: {credits}")
+    if duration:
+        print(f"  Duration:     {duration}ms")
+    if created_at:
+        print(f"  Created:      {created_at}")
+    if completed_at:
+        print(f"  Completed:    {completed_at}")
+    if error:
+        print(f"  Error:        {error}")
+    if has_more:
+        print("  (Results truncated — use --json for full data)")
+
+
 def cmd_monitor(client: Client, args: argparse.Namespace) -> None:
     """Manage change monitors."""
     action = args.command_action
@@ -1751,11 +1832,11 @@ def cmd_monitor(client: Client, args: argparse.Namespace) -> None:
             mt = result.get("monitor_type", "scrape")
             if mt == "search":
                 sc = result.get("search_config", {})
-                log(f"  Type:     search")
+                log("  Type:     search")
                 log(f"  Query:    {sc.get('query', '')}")
                 log(f"  Results:  {sc.get('numResults', 10)}")
             else:
-                log(f"  Type:     scrape")
+                log("  Type:     scrape")
                 log(f"  URL:      {result.get('url', '')}")
             log(f"  Schedule: {args.schedule}")
 
@@ -2325,6 +2406,18 @@ def make_parser() -> argparse.ArgumentParser:
         help="Search mode: qdrant (local vector index) or web (open web search + rerank)",
     )
 
+    p_batch_scrape = subparsers.add_parser(
+        "batch-scrape",
+        help="Manage batch scrape jobs (status, cancel, errors)",
+    )
+    p_batch_scrape.add_argument("job_id", help="Batch scrape job ID")
+    p_batch_scrape.add_argument(
+        "--cancel", action="store_true", help="Cancel the batch scrape"
+    )
+    p_batch_scrape.add_argument(
+        "--errors", action="store_true", help="List per-URL errors"
+    )
+
     p_llmstxt = subparsers.add_parser(
         "generate-llmstxt", help="Generate an llms.txt for a website"
     )
@@ -2398,6 +2491,7 @@ def main() -> None:
         "parse": cmd_parse,
         "generate-llmstxt": cmd_generate_llmstxt,
         "answer": cmd_answer,
+        "batch-scrape": cmd_batch_scrape,
         "enrich": cmd_enrich,
         "find-similar": cmd_find_similar,
     }

--- a/groktocrawl
+++ b/groktocrawl
@@ -1771,9 +1771,9 @@ def cmd_batch_scrape(client: Client, args: argparse.Namespace) -> None:
     completed = result.get("completed", 0)
     total = result.get("total", 0)
     duration = result.get("duration")
-    created_at = result.get("created_at")
-    completed_at = result.get("completed_at")
-    credits = result.get("credits_used")
+    created_at = result.get("createdAt") or result.get("created_at")
+    completed_at = result.get("completedAt") or result.get("completed_at")
+    credits = result.get("creditsUsed") or result.get("credits_used")
     error = result.get("error")
     has_more = result.get("next") is not None
 
@@ -1782,7 +1782,7 @@ def cmd_batch_scrape(client: Client, args: argparse.Namespace) -> None:
     print(f"  Progress:     {completed}/{total} pages")
     if credits is not None:
         print(f"  Credits used: {credits}")
-    if duration:
+    if duration is not None:
         print(f"  Duration:     {duration}ms")
     if created_at:
         print(f"  Created:      {created_at}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -515,3 +515,120 @@ class TestCLISubprocess:
         )
         assert result.returncode == 0
         assert "crawl" in result.stdout
+
+
+# ── cmd_batch_scrape handler tests ────────────────────────────────────────────
+
+
+class TestCmdBatchScrape:
+    """Tests for the cmd_batch_scrape() handler function."""
+
+    def test_default_shows_status(self):
+        """cmd_batch_scrape calls batch_status() when no flag is given."""
+        cmd_batch_scrape = _cli_ns["cmd_batch_scrape"]
+        mock_args = MagicMock()
+        mock_args.job_id = "batch-job-1"
+        mock_args.cancel = False
+        mock_args.errors = False
+        mock_args.dry_run = False
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.batch_status.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 3,
+            "total": 3,
+            "data": [
+                {"url": "http://example.com/1", "markdown": "# Page 1"},
+                {"url": "http://example.com/2", "markdown": "# Page 2"},
+                {"url": "http://example.com/3", "markdown": "# Page 3"},
+            ],
+        }
+        cmd_batch_scrape(mock_client, mock_args)
+        mock_client.batch_status.assert_called_once_with("batch-job-1")
+
+    def test_cancel_flag(self):
+        """--cancel calls cancel_batch()."""
+        cmd_batch_scrape = _cli_ns["cmd_batch_scrape"]
+        mock_args = MagicMock()
+        mock_args.job_id = "batch-job-2"
+        mock_args.cancel = True
+        mock_args.errors = False
+        mock_args.dry_run = False
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.cancel_batch.return_value = {"success": True}
+        cmd_batch_scrape(mock_client, mock_args)
+        mock_client.cancel_batch.assert_called_once_with("batch-job-2")
+        mock_client.batch_status.assert_not_called()
+
+    def test_errors_flag(self):
+        """--errors calls batch_errors()."""
+        cmd_batch_scrape = _cli_ns["cmd_batch_scrape"]
+        mock_args = MagicMock()
+        mock_args.job_id = "batch-job-3"
+        mock_args.cancel = False
+        mock_args.errors = True
+        mock_args.dry_run = False
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.batch_errors.return_value = {
+            "success": True,
+            "errors": [
+                {"url": "http://example.com/bad", "error": "timeout"},
+            ],
+        }
+        cmd_batch_scrape(mock_client, mock_args)
+        mock_client.batch_errors.assert_called_once_with("batch-job-3")
+        mock_client.batch_status.assert_not_called()
+
+    def test_json_output(self):
+        """JSON_OUTPUT=True produces valid JSON."""
+        cmd_batch_scrape = _cli_ns["cmd_batch_scrape"]
+        mock_args = MagicMock()
+        mock_args.job_id = "batch-json-1"
+        mock_args.cancel = False
+        mock_args.errors = False
+        mock_args.dry_run = False
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.batch_status.return_value = {
+            "success": True,
+            "status": "completed",
+            "completed": 2,
+            "total": 2,
+            "data": [
+                {"url": "http://example.com/a", "markdown": "# A"},
+                {"url": "http://example.com/b", "markdown": "# B"},
+            ],
+        }
+        original_json = _cli_ns["JSON_OUTPUT"]
+        _cli_ns["JSON_OUTPUT"] = True
+        try:
+            stdout = _capture_stdout(cmd_batch_scrape, mock_client, mock_args)
+        finally:
+            _cli_ns["JSON_OUTPUT"] = original_json
+        output = stdout.strip()
+        parsed = json.loads(output)
+        assert parsed["status"] == "completed"
+        assert parsed["completed"] == 2
+        assert parsed["total"] == 2
+
+    def test_api_error_handled(self):
+        """ApiError in cmd_batch_scrape exits with clean error message."""
+        cmd_batch_scrape = _cli_ns["cmd_batch_scrape"]
+        api_error_cls = _cli_ns["ApiError"]
+        mock_args = MagicMock()
+        mock_args.job_id = "batch-err-1"
+        mock_args.cancel = False
+        mock_args.errors = False
+        mock_args.dry_run = False
+        mock_client = MagicMock()
+        mock_client.dry_run = False
+        mock_client.batch_status.side_effect = api_error_cls(
+            "Cannot connect to http://test-server:8080: Connection refused"
+        )
+        stderr = _capture_stderr(cmd_batch_scrape, mock_client, mock_args)
+        assert "Error:" in stderr
+        assert "Cannot connect" in stderr
+        assert "Traceback" not in stderr


### PR DESCRIPTION
## Summary

Adds `groktocrawl batch-scrape <job_id>` CLI subcommand for the `/v2/batch/scrape` endpoints that landed in #344.

Every other API endpoint has a CLI command — this closes the last gap.

## Related Issue

Closes #353

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test (adding or updating tests)

## What's Included

| CLI Command | API Endpoint | Action |
|---|---|---|
| `groktocrawl batch-scrape <job_id>` | `GET /v2/batch/scrape/{id}` | Show job status with paginated results |
| `groktocrawl batch-scrape <job_id> --cancel` | `DELETE /v2/batch/scrape/{id}` | Cancel an in-progress batch scrape |
| `groktocrawl batch-scrape <job_id> --errors` | `GET /v2/batch/scrape/{id}/errors` | List per-URL errors |
| All of the above + `--json` | — | Machine-readable JSON output |

## Test Plan

- [x] 5 new tests in `test_cli.py` covering all three modes + JSON output + error handling
- [x] All 30 pre-existing tests pass (1 unrelated pre-existing failure in `test_basic_crawl_sends_correct_data` — asserts limit=50 vs default 0)

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
