### PR TITLE
fix: document BRAVE_API_KEY and surface search degradation warnings

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -75,6 +75,12 @@
 # PAT scopes: public_repo for public repos, repo for private repos.
 # GITHUB_TOKEN=ghp_you...token
 
+# ── Search Engine ─────────────────────────────────────────
+# Brave Search API key (required for web search to function out of the box)
+# Without it, slopsearx engines return zero results for most queries.
+# Sign up for a free key at https://brave.com/search/api/
+# BRAVE_API_KEY=
+
 # NVD API adapter — optional free API key from NVD.
 # Without it, NVD API rate limit is 5 requests per 30 seconds.
 # With a key, rate limit rises to 50 requests per 30 seconds.

--- a/agent-svc/agent/models.py
+++ b/agent-svc/agent/models.py
@@ -852,6 +852,9 @@ class SearchResponse(BaseModel):
     data: dict = Field(default_factory=lambda: {"web": [], "images": [], "news": []})
     output: dict[str, Any] | None = None  # Present only when output_schema provided
     query_variations: list[str] | None = None  # Present for deep search type
+    warning: str | None = (
+        None  # Degraded search state (e.g. all engines returned no results)
+    )
 
 
 class FindSimilarRequest(BaseModel):

--- a/agent-svc/agent/routes/search.py
+++ b/agent-svc/agent/routes/search.py
@@ -83,6 +83,8 @@ async def search(request: Request, body: SearchRequest) -> SearchResponse:
     from ..searxng_client import SearXNGClient
 
     searxng = SearXNGClient(request.app.state.searxng_url)
+    warning_msg: str | None = None
+
     try:
         # ── Determine which source types to query ──────────────────
         has_image_source = body.sources and "images" in body.sources
@@ -190,6 +192,11 @@ async def search(request: Request, body: SearchRequest) -> SearchResponse:
                     categories=body.categories,
                     sources=effective_sources,
                 )
+                if not searxng_results and _health.engines_responding == 0:
+                    warning_msg = (
+                        "All search engines returned no results. "
+                        "Check your BRAVE_API_KEY configuration."
+                    )
                 # Query vector index in parallel (async would be better, but sequential for now)
                 vector_results = await semantic.search_vector(
                     body.query, limit=body.limit
@@ -229,6 +236,11 @@ async def search(request: Request, body: SearchRequest) -> SearchResponse:
                 categories=body.categories,
                 sources=effective_sources,
             )
+            if not results and _health.engines_responding == 0:
+                warning_msg = (
+                    "All search engines returned no results. "
+                    "Check your BRAVE_API_KEY configuration."
+                )
             search_results = [
                 SearchResult(
                     url=r["url"], title=r["title"], description=r.get("description", "")
@@ -382,6 +394,6 @@ async def search(request: Request, body: SearchRequest) -> SearchResponse:
                 await llm_client.close()
                 await scraper_client.close()
 
-        return SearchResponse(data=result_data, output=output)
+        return SearchResponse(data=result_data, output=output, warning=warning_msg)
     finally:
         await searxng.close()


### PR DESCRIPTION
Closes #406

## Problem
When `BRAVE_API_KEY` is not configured, all slopsearx engines return zero results for most queries. This was a silent failure — the API returned HTTP 200 with `{"success":true,"data":{"web":[]}}`.

## Changes
- **`.env.sample`**: Document `BRAVE_API_KEY` with signup link to <https://brave.com/search/api/>
- **`models.py`**: Add optional `warning` field to `SearchResponse`
- **`routes/search.py`**: Set warning message when all search engines report 0 results with `engines_responding == 0`

## Verification
- Syntax check passed for all changed files
- Backward compatible: `warning` is an optional field, defaults to `None`
- Existing callers unaffected