### PR TITLE
fix: add graceful shutdown with drain timeout to MCP server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,7 @@ services:
     depends_on:
       - agent-svc
     restart: unless-stopped
+    stop_grace_period: 35s
 
 volumes:
   valkey_data:

--- a/mcp-svc/mcp_server.py
+++ b/mcp-svc/mcp_server.py
@@ -682,6 +682,9 @@ class _LoggingMiddleware:
 
 def main() -> None:
     """Start the MCP server with Streamable HTTP transport on port 8002."""
+    import asyncio
+    import signal
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
@@ -706,7 +709,34 @@ def main() -> None:
 
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=PORT)
+    config = uvicorn.Config(
+        app,
+        host="0.0.0.0",
+        port=PORT,
+        timeout_graceful_shutdown=30,
+    )
+    server = uvicorn.Server(config)
+
+    # Signal handlers for clean shutdown with drain
+    shutdown_event = asyncio.Event()
+
+    def _handle_shutdown() -> None:
+        logger.info("Received shutdown signal, draining in-flight requests...")
+        shutdown_event.set()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.add_signal_handler(signal.SIGTERM, _handle_shutdown)
+        loop.add_signal_handler(signal.SIGINT, _handle_shutdown)
+    except NotImplementedError:
+        # Signal handlers not available on this platform (e.g. Windows)
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                signal.signal(sig, lambda *_: _handle_shutdown())
+            except (ValueError, OSError):
+                pass
+
+    loop.run_until_complete(server.serve())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #410

## Problem
The MCP server emits `"ASGI callable returned without completing response"` on SIGTERM because `uvicorn.run()` shuts down without draining in-flight SSE connections. The Docker default `stop_grace_period` (10s) may also be too short. Cosmetic log noise only — no data loss since long-running operations run in `agent-svc`.

## Changes
- **`mcp_server.py`**: Replaced `uvicorn.run(app, ...)` with `uvicorn.Config` + `uvicorn.Server` with `timeout_graceful_shutdown=30` and SIGTERM/SIGINT signal handlers
- **`docker-compose.yml`**: Added `stop_grace_period: 35s` to `mcp-svc` so Docker's timeout exceeds uvicorn's drain timeout

## Verification
- Syntax check passed
- `timeout_graceful_shutdown=30` tells uvicorn to wait up to 30s for in-flight requests before force-closing
- `stop_grace_period=35s` gives Docker a 5s buffer before sending SIGKILL
- Signal handlers log a clear message on shutdown (helps operators distinguish graceful from forced shutdown)