### PR TITLE
ci: serialize shared-runner integration jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -121,6 +121,9 @@ jobs:
     name: Integration Tests
     needs: build-and-push
     runs-on: [self-hosted, groktopus, docker]
+    concurrency:
+      group: groktocrawl-integration-${{ github.repository }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

- serialize only the shared-runner `Integration Tests` job across repository runs
- queue newer jobs instead of cancelling an active Compose suite
- leave independent image builds parallel

This prevents one run's stale-container cleanup or teardown from deleting another run's fixed `groktocrawl` Compose project.

## Related Issue

Closes #452

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [x] Docker/Integration workflow passes (run `29249862100`)
- [x] Workflow YAML parses and `git diff --check` passes
- [x] Collision evidence is preserved in #452

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated relevant documentation — N/A, workflow behavior is self-describing
- [x] I have added tests that prove my fix is effective — N/A, native Actions concurrency is the mechanism and workflow execution is the check
- [x] New API endpoints have a corresponding CLI subcommand — N/A
- [x] If adding a new async endpoint, it accepts a `webhook` field — N/A

## Notes for Reviewers

The change uses GitHub Actions' job-level `concurrency` primitive. A repository-scoped group is sufficient because every colliding job uses the same Compose project name on the same labeled runner.

AI assistance disclosure: diagnosed and implemented with Jasper (OpenAI GPT-5.6).