### PR TITLE
test: remove live-search dependency from cross-session isolation

### DIFF
--- a/tests/integration/test_stack.py
+++ b/tests/integration/test_stack.py
@@ -7684,14 +7684,15 @@ def test_deepen_cross_session_isolation_val_dpn_003():
     r2 = httpx.post(AGENT + "/v2/session/create", json={"ttl": 600}, timeout=10)
     s1_id = r1.json()["sessionId"]
     s2_id = r2.json()["sessionId"]
-    # Add search to session 1
+    # Seed session 1 with a deterministic content-backed ref.
     s1 = httpx.post(
         AGENT + f"/v2/session/{s1_id}/step",
-        json={"action": "search", "params": {"query": "Rust programming", "limit": 1}},
-        timeout=30,
+        json={"action": "scrape", "params": {"urls": ["http://example.com"]}},
+        timeout=120,
     )
-    refs = s1.json()["result"].get("top_refs", [])
-    assert len(refs) > 0
+    assert s1.status_code == 200, s1.text
+    refs = s1.json()["result"]["refs"]
+    assert len(refs) > 0, "Need at least one scraped ref"
     ref_from_s1 = refs[0]["ref_id"]
     # Try to deepen on session 2 using ref from session 1
     s2 = httpx.post(


### PR DESCRIPTION
## Summary

Makes the cross-session deepen-isolation test seed session A with an existing deterministic scrape reference. The test no longer assumes an external search query returns at least one result before it checks that session B rejects session A’s reference.

## Related Issue

Closes #441

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [ ] New tests added for the change
- [x] Manual verification done (describe)

```text
python3 -m py_compile tests/integration/test_stack.py
git diff --check HEAD^ HEAD
gitleaks detect --source . --log-opts 'HEAD^..HEAD' --no-banner --redact
```

The unmodified current-main baseline failed in Integration Tests at this exact test. Docker is unavailable locally; CI is the authoritative integration verification.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

The test’s contract is session isolation, not search-provider result cardinality. The new seed follows the existing session-scrape test pattern and retains the cross-session rejection assertion unchanged.

I don't run continuously; responses may take 24-48 hours.

Filed by Jasper (AI agent on behalf of Magnus Hedemark).
