### PR TITLE
fix: structural fallback in html_to_markdown for SPA-heavy sites

### DIFF
--- a/scraper-svc/scraper/fetch_quality.py
+++ b/scraper-svc/scraper/fetch_quality.py
@@ -290,8 +290,55 @@ def _looks_like_markdown(text: str) -> bool:
     return md_indicators >= 3
 
 
+def _structural_text_extraction(html: str) -> str:
+    """Extract visible text from HTML using BeautifulSoup.
+
+    Extracts page title, meta description, and body text, stripping
+    non-content elements. Used as fallback when readability-lxml
+    produces little or no output (common for SPA-heavy sites where
+    the non-JS HTML shell lacks article-like structure).
+
+    Returns text capped at 10,000 chars.
+    """
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    parts: list[str] = []
+
+    # Page title
+    title_tag = soup.find("title")
+    if title_tag and title_tag.get_text(strip=True):
+        parts.append(f"# {title_tag.get_text(strip=True)}")
+
+    # Meta description
+    meta_desc = soup.find("meta", attrs={"name": "description"})
+    if meta_desc:
+        content: str = str(meta_desc.get("content", "")).strip()
+        if content:
+            parts.append(content)
+
+    # Body text — strip non-content elements
+    for tag in soup(["script", "style", "nav", "footer", "header"]):
+        tag.decompose()
+
+    body_text = soup.get_text(separator="\n", strip=True)
+    body_text = re.sub(r"\n{3,}", "\n\n", body_text)
+
+    if body_text:
+        parts.append(body_text)
+
+    result = "\n\n".join(parts)
+    return result[:10000]
+
+
 def html_to_markdown(html: str) -> str:
-    """Convert HTML to clean markdown using readability + markdownify."""
+    """Convert HTML to clean markdown using readability + markdownify.
+
+    Falls back to structural BeautifulSoup text extraction when
+    readability produces little or no output (common for SPA-heavy
+    sites where the non-JS HTML shell lacks article-like structure).
+    """
     try:
         from markdownify import markdownify as md
         from readability import Document
@@ -302,19 +349,25 @@ def html_to_markdown(html: str) -> str:
         markdown = md(summary, heading_style="ATX", strip=["script", "style"])
         # Collapse multiple blank lines
         markdown = re.sub(r"\n{3,}", "\n\n", markdown)
-        return markdown.strip()
+        result = markdown.strip()
+
+        # Structural fallback: when readability produces little or no output,
+        # extract visible text nodes from the full HTML. This handles sites
+        # where FlareSolverr returns real HTML but readability-lxml finds no
+        # article-like content (SPA shells, torrent indexes, etc.).
+        if not result or len(result) < 50:
+            logger.debug(
+                "Readability produced %d chars, falling back to structural extraction",
+                len(result),
+            )
+            return _structural_text_extraction(html)
+
+        return result
     except Exception as e:
         logger.error("HTML-to-markdown conversion failed: %s", e)
         # Fallback: try BeautifulSoup for text extraction
         try:
-            from bs4 import BeautifulSoup
-
-            soup = BeautifulSoup(html, "html.parser")
-            # Remove script/style
-            for tag in soup(["script", "style", "nav", "footer", "header"]):
-                tag.decompose()
-            text = soup.get_text(separator="\n", strip=True)
-            return text[:10000]  # Limit to 10K chars as fallback
+            return _structural_text_extraction(html)
         except Exception:
             return html[:5000]  # Last resort raw truncation
 

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -58,7 +58,7 @@ def test_boilerplate_nav_page():
     """Navigation/list pages with many links but some content warn or fail."""
     lines = "\n".join([f"[Link {i}](https://example.com/{i})" for i in range(15)])
     lines += "\n\nA single line of explanation that is not a link."
-    score, status = _check_boilerplate(lines)
+    _score, status = _check_boilerplate(lines)
     assert status in ("warn", "fail")
 
 
@@ -73,7 +73,7 @@ def test_completeness_empty():
 
 def test_completeness_short_content_no_title():
     """Very short content (<200 chars) with no paragraphs fails."""
-    score, status = _check_completeness("Hello world")
+    _score, status = _check_completeness("Hello world")
     assert status == "fail"
 
 
@@ -96,7 +96,7 @@ def test_completeness_good_content():
 def test_completeness_paragraph_threshold():
     """Content with adequate length but only one paragraph warns."""
     long_single_para = "Sentence one. " * 50  # Single paragraph, >500 chars
-    score, status = _check_completeness(long_single_para)
+    _score, status = _check_completeness(long_single_para)
     assert status == "warn"
 
 
@@ -131,7 +131,7 @@ def test_block_page_geo_restriction():
         "Sorry, this content is not available in your country.\n"
         "Due to licensing restrictions, access is geo-blocked."
     )
-    score, status = _check_block_page(content)
+    _score, status = _check_block_page(content)
     assert status == "fail"
 
 
@@ -140,7 +140,7 @@ def test_block_page_paywall():
     content = (
         "Subscribe to continue reading this article.\nThis content is for members only."
     )
