### PR TITLE
Fix agent SSE token streaming

### DIFF
--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -161,7 +161,9 @@ async def run_research(
 
             # ── Gap detection after pass 1 ─────────────────────────
             if pass_count == 1:
-                gap_topics = await _detect_gaps(combined_context, llm, original_query=prompt)
+                gap_topics = await _detect_gaps(
+                    combined_context, llm, original_query=prompt
+                )
                 if not gap_topics:
                     break  # Coverage is adequate, done
                 max_passes = 2  # Enable second pass
@@ -379,12 +381,15 @@ async def run_research_stream(
 
                 # ── Gap detection after pass 1 ──────────────────────
                 if pass_count == 1:
-                    gap_topics = await _detect_gaps(combined_context, llm, original_query=prompt)
+                    gap_topics = await _detect_gaps(
+                        combined_context, llm, original_query=prompt
+                    )
                     if not gap_topics:
                         break  # Coverage is adequate, done
                     max_passes = 2  # Enable second pass
                     if pass_count == 1:
                         continue
+            else:
                 # No schema — stream tokens from the LLM
                 yield {
                     "type": "sources",
@@ -408,12 +413,13 @@ async def run_research_stream(
 
                 # ── Gap detection after pass 1 ──────────────────────
                 if pass_count == 1:
-                    gap_topics = await _detect_gaps(combined_context, llm, original_query=prompt)
+                    gap_topics = await _detect_gaps(
+                        combined_context, llm, original_query=prompt
+                    )
                     if not gap_topics:
                         break  # Coverage is adequate, done
                     max_passes = 2  # Enable second pass
-                    if pass_count == 1:
-                        continue
+                    continue
         # ── Final done event after all passes ───────────────────────
         source_list = [s["url"] for s in all_source_details]
         elapsed = int((time.monotonic() - start) * 1000)

--- a/tests/integration/test_research.py
+++ b/tests/integration/test_research.py
@@ -613,7 +613,9 @@ class TestRunResearchStream:
             patch("agent.research.loop.LLMClient", return_value=llm),
         ):
             events = []
-            async for event in run_research_stream(prompt="What is AI?"):
+            async for event in run_research_stream(
+                prompt="What is AI?", llm_model="fixture-model"
+            ):
                 events.append(event)
 
         # Verify event sequence — Phase 0 planning → Phase 1 discovery → Phase 2 synthesis
@@ -686,7 +688,7 @@ class TestRunResearchStream:
         ):
             events = []
             async for event in run_research_stream(
-                prompt="Extract data", schema=schema
+                prompt="Extract data", schema=schema, llm_model="fixture-model"
             ):
                 events.append(event)
 
@@ -741,7 +743,9 @@ class TestRunResearchStream:
             patch("agent.research.loop.LLMClient", return_value=llm),
         ):
             events = []
-            async for event in run_research_stream(prompt="Anything?"):
+            async for event in run_research_stream(
+                prompt="Anything?", llm_model="fixture-model"
+            ):
                 events.append(event)
 
         types = [e["type"] for e in events]
@@ -796,7 +800,9 @@ class TestRunResearchStream:
             patch("agent.research.loop.LLMClient", return_value=llm),
         ):
             events = []
-            async for event in run_research_stream(prompt="Test"):
+            async for event in run_research_stream(
+                prompt="Test", llm_model="fixture-model"
+            ):
                 events.append(event)
 
         error_events = [e for e in events if e["type"] == "error"]


### PR DESCRIPTION
## Summary

- Restore the non-schema branch of `run_research_stream()` so it emits SSE source/token events and initializes the final answer.
- Update focused streaming tests to pass the explicit fixture model required by the current research API.

## Root cause

The non-schema streaming block was indented inside `if schema`, so the CLI default streaming mode skipped LLM token generation and reached the final response with `full_answer` undefined.

Fixes #428

## Validation

- `PYTHONPATH=agent-svc pytest -q -o addopts="" tests/integration/test_research.py::TestRunResearchStream`
- Pre-commit hooks: ruff lint/format, whitespace, YAML/TOML checks, merge-conflict check, and gitleaks