### PR TITLE
ci: preserve integration failure diagnostics

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -274,9 +274,44 @@ jobs:
             agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/ --timeout=120 --ignore-glob='*observability*'
         timeout-minutes: 20
 
-      - name: Collect logs on failure
+      - name: Collect diagnostics on failure
         if: failure()
-        run: docker compose logs --tail 50
+        run: |
+          report="$GITHUB_WORKSPACE/integration-test-diagnostics.txt"
+          {
+            echo "Integration test failure diagnostics"
+            echo "Collected at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo
+            echo "=== docker compose ps -a ==="
+            docker compose ps -a || true
+            echo
+            echo "=== docker stats --no-stream ==="
+            docker stats --no-stream || true
+            echo
+            echo "=== host memory ==="
+            free -h || vm_stat || true
+            echo
+            echo "=== host filesystem ==="
+            df -h || true
+            echo
+            echo "=== project container state ==="
+            docker ps -aq --filter "name=groktocrawl" | while read -r container; do
+              docker inspect --format \
+                'Name={{.Name}} Status={{.State.Status}} ExitCode={{.State.ExitCode}} FinishedAt={{.State.FinishedAt}} Error={{.State.Error}} OOMKilled={{.State.OOMKilled}}' \
+                "$container" || true
+            done || true
+            echo
+            echo "=== docker compose logs (last 50 lines) ==="
+            docker compose logs --tail 50 || true
+          } > "$report" 2>&1 || true
+
+      - name: Upload integration test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-diagnostics
+          path: integration-test-diagnostics.txt
+          if-no-files-found: warn
 
       - name: Tear down stack
         if: always()


### PR DESCRIPTION
## Summary

Preserves diagnostic evidence when Integration Tests fail before teardown removes the affected containers. The failure path now records container state, bounded logs, Docker statistics, and host memory and filesystem summaries, then uploads one workflow artifact.

## Related Issue

Closes #436

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [ ] New tests added for the change
- [x] Manual verification done (describe)

```text
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker.yml')"
python3 scripts/check-cli-coverage.py
python3 scripts/check-docs-surface.py
git diff --check HEAD^ HEAD
gitleaks detect --source . --log-opts 'HEAD^..HEAD' --no-banner --redact
```

Docker is unavailable on this workstation. The self-hosted Integration Tests workflow is the clean-room verification environment.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

```mermaid
flowchart TD
    A[Integration Tests fail] --> B[Collect best-effort diagnostics]
    B --> C[Upload diagnostic artifact]
    C --> D[Always tear down stack]
```

The collection commands tolerate dead or unavailable containers and do not alter the original failure result. No application, Docker Compose, environment, or public API behavior changes.

I don't run continuously; responses may take 24-48 hours.

Filed by Jasper (AI agent on behalf of Magnus Hedemark).
