### PR TITLE
docs: verify observability artifact chain

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run ruff TD check (TODO/FIXME enforcement)
         run: python3 -m ruff check --select TD
 
+      - name: Validate observability artifacts
+        run: python3 tests/service/test_observability_contract.py
+
   duplicate-code:
     name: Duplicate Code
     runs-on: ubuntu-latest

--- a/docs/grafana/agent-svc-dashboard.json
+++ b/docs/grafana/agent-svc-dashboard.json
@@ -3,16 +3,24 @@
   "uid": "groktocrawl_agent_svc",
   "schemaVersion": 39,
   "version": 1,
-  "tags": ["groktocrawl", "agent-svc"],
+  "tags": ["groktocrawl", "agent-svc", "owner:groktocrawl-maintainers"],
+  "description": "Owner: GroktoCrawl maintainers",
   "timezone": "browser",
   "editable": true,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {
+    "list": [
+      {"name": "datasource", "type": "datasource", "query": "prometheus"}
+    ]
+  },
   "panels": [
     {
       "title": "Job Execution Rate",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -24,15 +32,15 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(jobs_submitted_total{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(jobs_submitted_total{job=\"agent-svc\"}[$__rate_interval])) by (type)",
           "legendFormat": "submitted {{type}}"
         },
         {
-          "expr": "sum(rate(jobs_completed_total{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(jobs_completed_total{job=\"agent-svc\"}[$__rate_interval])) by (type)",
           "legendFormat": "completed {{type}}"
         },
         {
-          "expr": "sum(rate(jobs_failed_total{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(jobs_failed_total{job=\"agent-svc\"}[$__rate_interval])) by (type)",
           "legendFormat": "failed {{type}}"
         }
       ],
@@ -43,7 +51,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -55,7 +63,7 @@
       },
       "targets": [
         {
-          "expr": "queue_depth{instance=~\"agent-svc:8080.*\"}",
+          "expr": "queue_depth{job=\"agent-svc\"}",
           "legendFormat": "Active jobs"
         }
       ],
@@ -66,14 +74,11 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
           "unit": "none",
-          "color": {
-            "mode": "background"
-          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -88,18 +93,19 @@
       },
       "targets": [
         {
-          "expr": "dependency_health{instance=~\"agent-svc:8080.*\"}",
+          "expr": "dependency_health{job=\"agent-svc\"}",
           "legendFormat": "{{dependency}}"
         }
       ],
-      "gridPos": {"h": 8, "w": 3, "x": 9, "y": 0}
+      "gridPos": {"h": 8, "w": 3, "x": 9, "y": 0},
+      "options": {"colorMode": "background"}
     },
     {
       "title": "Request Latency (p50/p95/p99)",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -111,15 +117,15 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"agent-svc\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"agent-svc\"}[$__rate_interval])) by (le))",
           "legendFormat": "p95"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"agent-svc\"}[$__rate_interval])) by (le))",
           "legendFormat": "p99"
         }
       ],
@@ -130,7 +136,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -142,15 +148,15 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(job_duration_seconds_bucket{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.50, sum(rate(job_duration_seconds_bucket{job=\"agent-svc\"}[$__rate_interval])) by (le, type))",
           "legendFormat": "p50 {{type}}"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(job_duration_seconds_bucket{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.95, sum(rate(job_duration_seconds_bucket{job=\"agent-svc\"}[$__rate_interval])) by (le, type))",
           "legendFormat": "p95 {{type}}"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(job_duration_seconds_bucket{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.99, sum(rate(job_duration_seconds_bucket{job=\"agent-svc\"}[$__rate_interval])) by (le, type))",
           "legendFormat": "p99 {{type}}"
         }
       ],
@@ -161,7 +167,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -173,7 +179,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(search_calls_total{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (status)",
+          "expr": "sum(rate(search_calls_total{job=\"agent-svc\"}[$__rate_interval])) by (status)",
           "legendFormat": "{{status}}"
         }
       ],
@@ -184,7 +190,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -196,11 +202,11 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(scrapes_total{instance=~\"agent-svc:8080.*\"}[$__rate_interval])) by (tier)",
+          "expr": "sum(rate(scrapes_total{job=\"agent-svc\"}[$__rate_interval])) by (tier)",
           "legendFormat": "Scrapes {{tier}}"
         },
         {
-          "expr": "rate(scrape_duration_seconds_sum{instance=~\"agent-svc:8080.*\"}[$__rate_interval]) / rate(scrape_duration_seconds_count{instance=~\"agent-svc:8080.*\"}[$__rate_interval])",
+          "expr": "rate(scrape_duration_seconds_sum{job=\"agent-svc\"}[$__rate_interval]) / rate(scrape_duration_seconds_count{job=\"agent-svc\"}[$__rate_interval])",
           "legendFormat": "Avg scrape duration (s)"
         }
       ],

--- a/docs/grafana/scraper-svc-dashboard.json
+++ b/docs/grafana/scraper-svc-dashboard.json
@@ -3,16 +3,24 @@
   "uid": "groktocrawl_scraper_svc",
   "schemaVersion": 39,
   "version": 1,
-  "tags": ["groktocrawl", "scraper-svc"],
+  "tags": ["groktocrawl", "scraper-svc", "owner:groktocrawl-maintainers"],
+  "description": "Owner: GroktoCrawl maintainers",
   "timezone": "browser",
   "editable": true,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {
+    "list": [
+      {"name": "datasource", "type": "datasource", "query": "prometheus"}
+    ]
+  },
   "panels": [
     {
       "title": "Scrape Call Rate",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -24,7 +32,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(scrape_calls_total{instance=~\"scraper-svc:8001.*\"}[$__rate_interval])) by (status)",
+          "expr": "sum(rate(scrape_calls_total{job=\"scraper-svc\"}[$__rate_interval])) by (status)",
           "legendFormat": "{{status}}"
         }
       ],
@@ -35,7 +43,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -47,7 +55,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(meta_calls_total{instance=~\"scraper-svc:8001.*\"}[$__rate_interval])) by (status)",
+          "expr": "sum(rate(meta_calls_total{job=\"scraper-svc\"}[$__rate_interval])) by (status)",
           "legendFormat": "{{status}}"
         }
       ],
@@ -58,7 +66,7 @@
       "type": "barchart",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -67,11 +75,11 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(scrape_calls_total{instance=~\"scraper-svc:8001.*\"}[$__rate_interval])) by (status)",
+          "expr": "sum(rate(scrape_calls_total{job=\"scraper-svc\"}[$__rate_interval])) by (status)",
           "legendFormat": "scrape {{status}}"
         },
         {
-          "expr": "sum(rate(meta_calls_total{instance=~\"scraper-svc:8001.*\"}[$__rate_interval])) by (status)",
+          "expr": "sum(rate(meta_calls_total{job=\"scraper-svc\"}[$__rate_interval])) by (status)",
           "legendFormat": "meta {{status}}"
         }
       ],
@@ -82,7 +90,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -94,15 +102,15 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{instance=~\"scraper-svc:8001.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"scraper-svc\"}[$__rate_interval])) by (le))",
           "legendFormat": "p50"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{instance=~\"scraper-svc:8001.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"scraper-svc\"}[$__rate_interval])) by (le))",
           "legendFormat": "p95"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{instance=~\"scraper-svc:8001.*\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"scraper-svc\"}[$__rate_interval])) by (le))",
           "legendFormat": "p99"
         }
       ],

--- a/docs/grafana/semantic-svc-dashboard.json
+++ b/docs/grafana/semantic-svc-dashboard.json
@@ -3,16 +3,24 @@
   "uid": "groktocrawl_semantic_svc",
   "schemaVersion": 39,
   "version": 1,
-  "tags": ["groktocrawl", "semantic-svc"],
+  "tags": ["groktocrawl", "semantic-svc", "owner:groktocrawl-maintainers"],
+  "description": "Owner: GroktoCrawl maintainers",
   "timezone": "browser",
   "editable": true,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {
+    "list": [
+      {"name": "datasource", "type": "datasource", "query": "prometheus"}
+    ]
+  },
   "panels": [
     {
       "title": "Index Size",
       "type": "gauge",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -32,7 +40,7 @@
       },
       "targets": [
         {
-          "expr": "groktocrawl_index_docs_total{instance=~\"semantic-svc:8003.*\"}",
+          "expr": "groktocrawl_index_docs_total{job=\"semantic-svc\"}",
           "legendFormat": "Documents"
         }
       ],
@@ -43,12 +51,11 @@
       "type": "stat",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
           "unit": "none",
-          "color": {"mode": "background"},
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -61,30 +68,31 @@
       },
       "targets": [
         {
-          "expr": "increase(groktocrawl_index_evictions_total{instance=~\"semantic-svc:8003.*\"}[$__rate_interval])",
+          "expr": "increase(groktocrawl_index_evictions_total{job=\"semantic-svc\"}[$__rate_interval])",
           "legendFormat": "Evictions/s"
         }
       ],
-      "gridPos": {"h": 8, "w": 6, "x": 6, "y": 0}
+      "gridPos": {"h": 8, "w": 6, "x": 6, "y": 0},
+      "options": {"colorMode": "background"}
     },
     {
       "title": "Query Latency (p50/p95/p99)",
       "type": "heatmap",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(groktocrawl_index_query_duration_seconds_bucket{instance=~\"semantic-svc:8003.*\"}[$__rate_interval])) by (le, endpoint))",
+          "expr": "histogram_quantile(0.50, sum(rate(groktocrawl_index_query_duration_seconds_bucket{job=\"semantic-svc\"}[$__rate_interval])) by (le, endpoint))",
           "legendFormat": "p50 {{endpoint}}"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(groktocrawl_index_query_duration_seconds_bucket{instance=~\"semantic-svc:8003.*\"}[$__rate_interval])) by (le, endpoint))",
+          "expr": "histogram_quantile(0.95, sum(rate(groktocrawl_index_query_duration_seconds_bucket{job=\"semantic-svc\"}[$__rate_interval])) by (le, endpoint))",
           "legendFormat": "p95 {{endpoint}}"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(groktocrawl_index_query_duration_seconds_bucket{instance=~\"semantic-svc:8003.*\"}[$__rate_interval])) by (le, endpoint))",
+          "expr": "histogram_quantile(0.99, sum(rate(groktocrawl_index_query_duration_seconds_bucket{job=\"semantic-svc\"}[$__rate_interval])) by (le, endpoint))",
           "legendFormat": "p99 {{endpoint}}"
         }
       ],
@@ -95,7 +103,7 @@
       "type": "barchart",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -104,7 +112,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(groktocrawl_search_requests_total{instance=~\"semantic-svc:8003.*\"}[$__rate_interval])) by (endpoint)",
+          "expr": "sum(rate(groktocrawl_search_requests_total{job=\"semantic-svc\"}[$__rate_interval])) by (endpoint)",
           "legendFormat": "{{endpoint}}"
         }
       ],
@@ -115,7 +123,7 @@
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -127,7 +135,7 @@
       },
       "targets": [
         {
-          "expr": "rate(groktocrawl_index_embeddings_duration_seconds_sum{instance=~\"semantic-svc:8003.*\"}[$__rate_interval]) / rate(groktocrawl_index_embeddings_duration_seconds_count{instance=~\"semantic-svc:8003.*\"}[$__rate_interval])",
+          "expr": "rate(groktocrawl_index_embeddings_duration_seconds_sum{job=\"semantic-svc\"}[$__rate_interval]) / rate(groktocrawl_index_embeddings_duration_seconds_count{job=\"semantic-svc\"}[$__rate_interval])",
           "legendFormat": "Average embed duration"
         }
       ],

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,36 @@
+# Observability
+
+**Owner:** GroktoCrawl maintainers
+
+| Source of truth | Artifact |
+|---|---|
+| Prometheus scrape jobs | `docs/prometheus/scrape-config.yml` |
+| Prometheus alerts | `docs/prometheus/alerts.yml` |
+| Grafana dashboards | `docs/grafana/*-svc-dashboard.json` |
+| Incident response | `docs/runbooks/` |
+
+| Service | Metrics endpoint | Prometheus job | Dashboard UID |
+|---|---|---|---|
+| agent-svc | `http://agent-svc:8080/metrics` | `agent-svc` | `groktocrawl_agent_svc` |
+| scraper-svc | `http://scraper-svc:8001/metrics` | `scraper-svc` | `groktocrawl_scraper_svc` |
+| semantic-svc | `http://semantic-svc:8003/metrics` | `semantic-svc` | `groktocrawl_semantic_svc` |
+
+| Alert | Runbook |
+|---|---|
+| HighJobErrorRate | `docs/runbooks/high-job-error-rate.md` |
+| QueueDepthSpike | `docs/runbooks/queue-depth-spike.md` |
+| ServiceDown | `docs/runbooks/service-down.md` |
+
+Environment-specific target addresses and contact-point secrets are deployment overlays and must never enter this public repository.
+
+## Verification
+
+1. Validate the deployment's Prometheus configuration and rules with its native check commands.
+2. Confirm all three targets are healthy and query a current metric, for example `up{job="agent-svc"}`.
+3. Import or provision the dashboards and confirm their UIDs are loaded.
+4. Confirm the alert rules are loaded and test the deployment contact point.
+5. Run the supported external API probe:
+
+   ```bash
+   groktocrawl --server "$GROKTOCRAWL_API_URL" --json search "observability probe" --limit 1
+   ```

--- a/docs/prometheus/alerts.yml
+++ b/docs/prometheus/alerts.yml
@@ -6,24 +6,30 @@ groups:
         for: 5m
         labels:
           severity: critical
+          owner: groktocrawl-maintainers
         annotations:
           summary: "High job error rate for {{ $labels.type }} jobs"
           description: "The error rate for {{ $labels.type }} jobs has exceeded 0.1 errors/sec over the last 5 minutes (current value: {{ $value }})."
+          runbook_url: "https://github.com/groktopus/groktocrawl/blob/main/docs/runbooks/high-job-error-rate.md"
 
       - alert: ServiceDown
-        expr: up{job=~"agent-svc|scraper-svc"} == 0
+        expr: up{job=~"agent-svc|scraper-svc|semantic-svc"} == 0
         for: 2m
         labels:
           severity: critical
+          owner: groktocrawl-maintainers
         annotations:
           summary: "Service {{ $labels.job }} is down"
           description: "The {{ $labels.job }} instance {{ $labels.instance }} has been unreachable for more than 2 minutes."
+          runbook_url: "https://github.com/groktopus/groktocrawl/blob/main/docs/runbooks/service-down.md"
 
       - alert: QueueDepthSpike
         expr: queue_depth > 100
         for: 5m
         labels:
           severity: warning
+          owner: groktocrawl-maintainers
         annotations:
           summary: "Queue depth spike for agent-svc"
           description: "The job queue depth in agent-svc has exceeded 100 active jobs (current value: {{ $value }})."
+          runbook_url: "https://github.com/groktopus/groktocrawl/blob/main/docs/runbooks/queue-depth-spike.md"

--- a/docs/prometheus/scrape-config.yml
+++ b/docs/prometheus/scrape-config.yml
@@ -1,0 +1,20 @@
+# Merge this fragment into the deployment-specific Prometheus configuration.
+scrape_configs:
+  - job_name: agent-svc
+    static_configs:
+      - targets: ["agent-svc:8080"]
+        labels:
+          owner: groktocrawl-maintainers
+          service: agent-svc
+  - job_name: scraper-svc
+    static_configs:
+      - targets: ["scraper-svc:8001"]
+        labels:
+          owner: groktocrawl-maintainers
+          service: scraper-svc
+  - job_name: semantic-svc
+    static_configs:
+      - targets: ["semantic-svc:8003"]
+        labels:
+          owner: groktocrawl-maintainers
+          service: semantic-svc

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,6 +2,14 @@
 
 Operational runbooks for common incidents and maintenance procedures.
 
+Owner: GroktoCrawl maintainers
+
+## Alert Runbooks
+
+- [HighJobErrorRate](high-job-error-rate.md)
+- [QueueDepthSpike](queue-depth-spike.md)
+- [ServiceDown](service-down.md)
+
 ---
 
 ## Service Health Check
@@ -27,17 +35,13 @@ docker compose up -d --force-recreate scraper-svc
 
 ## Valkey (Redis) Recovery
 
-If Valkey data is corrupted or the container won't start:
+If Valkey is unavailable or the container will not start:
 
 ```bash
-# Stop Valkey
-docker compose stop valkey
-
-# Remove the volume (DESTRUCTIVE - clears all job data)
-docker compose down -v valkey
-
-# Recreate
-docker compose up -d valkey
+# Inspect the failure, restart or recreate the service, then verify it responds.
+docker compose logs --tail=200 valkey
+docker compose up -d --force-recreate valkey
+docker compose exec valkey valkey-cli PING
 ```
 
 ## Qdrant Recovery

--- a/docs/runbooks/high-job-error-rate.md
+++ b/docs/runbooks/high-job-error-rate.md
@@ -2,6 +2,8 @@
 
 HighJobErrorRate
 
+Owner: GroktoCrawl maintainers
+
 ## Severity
 
 Critical
@@ -26,7 +28,6 @@ Critical
    curl -s http://localhost:8080/health
    ```
    Look for any dependency in a non-ok state (valkey, slopsearx, scraper, browser, portal).
-5. **Pause job processing** if needed by setting the `FEATURE_AGENT_ENABLED` toggle to `false` and restarting agent-svc.
 
 ## Investigation Steps
 
@@ -41,7 +42,7 @@ Critical
    ```
 3. **Check resource utilization** — look for memory or CPU pressure on the agent-svc container:
    ```bash
-   docker stats agent-svc --no-stream
+   docker compose stats --no-stream agent-svc
    ```
 4. **Verify Valkey connectivity** — if jobs cannot store state, failures cascade:
    ```bash

--- a/docs/runbooks/queue-depth-spike.md
+++ b/docs/runbooks/queue-depth-spike.md
@@ -2,6 +2,8 @@
 
 QueueDepthSpike
 
+Owner: GroktoCrawl maintainers
+
 ## Severity
 
 Warning
@@ -28,7 +30,7 @@ Warning
    ```bash
    curl -s http://localhost:8080/health
    ```
-5. **If the backlog is growing rapidly and dependencies are healthy**, consider scaling horizontally (if supported) or throttling incoming requests.
+5. **If the backlog is growing rapidly and dependencies are healthy**, identify the slow job type and recent configuration or deployment changes.
 
 ## Investigation Steps
 
@@ -50,7 +52,7 @@ Warning
    ```
 5. **Verify resource utilization** — CPU or memory contention can slow job processing:
    ```bash
-   docker stats agent-svc --no-stream
+   docker compose stats --no-stream agent-svc
    ```
 6. **Determine if the spike is traffic-driven** — check for a corresponding increase in `jobs_submitted_total` rate. If submissions are normal but queue is growing, the bottleneck is processing speed.
 7. **Review recent deployments or configuration changes** that may have introduced a performance regression.
@@ -59,4 +61,4 @@ Warning
 
 - **Level 1 (On-call engineer)**: Follow immediate actions. If the queue depth is driven by a transient traffic spike and dependencies are healthy, monitor for 10 minutes. The backlog should clear naturally as jobs complete.
 - **Level 2 (Service owner)**: If the queue depth exceeds 200 or persists for more than 15 minutes despite healthy dependencies, escalate to the service owner. Investigate potential performance regressions or resource bottlenecks.
-- **Level 3 (Engineering leadership)**: If the queue depth spike is caused by a systemic issue (e.g., all jobs are stuck due to a code defect, or the LLM provider is degraded), escalate to engineering leadership. Consider temporarily pausing new job submissions via the feature toggle (`FEATURE_AGENT_ENABLED=false`) and restarting agent-svc to drain the queue.
+- **Level 3 (Engineering leadership)**: If the queue depth spike is caused by a systemic issue (e.g., all jobs are stuck due to a code defect, or the LLM provider is degraded), escalate to engineering leadership.

--- a/docs/runbooks/service-down.md
+++ b/docs/runbooks/service-down.md
@@ -2,13 +2,15 @@
 
 ServiceDown
 
+Owner: GroktoCrawl maintainers
+
 ## Severity
 
 Critical
 
 ## Symptoms
 
-- The `up` metric for `agent-svc` or `scraper-svc` is `0`, indicating the service is unreachable by Prometheus.
+- The `up` metric for `agent-svc`, `scraper-svc`, or `semantic-svc` is `0`, indicating the service is unreachable by Prometheus.
 - Users cannot access the affected service's API endpoints.
 - Health checks for the affected service return connection refused or timeout.
 - Downstream services that depend on the affected service may also exhibit failures.
@@ -20,7 +22,7 @@ Critical
    ```bash
    docker compose ps <service-name>
    ```
-   Replace `<service-name>` with `agent-svc` or `scraper-svc`.
+   Replace `<service-name>` with `agent-svc`, `scraper-svc`, or `semantic-svc`.
 3. **Check service logs** for crash indicators or startup failures:
    ```bash
    docker compose logs --tail=100 <service-name>
@@ -35,6 +37,7 @@ Critical
    ```
    - agent-svc health: `http://localhost:8080/health`
    - scraper-svc health: `http://localhost:8001/health`
+   - semantic-svc health: `http://localhost:8003/health`
 
 ## Investigation Steps
 
@@ -44,7 +47,7 @@ Critical
    ```
 2. **Check for OOM kills** — look for `Killed` or `OOM` in docker logs:
    ```bash
-   docker inspect <container-id> | jq '.[].State.OOMKilled'
+   docker inspect "$(docker compose ps -q <service-name>)" --format '{{.State.OOMKilled}}'
    ```
 3. **Verify Docker host resources** — insufficient memory or disk space can cause service termination:
    ```bash

--- a/tests/service/test_observability_contract.py
+++ b/tests/service/test_observability_contract.py
@@ -1,0 +1,81 @@
+"""Contract tests for public GroktoCrawl observability source artifacts."""
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DASHBOARDS = {
+    "agent-svc": ROOT / "docs/grafana/agent-svc-dashboard.json",
+    "scraper-svc": ROOT / "docs/grafana/scraper-svc-dashboard.json",
+    "semantic-svc": ROOT / "docs/grafana/semantic-svc-dashboard.json",
+}
+RUNBOOK_URL = "https://github.com/groktopus/groktocrawl/blob/main/"
+
+
+class ObservabilityContractTests(unittest.TestCase):
+    def test_dashboards_are_portable_and_owned(self) -> None:
+        for service, path in DASHBOARDS.items():
+            with self.subTest(dashboard=path.name):
+                dashboard = json.loads(path.read_text())
+                self.assertIn("owner:groktocrawl-maintainers", dashboard["tags"])
+                self.assertIn("Owner: GroktoCrawl maintainers", dashboard["description"])
+                self.assertEqual(dashboard["refresh"], "30s")
+                self.assertEqual(dashboard["time"], {"from": "now-6h", "to": "now"})
+
+                variables = dashboard["templating"]["list"]
+                self.assertTrue(
+                    any(
+                        variable.get("name") == "datasource"
+                        and variable.get("type") == "datasource"
+                        and variable.get("query") == "prometheus"
+                        for variable in variables
+                    )
+                )
+
+                for panel in dashboard["panels"]:
+                    self.assertEqual(panel["datasource"]["uid"], "$datasource")
+                    self.assertNotEqual(
+                        panel.get("fieldConfig", {})
+                        .get("defaults", {})
+                        .get("color", {})
+                        .get("mode"),
+                        "background",
+                    )
+                    for target in panel.get("targets", []):
+                        expression = target["expr"]
+                        self.assertIn(f'job="{service}"', expression)
+                        self.assertNotIn("instance=", expression)
+
+    def test_scrape_fragment_has_only_owned_service_jobs(self) -> None:
+        fragment = (ROOT / "docs/prometheus/scrape-config.yml").read_text()
+        job_names = re.findall(r"^  - job_name: ([\w-]+)$", fragment, re.MULTILINE)
+        self.assertEqual(job_names, ["agent-svc", "scraper-svc", "semantic-svc"])
+        for service in job_names:
+            self.assertRegex(
+                fragment,
+                rf"job_name: {service}[\s\S]*?owner: groktocrawl-maintainers"
+                rf"[\s\S]*?service: {service}",
+            )
+
+    def test_alerts_have_owner_and_existing_runbooks(self) -> None:
+        alerts = (ROOT / "docs/prometheus/alerts.yml").read_text()
+        blocks = re.split(r"(?m)^      - alert: ", alerts)[1:]
+        self.assertEqual(len(blocks), 3)
+
+        for block in blocks:
+            alert_name = block.splitlines()[0]
+            with self.subTest(alert=alert_name):
+                self.assertIn("owner: groktocrawl-maintainers", block)
+                match = re.search(r'runbook_url: "([^"]+)"', block)
+                self.assertIsNotNone(match)
+                assert match is not None
+                self.assertTrue(match.group(1).startswith(RUNBOOK_URL))
+                runbook_path = match.group(1).removeprefix(RUNBOOK_URL)
+                self.assertTrue((ROOT / runbook_path).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the public, machine-readable Prometheus scrape fragment for the three supported services
- make all three Grafana dashboards portable, owned, current-data oriented, and compatible with Grafana 11 stat coloring
- connect alert rules to explicit owners and executable runbooks, including `semantic-svc` in `ServiceDown`
- remove stale/destructive runbook instructions and add a concise source-to-runtime observability inventory
- add a stdlib-only contract test that guards the dashboard, scrape, alert, owner, and runbook chain

This PR repairs the repository source artifacts first. After merge, the same artifacts will be deployed and verified against the live Prometheus/Grafana chain per #438.

## Related Issue

Closes #438

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [x] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` (GitHub Docker/Integration run `29226742367`)
- [x] New tests added for the change
- [x] Manual verification done: all dashboard JSON parsed; Prometheus YAML parsed; focused observability contract passed 3 tests; `git diff --check`, DCO, and commit-scoped Gitleaks passed

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — N/A, no endpoint added
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — N/A, no endpoint added

## Notes for Reviewers

- No private infrastructure names, addresses, credentials, or contact-point destinations are included. Environment-specific targets and alert destinations remain deployment overlays.
- Thresholds were intentionally preserved; this PR fixes ownership, routing metadata, portability, and runbook correctness without inventing SLOs.
- Repository-wide privacy review found an unrelated pre-existing private identifier in ADR-0026; it is tracked separately in #448 to preserve single-issue PR scope.
- AI assistance disclosure: implementation was delegated to OpenCode and independently reviewed by Jasper (OpenAI GPT-5.6).