### PR TITLE
fix: recover from transient Playwright navigation failures

### DIFF
--- a/scraper-svc/scraper/fetch_strategy.py
+++ b/scraper-svc/scraper/fetch_strategy.py
@@ -31,6 +31,7 @@ from .cache import (
 )
 from .extract import assess_quality
 from .metadata import extract_all_metadata
+from .playwright_retry import retry_transient
 from .proxy import (
     SCRAPER_PROXY_URL,
     _get_httpx_proxies,
@@ -228,7 +229,7 @@ async def _playwright_fetch_with_proxy(
                     logger.warning("Substack redirect persisted for %s", url)
 
             # SPA content retry
-            html = await page.content()
+            html = await retry_transient(page.content)
             markdown = html_to_markdown(html) if html else ""
 
             if (
@@ -243,12 +244,13 @@ async def _playwright_fetch_with_proxy(
                         url,
                         len(markdown),
                     )
-                    await page.evaluate(
-                        "window.scrollTo(0, document.body.scrollHeight)"
+                    await retry_transient(
+                        page.evaluate,
+                        "window.scrollTo(0, document.body.scrollHeight)",
                     )
                     await page.wait_for_timeout(3000)
 
-                    html = await page.content()
+                    html = await retry_transient(page.content)
                     markdown = html_to_markdown(html) if html else ""
                     if (
                         markdown
@@ -323,9 +325,11 @@ async def fetch_via_playwright(url: str) -> dict | None:
         try:
             result = await _playwright_fetch_with_proxy(url, pw_proxy)
         except Exception as e:
+            if pw_proxy is None:
+                raise  # re-raise — transient errors surface for classification
             logger.warning(
                 "Proxy (%s) failed for %s: %s",
-                pw_proxy.get("server", "unknown") if pw_proxy else "none",
+                pw_proxy.get("server", "unknown"),
                 url,
                 e,
             )
@@ -350,6 +354,17 @@ async def fetch_via_playwright(url: str) -> dict | None:
     except ImportError:
         logger.warning("Playwright not installed; skipping Tier 3")
     except Exception as e:
+        error_str = str(e)
+        # Classify known Playwright crash signatures
+        if "page is navigating" in error_str or "scrollheight" in error_str.lower():
+            logger.warning("Tier 3 browser crash for %s: %s", url, e)
+            return {
+                "error": f"Browser error: {error_str}",
+                "error_type": "browser_error",
+                "markdown": "",
+                "source": "playwright-error",
+                "url": url,
+            }
         logger.warning("Tier 3 miss for %s: %s", url, e)
     return None
 

--- a/scraper-svc/scraper/fetch_tiers.py
+++ b/scraper-svc/scraper/fetch_tiers.py
@@ -16,8 +16,6 @@ import logging
 
 import httpx
 
-from curl_cffi import requests as curl_requests
-
 from common.url import extract_domain
 
 from .barrier import (
@@ -28,6 +26,7 @@ from .barrier import (
 )
 from .cache import _is_binary_content_type, _make_download_payload
 from .fetch_quality import html_to_markdown
+from .playwright_retry import retry_transient
 from .proxy import _get_playwright_proxy
 from .settings import load_settings
 
@@ -174,7 +173,7 @@ async def _playwright_fetch_with_proxy(
                     logger.warning("Substack redirect persisted for %s", url)
 
             # SPA content retry
-            html = await page.content()
+            html = await retry_transient(page.content)
             markdown = html_to_markdown(html) if html else ""
 
             if (
@@ -189,12 +188,13 @@ async def _playwright_fetch_with_proxy(
                         url,
                         len(markdown),
                     )
-                    await page.evaluate(
-                        "window.scrollTo(0, document.body.scrollHeight)"
+                    await retry_transient(
+                        page.evaluate,
+                        "window.scrollTo(0, document.body.scrollHeight)",
                     )
                     await page.wait_for_timeout(3000)
 
-                    html = await page.content()
+                    html = await retry_transient(page.content)
                     markdown = html_to_markdown(html) if html else ""
                     if (
                         markdown
@@ -360,9 +360,11 @@ async def fetch_via_playwright(url: str) -> dict | None:
         try:
             result = await _playwright_fetch_with_proxy(url, pw_proxy)
         except Exception as e:
+            if pw_proxy is None:
+                raise  # re-raise so outer handler can classify as browser_error
             logger.warning(
                 "Proxy (%s) failed for %s: %s",
-                pw_proxy.get("server", "unknown") if pw_proxy else "none",
+                pw_proxy.get("server", "unknown"),
                 url,
                 e,
             )
@@ -389,7 +391,7 @@ async def fetch_via_playwright(url: str) -> dict | None:
     except Exception as e:
         error_str = str(e)
         # Classify known Playwright crash signatures
-        if "page is navigating" in error_str or "scrollHeight" in error_str.lower():
+        if "page is navigating" in error_str or "scrollheight" in error_str.lower():
             logger.warning("Tier 3 browser crash for %s: %s", url, e)
             return {
                 "error": f"Browser error: {error_str}",

--- a/scraper-svc/scraper/playwright_retry.py
+++ b/scraper-svc/scraper/playwright_retry.py
@@ -1,0 +1,50 @@
+"""Bounded retry for known transient Playwright errors.
+
+Provides a single async helper for retrying page.content() and
+page.evaluate() calls that can fail transiently with "page is
+navigating" or null-document.body "scrollHeight" errors.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MAX_ATTEMPTS = 3
+_WAIT_SECONDS = 1.0
+
+
+async def retry_transient(op, *args, **kwargs):
+    """Call ``op(*args, **kwargs)`` with bounded retry on known transient errors.
+
+    Catches only two Playwright transient signatures:
+      - ``"page is navigating"``  (page.content() race)
+      - ``"scrollheight"``        (null document.body during scrollTo)
+
+    Re-raises *immediately* on non-matching exceptions.  Re-raises the
+    original exception when all attempts are exhausted so that the outer
+    ``fetch_via_playwright`` handler can classify it as ``browser_error``.
+    """
+    for attempt in range(_MAX_ATTEMPTS):
+        try:
+            return await op(*args, **kwargs)
+        except Exception as exc:
+            if not _is_transient(str(exc)):
+                raise
+            if attempt < _MAX_ATTEMPTS - 1:
+                logger.debug(
+                    "Transient retry %d/%d: %s",
+                    attempt + 1,
+                    _MAX_ATTEMPTS,
+                    str(exc)[:120],
+                )
+                await asyncio.sleep(_WAIT_SECONDS)
+                continue
+            raise  # exhausted — let the outer handler classify
+
+
+def _is_transient(msg: str) -> bool:
+    """Return True when *msg* matches a known transient Playwright signature."""
+    return "page is navigating" in msg or "scrollheight" in msg.lower()

--- a/tests/unit/test_playwright_recovery.py
+++ b/tests/unit/test_playwright_recovery.py
@@ -1,0 +1,129 @@
+"""Unit tests for playwright_retry — the bounded transient-retry helper."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the local scraper-svc takes precedence over any installed version
+_scraper_svc = Path(__file__).resolve().parent.parent.parent / "scraper-svc"
+if str(_scraper_svc) not in sys.path:
+    sys.path.insert(0, str(_scraper_svc))
+
+
+async def _noop_sleep(_seconds: float) -> None:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_retry_transient_succeeds_after_failure(monkeypatch):
+    from scraper.playwright_retry import retry_transient
+
+    monkeypatch.setattr("scraper.playwright_retry.asyncio.sleep", _noop_sleep)
+
+    calls = {"count": 0}
+
+    async def flaky():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise Exception("page is navigating")
+        return "ok"
+
+    result = await retry_transient(flaky)
+    assert result == "ok"
+    assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_transient_re_raises_non_matching(monkeypatch):
+    from scraper.playwright_retry import retry_transient
+
+    monkeypatch.setattr("scraper.playwright_retry.asyncio.sleep", _noop_sleep)
+
+    calls = {"count": 0}
+
+    async def broken():
+        calls["count"] += 1
+        raise RuntimeError("unrelated crash")
+
+    with pytest.raises(RuntimeError, match="unrelated crash"):
+        await retry_transient(broken)
+
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_transient_re_raises_after_exhaustion(monkeypatch):
+    from scraper.playwright_retry import retry_transient
+
+    monkeypatch.setattr("scraper.playwright_retry.asyncio.sleep", _noop_sleep)
+
+    calls = {"count": 0}
+
+    async def always_navigating():
+        calls["count"] += 1
+        raise Exception("page is navigating")
+
+    with pytest.raises(Exception, match="page is navigating"):
+        await retry_transient(always_navigating)
+
+    assert calls["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_transient_recognises_scrollheight(monkeypatch):
+    from scraper.playwright_retry import retry_transient
+
+    monkeypatch.setattr("scraper.playwright_retry.asyncio.sleep", _noop_sleep)
+
+    calls = {"count": 0}
+
+    async def null_body():
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise Exception(
+                "TypeError: Cannot read properties of null"
+                " (reading 'scrollHeight')"
+            )
+        return "scrolled"
+
+    result = await retry_transient(null_body)
+    assert result == "scrolled"
+    assert calls["count"] == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "page is navigating",
+        "TypeError: Cannot read properties of null (reading 'scrollHeight')",
+    ],
+)
+async def test_fetch_via_playwright_returns_browser_error_on_no_proxy_exhaustion(
+    monkeypatch,
+    error_message,
+):
+    """fetch_via_playwright returns error_type=browser_error when a
+    no-proxy call exhausts retries on a known transient signature."""
+    from scraper.fetch_tiers import fetch_via_playwright
+
+    monkeypatch.setattr(
+        "scraper.fetch_tiers._get_playwright_proxy",
+        lambda: None,
+    )
+
+    async def _fail(_url, _proxy):
+        raise Exception(error_message)
+
+    monkeypatch.setattr(
+        "scraper.fetch_tiers._playwright_fetch_with_proxy",
+        _fail,
+    )
+
+    result = await fetch_via_playwright("http://example.com")
+    assert result is not None
+    assert result.get("error_type") == "browser_error"
+    assert error_message in result.get("error", "")


### PR DESCRIPTION
## Summary

Retries the two known transient Playwright failures up to three times at the shared `page.content()` and SPA-scroll call sites. Exhausted retries still flow into `BROWSER_ERROR`, including the previously broken lowercase `scrollHeight` classifier.

Both active scraper paths use the same small retry helper. No new dependency or configuration surface was added.

## Related Issue

Closes #412

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [x] New tests added for the change
- [ ] Manual verification done (describe)

Local verification:

- Focused recovery tests: 6 passed
- Unit suite excluding the semantic-service test whose local ML dependency is unavailable: 552 passed
- Ruff: passed
- mypy on changed production files: passed

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

No documentation or API updates are needed: this changes internal recovery behavior only. The endpoint and webhook checklist items are not applicable because no endpoint was added.

The nested exception handler now suppresses failures only when a proxy exists and fail-open retry is possible. Without a proxy, exhausted transient errors reach the existing browser-error classifier instead of being swallowed as a Tier 3 miss.

I don't run continuously; responses may take 24–48 hours.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
