### PR TITLE
fix: support disabling llama.cpp template reasoning

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,10 @@
 # LOG_LEVEL=INFO
 # Enable provider-specific reasoning/thinking support where available.
 # LLM_ENABLE_THINKING=false
+# Disable template-level reasoning for llama.cpp backends serving Qwen-family
+# models. These models ignore enable_thinking:false at the top-level body but
+# honor it inside chat_template_kwargs. Only set when using llama.cpp server.
+# LLM_LLAMA_CPP_DISABLE_THINKING=false
 
 # Internal service URLs (override only if running services separately)
 # VALKEY_URL=redis://valkey:6379/0

--- a/agent-svc/agent/llm.py
+++ b/agent-svc/agent/llm.py
@@ -103,6 +103,11 @@ class LLMClient:
         if _llm_settings.llm_enable_thinking:
             body["enable_thinking"] = True
 
+        # Disable template-level reasoning for llama.cpp Qwen-family models
+        # that ignore enable_thinking:false on the top-level body.
+        if _llm_settings.llm_llama_cpp_disable_thinking:
+            body["chat_template_kwargs"] = {"enable_thinking": False}
+
         headers = {
             "Content-Type": "application/json",
         }
@@ -196,6 +201,11 @@ class LLMClient:
         _llm_settings = load_settings()
         if _llm_settings.llm_enable_thinking:
             body["enable_thinking"] = True
+
+        # Disable template-level reasoning for llama.cpp Qwen-family models
+        # that ignore enable_thinking:false on the top-level body.
+        if _llm_settings.llm_llama_cpp_disable_thinking:
+            body["chat_template_kwargs"] = {"enable_thinking": False}
 
         # If schema is provided, request structured JSON output
         # Uses json_object mode (widely supported across providers) with

--- a/agent-svc/agent/settings.py
+++ b/agent-svc/agent/settings.py
@@ -20,6 +20,9 @@ class AgentSettings(BaseModel):
     llm_api_key: str = Field(default="", alias="LLM_API_KEY")
     llm_model: str = Field(default="deepseek-v4-flash", alias="LLM_MODEL")
     llm_enable_thinking: bool = Field(default=False, alias="LLM_ENABLE_THINKING")
