### PR TITLE
fix: differentiate Playwright browser errors from generic upstream errors

### DIFF
--- a/scraper-svc/scraper/app.py
+++ b/scraper-svc/scraper/app.py
@@ -17,7 +17,7 @@ from common.metrics import METRICS
 from common.middleware import add_request_id_middleware
 
 from .cookie_store import close_client, get_client
-from .exceptions import GroktoCrawlError, UpstreamError
+from .exceptions import BrowserError, GroktoCrawlError, UpstreamError
 from .fetch import smart_scrape
 from .meta import fetch_meta_tags
 
@@ -268,6 +268,8 @@ async def scrape(request: ScrapeRequest):
             METRICS.counter(
                 "scrape_calls_total", "Total scrape requests", ["status"]
             ).inc({"status": "error"})
+            if result.get("error_type") == "browser_error":
+                raise BrowserError(detail=result["error"])
             raise UpstreamError(detail=result["error"])
         markdown = result.get("markdown", "")
         raw_html = result.get("raw_html_start", "")

--- a/scraper-svc/scraper/fetch_tiers.py
+++ b/scraper-svc/scraper/fetch_tiers.py
@@ -387,6 +387,17 @@ async def fetch_via_playwright(url: str) -> dict | None:
     except ImportError:
         logger.warning("Playwright not installed; skipping Tier 3")
     except Exception as e:
+        error_str = str(e)
+        # Classify known Playwright crash signatures
+        if "page is navigating" in error_str or "scrollHeight" in error_str.lower():
+            logger.warning("Tier 3 browser crash for %s: %s", url, e)
+            return {
+                "error": f"Browser error: {error_str}",
+                "error_type": "browser_error",
+                "markdown": "",
+                "source": "playwright-error",
+                "url": url,
+            }
         logger.warning("Tier 3 miss for %s: %s", url, e)
     return None
 


### PR DESCRIPTION
Closes #408

## Problem
`BrowserError` exists in `exceptions.py` with `error_code = "BROWSER_ERROR"` but was never raised. Playwright crashes ("page is navigating", null scrollHeight) all surfaced as generic `UPSTREAM_ERROR` with `"Could not extract content"`.

## Changes
- **`fetch_tiers.py`**: `fetch_via_playwright()` now catches known Playwright crash signatures and returns an error dict with `error_type: "browser_error"` instead of `None`
- **`app.py`**: Scrape endpoint checks `error_type == "browser_error"` and raises `BrowserError` (502/BROWSER_ERROR) instead of `UpstreamError`

## Verification
- Syntax check passed for all changed files
- `BrowserError` extends `GroktoCrawlError` with correct status_code=502 and error_code=BROWSER_ERROR
- Existing exception handler catches it automatically
- Backward compatible: non-browser errors still raise UpstreamError as before