### PR TITLE
ci: add diagnostic critical journey smoke

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -260,6 +260,27 @@ jobs:
             docker cp "$pkg/." "$svc:/app/$pkg/"
           done
 
+      - name: Critical journey smoke (diagnostic)
+        continue-on-error: true
+        run: |
+          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate -q
+          set +e
+          docker compose exec -T \
+            -e PYTHONPATH=/app/agent-svc:/app/scraper-svc:/app/llm-svc:/app/parse-svc:/app/portal-svc:/app/browser-svc:/app \
+            -e SCRAPER_BASE_URL=http://scraper-svc:8001 \
+            -e SEARCH_BASE_URL=http://slopsearx:8080 \
+            -e LLM_BASE_URL=http://llm-svc:8011 \
+            -e TEST_SITE_BASE_URL=http://test-site:8000 \
+            -e TIER3_FIXTURE_BASE_URL=http://tier3-fixture:8000 \
+            -e SEMANTIC_BASE_URL=http://semantic-svc:8003 \
+            agent-svc python3 -m pytest /app/tests/integration/test_critical_journey.py -vv -rA
+          pytest_status=$?
+          if [ "$pytest_status" -ne 0 ]; then
+            docker compose logs --tail 50 test-site scraper-svc || true
+          fi
+          exit "$pytest_status"
+        timeout-minutes: 20
+
       - name: Run integration tests
         run: |
           docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate -q
@@ -271,7 +292,7 @@ jobs:
             -e TEST_SITE_BASE_URL=http://test-site:8000 \
             -e TIER3_FIXTURE_BASE_URL=http://tier3-fixture:8000 \
             -e SEMANTIC_BASE_URL=http://semantic-svc:8003 \
-            agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/ --timeout=120 --ignore-glob='*observability*'
+            agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/ --timeout=120 --ignore-glob='*observability*' --ignore=/app/tests/integration/test_critical_journey.py
         timeout-minutes: 20
 
       - name: Collect diagnostics on failure

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -24,4 +24,6 @@ Only expose or override internal service URLs when deliberately splitting the co
 
 `/health` reports dependency probes and `/metrics` exposes OpenMetrics data. Prometheus alerts and response procedures live in [runbooks](../runbooks/README.md). Important capacity controls include `AGENT_MAX_SEARCHES_PER_REQUEST`, `AGENT_SEARCH_RATE_LIMIT`, crawl duration/idle limits, scrape-cache TTLs, and vector-index capacity.
 
+The fixture-backed critical-journey diagnostic checks `/health`, the fast-search response contract, and `/v2/scrape` for `test-site`'s substantive `/content/multi-sentence` page; it deliberately does not promise live-search result cardinality, semantic retrieval, or research-agent results.
+
 Before upgrading, run `docker compose config --quiet`, rebuild changed services, and review [CHANGELOG.md](../../CHANGELOG.md). Use the fixture profile and test suite before changing production configuration.

