### PR TITLE
fix(agent): wire search_type through streaming pipeline and SSE plan event

### DIFF
--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -225,18 +225,18 @@ async def run_research_stream(
         strategy = research_plan["research_strategy"]
         reasoning = research_plan.get("reasoning", "")
 
+        # search_type user preference overrides auto-classification
+        if search_type == "deep":
+            strategy = "deep"
+        elif search_type == "focused":
+            strategy = "focused"
+
         yield {
             "type": "research_plan",
             "strategy": strategy,
             "queries": queries,
             "reasoning": reasoning,
         }
-
-        # search_type user preference overrides auto-classification
-        if search_type == "deep":
-            strategy = "deep"
-        elif search_type == "focused":
-            strategy = "focused"
 
         pass_count = 0
         max_passes = 2 if search_type == "deep" else 1

--- a/agent-svc/agent/research/streaming.py
+++ b/agent-svc/agent/research/streaming.py
@@ -80,6 +80,7 @@ async def stream_research_live(
     max_searches_per_request: int,
     include_images: bool,
     citation_style: CitationStyle,
+    search_type: str = "deep",
 ) -> Any:
     """Orchestrate full research SSE pipeline for cache-miss or force-fresh.
 
@@ -99,6 +100,7 @@ async def stream_research_live(
         max_searches_per_request=max_searches_per_request,
         include_images=include_images,
         citation_style=citation_style,
+        search_type=search_type,
     ):
         if event["type"] == "sources_pending":
             yield f"data: {json.dumps({'type': 'sources_pending', 'sources': event['sources']})}\n\n"

--- a/agent-svc/agent/routes/agent.py
+++ b/agent-svc/agent/routes/agent.py
@@ -144,6 +144,7 @@ async def _handle_agent_streaming(
                 max_searches_per_request=max_searches,
                 include_images=body.include_images,
                 citation_style=body.citation_style,
+                search_type=body.search_type,
             ),
             media_type="text/event-stream",
             headers=headers,
@@ -222,6 +223,7 @@ async def create_agent(request: Request, body: AgentRequest, response: Response)
             force_fresh=body.force_fresh,
             user_id=user_id,
             research_memory=request.app.state.research_memory,
+            search_type=body.search_type,
         )
     )
 


### PR DESCRIPTION
## Summary

Three fixes completing the search_type pass-through chain that was partially missing after the route extraction refactor.

## Changes

1. **streaming.py** — `stream_research_live()` didn't accept or forward `search_type` to `run_research_stream()`. The streaming SSE path always used the default "deep" regardless of the user's explicit `--search-type` choice.

2. **routes/agent.py** — The sync path (`_process_agent_async` call) also didn't pass `body.search_type`.

3. **loop.py** — The `research_plan` SSE event was yielded BEFORE the `search_type` override was applied, so the strategy field showed the auto-classified value rather than the user-requested one. Moved the override before the yield.

## Files changed

| File | Change |
|------|--------|
| `research/streaming.py` | Add `search_type` param to `stream_research_live()`; pass to `run_research_stream()` |
| `routes/agent.py` | Pass `search_type=body.search_type` to both streaming and sync paths |
| `research/loop.py` | Move search_type override before the `research_plan` SSE event yield |

Closes #418 (follow-up)