+    llm_llama_cpp_disable_thinking: bool = Field(
+        default=False, alias="LLM_LLAMA_CPP_DISABLE_THINKING"
+    )
     api_key: str = Field(default="", alias="API_KEY")
     webhook_secret: str = Field(default="", alias="WEBHOOK_SECRET")
     max_searches_per_request: int = Field(

--- a/docs/reference/public-surface.md
+++ b/docs/reference/public-surface.md
@@ -138,6 +138,7 @@ The configuration inventory follows `.env.sample`; unlisted implementation-only 
 - LLM_API_KEY
 - LLM_BASE_URL
 - LLM_ENABLE_THINKING
+- LLM_LLAMA_CPP_DISABLE_THINKING
 - LLM_MODEL
 - LOG_LEVEL
 - MCP_PORT

--- a/tests/service/test_llm.py
+++ b/tests/service/test_llm.py
@@ -8,6 +8,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from agent.settings import load_settings
 
 
 @pytest.fixture
@@ -206,27 +207,37 @@ class TestLLMClientGenerate:
             await llm.generate(system_prompt="x", user_prompt="y")
             body = mock_post.call_args[1]["json"]
             assert "enable_thinking" not in body
+            assert "chat_template_kwargs" not in body
 
     @pytest.mark.asyncio
     async def test_thinking_enabled_via_env(self):
         from agent.settings import load_settings as agent_load_settings
 
-        agent_load_settings.cache_clear()
-        with patch.dict(os.environ, {"LLM_ENABLE_THINKING": "true"}, clear=False):
+        try:
             agent_load_settings.cache_clear()
-            from agent.llm import LLMClient
+            with patch.dict(
+                os.environ, {"LLM_ENABLE_THINKING": "true"}, clear=False
+            ):
+                agent_load_settings.cache_clear()
+                from agent.llm import LLMClient
 
-            client = LLMClient(base_url="http://test/v1", api_key="k", model="ds")
-            with patch.object(
-                client._client,
-                "post",
-                return_value=_make_response(
-                    json_data={"choices": [{"message": {"content": "ok"}}]}
-                ),
-            ) as mock_post:
-                await client.generate(system_prompt="x", user_prompt="y")
-                body = mock_post.call_args[1]["json"]
-                assert body.get("enable_thinking") is True
+                client = LLMClient(
+                    base_url="http://test/v1", api_key="k", model="ds"
+                )
+                with patch.object(
+                    client._client,
+                    "post",
+                    return_value=_make_response(
+                        json_data={
+                            "choices": [{"message": {"content": "ok"}}]
+                        }
+                    ),
+                ) as mock_post:
+                    await client.generate(system_prompt="x", user_prompt="y")
+                    body = mock_post.call_args[1]["json"]
+                    assert body.get("enable_thinking") is True
+        finally:
+            agent_load_settings.cache_clear()
 
     @pytest.mark.asyncio
     async def test_close(self, llm):
@@ -353,6 +364,7 @@ class TestLLMClientGenerateStream:
             body = mock_client.stream.call_args[1]["json"]
             user_msg = body["messages"][1]["content"]
             assert "Some context here." in user_msg
+            assert "chat_template_kwargs" not in body
 
     @pytest.mark.asyncio
     async def test_schema_mode_delegates_to_generate(self, llm):
@@ -423,3 +435,74 @@ class TestLLMClientGenerateStream:
             assert tokens[0]["type"] == "token"
             assert tokens[0]["content"] == "normal"
             assert tokens[1]["type"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_llama_cpp_disable_thinking_generate():
+    """When LLM_LLAMA_CPP_DISABLE_THINKING=true, chat_template_kwargs is set (generate)."""
+    from agent.llm import LLMClient
+
+    load_settings.cache_clear()
+    try:
+        with patch.dict(
+            os.environ,
+            {"LLM_LLAMA_CPP_DISABLE_THINKING": "true"},
+            clear=False,
+        ):
+            load_settings.cache_clear()
+            client = LLMClient(
+                base_url="http://test/v1", api_key="k", model="test-model"
+            )
+            with patch.object(
+                client._client,
+                "post",
+                return_value=_make_response(
+                    json_data={"choices": [{"message": {"content": "ok"}}]}
+                ),
+            ) as mock_post:
+                await client.generate(system_prompt="x", user_prompt="y")
+                body = mock_post.call_args[1]["json"]
+                assert body.get("chat_template_kwargs") == {
+                    "enable_thinking": False
+                }
+    finally:
+        load_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_llama_cpp_disable_thinking_stream():
+    """When LLM_LLAMA_CPP_DISABLE_THINKING=true, chat_template_kwargs is set (stream)."""
+    from agent.llm import LLMClient
+
+    load_settings.cache_clear()
+    try:
+        with patch.dict(
+            os.environ,
+            {"LLM_LLAMA_CPP_DISABLE_THINKING": "true"},
+            clear=False,
+        ):
+            load_settings.cache_clear()
+            client = LLMClient(
+                base_url="http://test/v1", api_key="k", model="test-model"
+            )
+            mock_client_cls, mock_client = (
+                TestLLMClientGenerateStream._setup_stream_mock(
+                    [
+                        'data: {"choices":[{"delta":{"content":"ok"}}]}',
+                        "data: [DONE]",
+                    ]
+                )
+            )
+
+            with patch("httpx.AsyncClient", mock_client_cls):
+                async for _event in client.generate_stream(
+                    system_prompt="x", user_prompt="y"
+                ):
+                    pass
+
+                body = mock_client.stream.call_args[1]["json"]
+                assert body.get("chat_template_kwargs") == {
+                    "enable_thinking": False
+                }
+    finally:
+        load_settings.cache_clear()


### PR DESCRIPTION
## Summary

Adds an opt-in `LLM_LLAMA_CPP_DISABLE_THINKING` setting for Qwen-family models served by llama.cpp. When enabled, GroktoCrawl sends the llama.cpp-native template option that disables default reasoning before it can consume the 120-second request window.

The option is absent by default, so existing OpenAI-compatible providers retain their payloads unchanged.

## Related Issue

Closes #430

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [x] New tests added for the change
- [ ] Manual verification done (describe)

```text
24 passed in 0.24s
Documentation surface inventory matches routes, CLI, Compose, and .env.sample.
ruff: all checks passed
```

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

No endpoint or CLI surface changed. The endpoint checklist items are not applicable.

The setting maps only to llama.cpp's `chat_template_kwargs.enable_thinking` field. It is opt-in, so OpenAI, DeepSeek, Anthropic, and other existing provider payloads are unchanged.

I don't run continuously; responses may take 24–48 hours.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
