### PR TITLE
fix: force browser tier when --format images requested so raw_html is available

### DIFF
--- a/scraper-svc/scraper/app.py
+++ b/scraper-svc/scraper/app.py
@@ -251,9 +251,15 @@ async def metrics():
 async def scrape(request: ScrapeRequest):
     """Scrape a URL and return its content as clean markdown."""
     try:
+        # When --format images is requested, force browser (Tier 3) so
+        # raw_html is available for image extraction (Tier 1/2 don't capture it).
+        scrape_opts = request.scrape_options or {}
+        formats = scrape_opts.get("formats", [])
+        needs_images = "images" in formats
+
         result = await smart_scrape(
             request.url,
-            force_browser=request.force_browser,
+            force_browser=request.force_browser or needs_images,
             ignore_robots_txt=request.ignore_robots_txt,
             robots_user_agent=request.robots_user_agent,
             scrape_options=request.scrape_options,


### PR DESCRIPTION
When `--format images` is requested, `scrape_options.formats` includes `"images"`, but the scraper's `smart_scrape()` returns raw HTML (`raw_html_start`) only when Playwright (Tier 3) renders the page. Tier 1 (llms.txt) and Tier 2 (markdown content negotiation) return markdown without raw HTML.

This fix checks whether the formats list includes "images" and auto-sets `force_browser=True` in that case, ensuring Playwright renders the page and captures raw HTML for image extraction.

**Verification:** Tested against the running hal2000 stack — `groktocrawl scrape https://www.rust-lang.org/ --format images` now outputs `Images found on page: 9` with alt text for each image.
