### PR TITLE
docs: promote ADR-0039 status to accepted

### DIFF
--- a/docs/adr/0039-api-cli-surface-ship-together.md
+++ b/docs/adr/0039-api-cli-surface-ship-together.md
@@ -1,6 +1,6 @@
 # ADR-0039: API-CLI Surface Must Ship Together
 
-**Status:** proposed
+**Status:** accepted
 
 **Deciders:** @magnus919
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0036 | [Split Scraper fetch.py into Focused Modules](0036-split-scraper-fetch-modules.md) | proposed |
 | 0037 | [Split Semantic Service app.py into Focused Modules](0037-split-semantic-svc-app-modules.md) | proposed |
 | 0038 | [Crawl Engine — BFS Orchestrator with Shared Link Extraction](0038-crawl-engine.md) | accepted |
-| 0039 | [API-CLI Surface Must Ship Together](0039-api-cli-surface-ship-together.md) | proposed |
+| 0039 | [API-CLI Surface Must Ship Together](0039-api-cli-surface-ship-together.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
Promote ADR-0039 from `proposed` to `accepted` following the lifecycle policy: ADRs move to accepted after the implementation PR is merged and deployed.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