--- a/tests/integration/test_critical_journey.py
+++ b/tests/integration/test_critical_journey.py
@@ -1,0 +1,71 @@
+"""Diagnostic checks for the minimum fixture-backed product journey."""
+
+import os
+
+import httpx
+import pytest
+
+AGENT = os.getenv("AGENT_BASE_URL", "http://localhost:8080")
+TEST_SITE = os.getenv("TEST_SITE_BASE_URL", "http://localhost:8005")
+
+
+def _payload(response: httpx.Response) -> dict:
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        pytest.fail(f"Expected JSON response: {response.text[:500]} ({exc})")
+    assert isinstance(payload, dict), f"Expected JSON object: {response.text[:500]}"
+    return payload
+
+
+def test_stack_readiness():
+    """stack readiness: the agent health endpoint reports an ok status."""
+    response = httpx.get(AGENT + "/health", timeout=30)
+    assert response.status_code == 200, (
+        f"stack readiness returned {response.status_code}: {response.text[:500]}"
+    )
+    payload = _payload(response)
+    assert payload.get("status") == "ok", f"stack readiness payload: {payload}"
+    print("stack readiness: status=ok")
+
+
+def test_search_contract():
+    """search contract: fast search succeeds regardless of live result count."""
+    response = httpx.post(
+        AGENT + "/v2/search",
+        json={"query": "fixture pricing", "search_type": "fast"},
+        timeout=30,
+    )
+    assert response.status_code == 200, (
+        f"search contract returned {response.status_code}: {response.text[:500]}"
+    )
+    payload = _payload(response)
+    assert payload.get("success") is True, f"search contract payload: {payload}"
+    data = payload.get("data")
+    assert isinstance(data, dict), f"search contract payload: {payload}"
+    web_results = data.get("web")
+    assert isinstance(web_results, list), f"search contract payload: {payload}"
+    print(f"search contract: result_count={len(web_results)}")
+
+
+def test_fixture_scrape():
+    """fixture scrape: the substantive fixture page returns expected markdown."""
+    response = httpx.post(
+        AGENT + "/v2/scrape",
+        json={"url": TEST_SITE + "/content/multi-sentence"},
+        timeout=30,
+    )
+    assert response.status_code == 200, (
+        f"fixture scrape returned {response.status_code}: {response.text[:500]}"
+    )
+    payload = _payload(response)
+    assert payload.get("success") is True, f"fixture scrape payload: {payload}"
+    data = payload.get("data")
+    assert isinstance(data, dict), f"fixture scrape payload: {payload}"
+    markdown = data.get("markdown")
+    assert isinstance(markdown, str), f"fixture scrape payload: {payload}"
+    assert "Multi-Sentence Page" in markdown, f"fixture scrape markdown: {markdown[:500]}"
+    assert "This is the first sentence of the description." in markdown, (
+        f"fixture scrape markdown: {markdown[:500]}"
+    )
+    print("fixture scrape: substantive markdown verified")


### PR DESCRIPTION
## Summary

Adds the first, diagnostic phase of a small fixture-backed critical-journey smoke check before the broad integration suite.

- Checks stack readiness through the agent health contract.
- Checks the fast-search response contract without treating valid zero live results as failure.
- Checks an agent-routed scrape of the existing substantive fixture endpoint, `/content/multi-sentence`.
- Keeps the first run non-blocking while it gathers evidence on synchronized `main`.
- Documents exactly what the diagnostic covers and excludes.

## Related Issue

Closes #437

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [x] New tests added for the change
- [x] Manual verification done (describe)

```text
python3 -m py_compile tests/integration/test_critical_journey.py
uv run --no-sync pytest --no-cov --collect-only tests/integration/test_critical_journey.py
# 3 tests collected
git diff --check HEAD^ HEAD
gitleaks detect --source . --log-opts 'HEAD^..HEAD' --no-banner --redact
```

Local Docker is unavailable. CI runs this smoke check in the existing fixture-backed Docker stack before the broad Integration Tests step. It is deliberately `continue-on-error` in this first diagnostic phase; its actual CI result determines whether the follow-up promotion can make it enforced.

The first two CI runs showed that collecting the new smoke inside the broad suite was invalid: the dedicated smoke passed, then the same stateful test ran again and failed. This update keeps the fixture-backed smoke in its own diagnostic stage and excludes that already-run file from the broad suite. It also retains bounded `test-site` and `scraper-svc` logs if the dedicated stage fails. The amended commit is `4704b47`; the rerun must still pass before this PR can merge.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

This does not alter application behavior, provider routing, test fixtures, or existing integration assertions. It intentionally does not claim deterministic live-search cardinality, semantic retrieval, browser fallback, or research-agent results.

I don't run continuously; responses may take 24-48 hours.

Filed by Jasper (AI agent on behalf of Magnus Hedemark).