-    score, status = _check_block_page(content)
+    _score, status = _check_block_page(content)
     assert status == "fail"
 
 
@@ -260,3 +260,99 @@ def test_quality_acceptable_at_threshold():
     # Exactly at threshold should pass
     result = {"quality": {"score": QA_MIN_QUALITY_THRESHOLD}}
     assert _quality_acceptable(result) is True
+
+
+# ── html_to_markdown structural fallback ────────────────────────
+
+
+def test_html_to_markdown_normal_article():
+    """Normal article HTML should use readability path with no fallback."""
+    from scraper.fetch_quality import html_to_markdown
+
+    html = """<html><head><title>My Article</title></head><body>
+    <article><h1>My Article</h1>
+    <p>This is a well-formed article with substantial content that should be easily
+    extracted by readability-lxml. It has multiple sentences and enough depth to
+    produce meaningful markdown output from the converter pipeline.</p>
+    <p>A second paragraph with additional context and information that builds on
+    the first paragraph and provides further detail about the topic.</p>
+    </article></body></html>"""
+    result = html_to_markdown(html)
+    assert len(result) > 50
+    assert "My Article" in result
+
+
+def test_html_to_markdown_spa_shell_falls_back_to_structural():
+    """SPA shell HTML (no article content) should use structural fallback."""
+    from scraper.fetch_quality import html_to_markdown
+
+    # Simulate SPA shell HTML like what FlareSolverr returns for 1337x.to
+    html = """<html><head>
+    <title>1337x | Torrent Search Engine</title>
+    <meta name="description" content="1337x is a search engine for torrents.">
+    </head><body>
+    <nav><a href="/">Home</a><a href="/top">Top 100</a></nav>
+    <div id="app"></div>
+    <footer>2024 1337x</footer>
+    </body></html>"""
+    result = html_to_markdown(html)
+    assert len(result) > 50
+    assert "1337x" in result
+    assert "Torrent Search Engine" in result
+
+
+def test_html_to_markdown_empty_html():
+    """Empty HTML should return empty string."""
+    from scraper.fetch_quality import html_to_markdown
+
+    result = html_to_markdown("")
+    assert result == ""
+
+
+def test_html_to_markdown_minimal_html():
+    """Minimal HTML with only a title and one word should still produce output."""
+    from scraper.fetch_quality import html_to_markdown
+
+    html = "<html><head><title>Page</title></head><body><p>Hello</p></body></html>"
+    result = html_to_markdown(html)
+    # Even minimal HTML should produce some text via structural fallback
+    assert len(result) > 0
+    assert "Page" in result or "Hello" in result
+
+
+def test_html_to_markdown_structural_extracts_meta_description():
+    """Structural fallback should extract meta description."""
+    from scraper.fetch_quality import html_to_markdown
+
+    html = """<html><head>
+    <title>Search Results</title>
+    <meta name="description" content="Browse and discover torrent files easily.">
+    </head><body>
+    <div id="root"></div>
+    </body></html>"""
+    result = html_to_markdown(html)
+    assert "Browse and discover torrent files easily" in result
+
+
+def test_html_to_markdown_structural_strips_non_content_tags():
+    """Structural fallback should strip script, style, nav, footer, header."""
+    from scraper.fetch_quality import html_to_markdown
+
+    html = """<html><head><title>Test</title>
+    <script>console.log('hidden')</script>
+    <style>.hidden { display: none; }</style>
+    </head><body>
+    <nav>Skip this nav text</nav>
+    <header>Skip this header text</header>
+    <p>Visible paragraph content here with enough text to pass the
+    threshold check and demonstrate that script and style content
+    is properly stripped from the extracted output.</p>
+    <footer>Skip this footer text</footer>
+    </body></html>"""
+    result = html_to_markdown(html)
+    assert "Visible paragraph" in result
+    assert "console.log" not in result
+    assert ".hidden" not in result
+    assert "Skip this nav text" not in result
+    assert "Skip this header text" not in result
+    assert "Skip this footer text" not in result


### PR DESCRIPTION
## Summary

Fixes #361 — FlareSolverr returns real HTML but html_to_markdown discards it for SPA-heavy sites.

### Problem
`html_to_markdown()` uses readability-lxml which produces empty output for SPA-heavy sites where the non-JS HTML shell lacks article-like structure. The BeautifulSoup fallback only triggered on exceptions, not on successful-but-empty readability output. This caused `fetch_via_flaresolverr()` to discard valid HTML, resulting in `"Could not extract content"` errors.

### Fix
- Added `_structural_text_extraction()` helper that extracts page title, meta description, and visible body text via BeautifulSoup when readability produces insufficient output
- This fallback triggers when readability produces < 50 chars, and is also used by the existing exception-based fallback path
- Benefits all callers: FlareSolverr, Playwright, and content-negotiation HTML fallback

### Changes
- **scraper-svc/scraper/fetch_quality.py**: Added `_structural_text_extraction()` and integrated into `html_to_markdown()`
- **tests/test_quality.py**: Added 6 unit tests, fixed 5 pre-existing ruff lint issues