### PR TITLE
fix: emit parseable semantic service metrics

### DIFF
--- a/semantic-svc/metrics.py
+++ b/semantic-svc/metrics.py
@@ -233,7 +233,7 @@ class MetricsCollector:
             lines.append("")
 
         lines.append("# EOF")
-        return "\n".join(lines)
+        return "\n".join(line for line in lines if line) + "\n"
 
 
 def _format_labels_no_braces(key: tuple) -> str:

--- a/tests/integration/test_semantic_svc_integration.py
+++ b/tests/integration/test_semantic_svc_integration.py
@@ -539,6 +539,8 @@ class TestMetrics:
         assert "# HELP" in text
         assert "# TYPE" in text
         assert "# EOF" in text
+        assert "\n\n" not in text
+        assert text.endswith("# EOF\n")
 
     def test_metrics_has_search_requests(self):
         skip_if_not_running()


### PR DESCRIPTION
## Summary

- remove blank separator lines from `semantic-svc` OpenMetrics output
- terminate the payload with a newline after `# EOF`
- strengthen the existing integration contract so syntactically broken output cannot pass on marker strings alone

Prometheus currently rejects the deployed endpoint at the first blank separator. This fixes the wire format at the shared semantic metrics generator rather than weakening the scrape target.

## Related Issue

Closes #450

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [x] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` (run `29246710849`, attempt 2)
- [x] Existing integration test strengthened for the change
- [x] Manual generator check verifies no blank lines and a trailing `# EOF\n`; Python compilation and `git diff --check` pass

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — N/A, wire-format fix only
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — N/A
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — N/A

## Notes for Reviewers

The diff is one generator expression plus two assertions in the existing endpoint contract. No dependency or parser abstraction was added.

AI assistance disclosure: diagnosed and implemented with Jasper (OpenAI GPT-5.6).