### PR TITLE
refactor(agent): unify research execution behind one event contract

### DIFF
--- a/agent-svc/agent/research/events.py
+++ b/agent-svc/agent/research/events.py
@@ -1,0 +1,37 @@
+"""Internal event contract for the research pipeline."""
+
+from typing import Any, Literal, NotRequired, Required, TypedDict
+
+ResearchEvent = TypedDict(
+    "ResearchEvent",
+    {
+        "type": Required[
+            Literal[
+                "status",
+                "research_plan",
+                "research_pass",
+                "sources_pending",
+                "source_scraped",
+                "sources",
+                "token",
+                "done",
+                "error",
+            ]
+        ],
+        "state": NotRequired[str],
+        "strategy": NotRequired[str],
+        "queries": NotRequired[list[str]],
+        "reasoning": NotRequired[str],
+        "pass": NotRequired[int],
+        "total_passes": NotRequired[int],
+        "sources": NotRequired[list[Any]],
+        "url": NotRequired[str],
+        "source": NotRequired[str],
+        "chars": NotRequired[int],
+        "content": NotRequired[str],
+        "result": NotRequired[str],
+        "source_details": NotRequired[list[dict[str, Any]]],
+        "latency_ms": NotRequired[int],
+    },
+    total=False,
+)

--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -18,6 +18,7 @@ from .discovery import (
     _run_research_discover_and_scrape,
     _scrape_urls,
 )
+from .events import ResearchEvent
 from .gaps import _detect_gaps
 from .plan import _generate_research_plan
 from .prompts import ANSWER_SYSTEM_PROMPT, EXTRACT_SYSTEM_PROMPT, SYSTEM_PROMPT
@@ -26,7 +27,7 @@ from .utils import _validate_json_if_schema
 logger = logging.getLogger(__name__)
 
 
-async def run_research(
+async def _run_research_events(
     prompt: str,
     urls: list[str] | None = None,
     schema: dict | None = None,
@@ -40,17 +41,10 @@ async def run_research(
     include_images: bool = False,
     citation_style: Any = None,
     search_type: str = "deep",
-) -> dict:
-    """Execute the research loop: plan → search → scrape → think → answer.
-
-    Phase 0: Query Intelligence analyzes the prompt and generates a research plan.
-    Phase 1: Search (single or multi-query) and scrape.
-    Phase 2: LLM synthesis with the scraped context.
-
-    Multi-pass: After Phase 2, detects content gaps via LLM. If gaps are found
-    and this is pass 1, a second pass searches the missing topics and re-synthesizes
-    with the combined context. Capped at 2 passes.
-    """
+    stream_tokens: bool = False,
+) -> AsyncGenerator[ResearchEvent, None]:
+    """Execute the canonical research loop and emit progress and terminal events."""
+    start = time.monotonic()
     if llm_model is None:
         raise ValueError("llm_model is required — set via LLM_MODEL env var")
     searxng = SearXNGClient(searxng_url, max_searches=max_searches_per_request)
@@ -66,26 +60,36 @@ async def run_research(
     )
 
     try:
-        pass_count = 0
-        max_passes = 2 if search_type == "deep" else 1
-
-        # Phase 0: Query Intelligence — analyze prompt, generate research plan (once)
+        yield {"type": "status", "state": "planning"}
         research_plan = await _generate_research_plan(prompt, llm)
         queries = research_plan["focused_queries"]
         strategy = research_plan["research_strategy"]
-
-        # search_type user preference overrides auto-classification
         if search_type == "deep":
             strategy = "deep"
         elif search_type == "focused":
             strategy = "focused"
+        yield {
+            "type": "research_plan",
+            "strategy": strategy,
+            "queries": queries,
+            "reasoning": research_plan.get("reasoning", ""),
+        }
 
+        pass_count = 0
+        max_passes = 2 if search_type == "deep" else 1
         all_source_details: list[dict] = []
         combined_context = ""
         gap_topics: list[str] = []
+        answer = ""
 
         while pass_count < max_passes:
             pass_count += 1
+            yield {
+                "type": "research_pass",
+                "pass": pass_count,
+                "total_passes": max_passes,
+            }
+            yield {"type": "status", "state": "searching"}
 
             if pass_count == 1:
                 # ── Pass 1: normal discovery ──────────────────────
@@ -121,15 +125,40 @@ async def run_research(
                 )
 
             context = discovered["context"]
+            source_details = discovered["source_details"]
+            search_results = discovered["search_results"]
+            pending_sources = (
+                [
+                    {
+                        "url": result["url"],
+                        "title": result.get("title", ""),
+                        "relevance": result.get("description", ""),
+                    }
+                    for result in search_results
+                    if result.get("url")
+                ]
+                if not urls
+                else [{"url": url, "title": "", "relevance": ""} for url in urls]
+            )
+            yield {"type": "sources_pending", "sources": pending_sources}
+            for source in source_details:
+                yield {
+                    "type": "source_scraped",
+                    "url": source["url"],
+                    "source": source["source"],
+                    "chars": source["char_count"],
+                }
             if not context and not combined_context:
-                return {
-                    "result": "I was unable to find or scrape any relevant web pages to answer your question.",
+                yield {"type": "sources", "sources": []}
+                yield {
+                    "type": "done",
+                    "result": "I was unable to find or scrape any relevant web pages.",
                     "sources": [],
                     "source_details": [],
+                    "latency_ms": int((time.monotonic() - start) * 1000),
                 }
+                return
 
-            # Combine contexts for multi-pass synthesis
-            source_details = discovered["source_details"]
             all_source_details.extend(source_details)
             if pass_count == 1:
                 combined_context = context
@@ -142,37 +171,116 @@ async def run_research(
                     )
 
             if not combined_context:
-                return {
-                    "result": "I was unable to find or scrape any relevant web pages to answer your question.",
+                yield {"type": "sources", "sources": []}
+                yield {
+                    "type": "done",
+                    "result": "I was unable to find or scrape any relevant web pages.",
                     "sources": [],
                     "source_details": [],
+                    "latency_ms": int((time.monotonic() - start) * 1000),
                 }
+                return
 
-            # ── Phase 2: Synthesis ────────────────────────────────
-            answer = await llm.generate(
-                system_prompt=SYSTEM_PROMPT,
-                user_prompt=prompt,
-                context=combined_context,
-                schema=schema,
-            )
-            _validate_json_if_schema(answer, schema)
+            yield {"type": "status", "state": "synthesizing"}
+            if schema or not stream_tokens:
+                answer = await llm.generate(
+                    system_prompt=SYSTEM_PROMPT,
+                    user_prompt=prompt,
+                    context=combined_context,
+                    schema=schema,
+                )
+                _validate_json_if_schema(answer, schema)
+            else:
+                yield {
+                    "type": "sources",
+                    "sources": [s["url"] for s in all_source_details],
+                }
+                answer = ""
+                async for event in llm.generate_stream(
+                    system_prompt=SYSTEM_PROMPT,
+                    user_prompt=prompt,
+                    context=combined_context,
+                ):
+                    if event["type"] == "token":
+                        answer += event["content"]
+                        yield {"type": "token", "content": event["content"]}
+                    elif event["type"] == "error":
+                        yield {"type": "error", "content": event["content"]}
+                        return
+                    elif event["type"] == "done":
+                        answer = event["full_content"]
 
             # ── Gap detection after pass 1 ─────────────────────────
             if pass_count == 1:
-                gap_topics = await _detect_gaps(combined_context, llm, original_query=prompt)
+                gap_topics = await _detect_gaps(
+                    combined_context, llm, original_query=prompt
+                )
                 if not gap_topics:
                     break  # Coverage is adequate, done
                 max_passes = 2  # Enable second pass
 
-        return {
+        source_list = [source["url"] for source in all_source_details]
+        if schema:
+            yield {"type": "sources", "sources": source_list}
+        yield {
+            "type": "done",
             "result": answer,
-            "sources": [s["url"] for s in all_source_details],
+            "sources": source_list,
             "source_details": all_source_details,
+            "latency_ms": int((time.monotonic() - start) * 1000),
         }
     finally:
         await searxng.close()
         await scraper.close()
         await llm.close()
+
+
+async def run_research(
+    prompt: str,
+    urls: list[str] | None = None,
+    schema: dict | None = None,
+    searxng_url: str = "http://searxng:8080",
+    scraper_url: str = "http://scraper-svc:8001",
+    llm_base_url: str = "https://api.openai.com/v1",
+    llm_api_key: str = "",
+    llm_model: str | None = None,
+    requested_model: str | None = None,
+    max_searches_per_request: int = 5,
+    include_images: bool = False,
+    citation_style: Any = None,
+    search_type: str = "deep",
+) -> dict:
+    """Consume the canonical research event stream and return its terminal result."""
+    async for event in _run_research_events(
+        prompt,
+        urls,
+        schema,
+        searxng_url,
+        scraper_url,
+        llm_base_url,
+        llm_api_key,
+        llm_model,
+        requested_model,
+        max_searches_per_request,
+        include_images,
+        citation_style,
+        search_type,
+    ):
+        if event["type"] == "done":
+            result = event["result"]
+            if not event["sources"] and result == (
+                "I was unable to find or scrape any relevant web pages."
+            ):
+                result = (
+                    "I was unable to find or scrape any relevant web pages "
+                    "to answer your question."
+                )
+            return {
+                "result": result,
+                "sources": event["sources"],
+                "source_details": event["source_details"],
+            }
+    raise RuntimeError("Research event engine ended without a terminal done event")
 
 
 async def run_research_stream(
@@ -189,246 +297,25 @@ async def run_research_stream(
     include_images: bool = False,
     citation_style: Any = None,
     search_type: str = "deep",
-) -> AsyncGenerator[dict[str, Any], None]:
-    """Streaming version of run_research. Yields SSE-suitable dicts.
-
-    Phase 0 - Query Intelligence: analyze prompt, generate research plan (NEW).
-    Phase 1 - Discovery: search (single or multi-query) + scrape, yielding progress events.
-    Phase 2 - Synthesis: LLM token stream (or full response for schema-based output).
-
-    Yields:
-      {"type": "research_plan", "strategy": "...", "queries": [...], "reasoning": "..."} — plan
-      {"type": "sources_pending", "sources": [...]} — search results (before scrape)
-      {"type": "source_scraped", "url": "...", "source": "...", "chars": N} — each scraped page
-      {"type": "token", "content": "..."} — individual tokens from the LLM (no schema)
-      {"type": "done", "result": "...", "sources": [...], "latency_ms": N} — final
-      {"type": "error", "content": "..."} — error
-    """
-    start = time.monotonic()
-    if llm_model is None:
-        raise ValueError("llm_model is required — set via LLM_MODEL env var")
-
-    searxng = SearXNGClient(searxng_url, max_searches=max_searches_per_request)
-    scraper = ScraperClient(scraper_url)
-    effective_model = (
-        requested_model
-        if requested_model and requested_model != "default"
-        else llm_model
-    )
-    llm = LLMClient(llm_base_url, llm_api_key, effective_model)
-    scrape_opts: dict | None = (
-        {"formats": ["markdown", "images"]} if include_images else None
-    )
-
-    try:
-        # Phase 0: Query Intelligence — analyze prompt, generate research plan
-        yield {"type": "status", "state": "planning"}
-
-        research_plan = await _generate_research_plan(prompt, llm)
-        queries = research_plan["focused_queries"]
-        strategy = research_plan["research_strategy"]
-        reasoning = research_plan.get("reasoning", "")
-
-        # search_type user preference overrides auto-classification
-        if search_type == "deep":
-            strategy = "deep"
-        elif search_type == "focused":
-            strategy = "focused"
-
-        yield {
-            "type": "research_plan",
-            "strategy": strategy,
-            "queries": queries,
-            "reasoning": reasoning,
-        }
-
-        pass_count = 0
-        max_passes = 2 if search_type == "deep" else 1
-        all_source_details: list[dict] = []
-        combined_context = ""
-        gap_topics: list[str] = []
-
-        while pass_count < max_passes:
-            pass_count += 1
-
-            yield {
-                "type": "research_pass",
-                "pass": pass_count,
-                "total_passes": max_passes,
-            }
-            yield {"type": "status", "state": "searching"}
-
-            if pass_count == 1:
-                # ── Pass 1: normal discovery ────────────────────────
-                if strategy == "deep" and len(queries) > 1:
-                    discovered = await _run_multi_query_discover_and_scrape(
-                        queries=queries,
-                        urls=urls,
-                        searxng=searxng,
-                        scraper=scraper,
-                        max_searches_per_request=max_searches_per_request,
-                        scrape_options=scrape_opts,
-                    )
-                else:
-                    query = queries[0] if queries else prompt
-                    discovered = await _run_research_discover_and_scrape(
-                        prompt=query,
-                        urls=urls,
-                        searxng=searxng,
-                        scraper=scraper,
-                        scrape_options=scrape_opts,
-                    )
-            else:
-                # ── Pass 2: gap-focused discovery ────────────────────
-                discovered = await _run_multi_query_discover_and_scrape(
-                    queries=gap_topics,
-                    urls=None,
-                    searxng=searxng,
-                    scraper=scraper,
-                    max_searches_per_request=min(
-                        len(gap_topics), max_searches_per_request
-                    ),
-                    scrape_options=scrape_opts,
-                )
-
-            search_results = discovered["search_results"]
-            source_details = discovered["source_details"]
-            context = discovered["context"]
-
-            # Yield pending sources for progress visibility
-            pending_sources = (
-                [
-                    {
-                        "url": r["url"],
-                        "title": r.get("title", ""),
-                        "relevance": r.get("description", ""),
-                    }
-                    for r in search_results
-                    if r.get("url")
-                ]
-                if not urls
-                else [{"url": u, "title": "", "relevance": ""} for u in urls]
-            )
-            yield {"type": "sources_pending", "sources": pending_sources}
-
-            # Yield scraped source progress events
-            for src in source_details:
-                yield {
-                    "type": "source_scraped",
-                    "url": src["url"],
-                    "source": src["source"],
-                    "chars": src["char_count"],
-                }
-
-            if not context and not combined_context:
-                elapsed = int((time.monotonic() - start) * 1000)
-                yield {"type": "sources", "sources": []}
-                yield {
-                    "type": "done",
-                    "result": (
-                        "I was unable to find or scrape any relevant web pages."
-                    ),
-                    "sources": [],
-                    "source_details": [],
-                    "latency_ms": elapsed,
-                }
-                return
-
-            # Combine contexts for multi-pass synthesis
-            all_source_details.extend(source_details)
-            if pass_count == 1:
-                combined_context = context
-            else:
-                if context:
-                    combined_context = (
-                        combined_context
-                        + "\n\n---\n\nAdditional sources (pass 2):\n\n"
-                        + context
-                    )
-
-            if not combined_context:
-                elapsed = int((time.monotonic() - start) * 1000)
-                yield {"type": "sources", "sources": []}
-                yield {
-                    "type": "done",
-                    "result": (
-                        "I was unable to find or scrape any relevant web pages."
-                    ),
-                    "sources": [],
-                    "source_details": [],
-                    "latency_ms": elapsed,
-                }
-                return
-
-            # Yield status heartbeat — synthesizing phase
-            yield {"type": "status", "state": "synthesizing"}
-
-            # Phase 2: Synthesis
-            if schema:
-                answer = await llm.generate(
-                    system_prompt=SYSTEM_PROMPT,
-                    user_prompt=prompt,
-                    context=combined_context,
-                    schema=schema,
-                )
-                _validate_json_if_schema(answer, schema)
-            else:
-                # No schema — stream tokens from the LLM
-                yield {
-                    "type": "sources",
-                    "sources": [s["url"] for s in all_source_details],
-                }
-
-                full_answer = ""
-                async for event in llm.generate_stream(
-                    system_prompt=SYSTEM_PROMPT,
-                    user_prompt=prompt,
-                    context=combined_context,
-                ):
-                    if event["type"] == "token":
-                        full_answer += event["content"]
-                        yield {"type": "token", "content": event["content"]}
-                    elif event["type"] == "error":
-                        yield {"type": "error", "content": event["content"]}
-                        return
-                    elif event["type"] == "done":
-                        full_answer = event["full_content"]
-
-            # ── Gap detection after pass 1 ──────────────────────
-            if pass_count == 1:
-                gap_topics = await _detect_gaps(
-                    combined_context, llm, original_query=prompt
-                )
-                if not gap_topics:
-                    break  # Coverage is adequate, done
-                max_passes = 2  # Enable second pass
-                continue
-        # ── Final done event after all passes ───────────────────────
-        source_list = [s["url"] for s in all_source_details]
-        elapsed = int((time.monotonic() - start) * 1000)
-
-        if schema:
-            yield {"type": "sources", "sources": source_list}
-            yield {
-                "type": "done",
-                "result": answer,
-                "sources": source_list,
-                "source_details": all_source_details,
-                "latency_ms": elapsed,
-            }
-        else:
-            yield {
-                "type": "done",
-                "result": full_answer,
-                "sources": source_list,
-                "source_details": all_source_details,
-                "latency_ms": elapsed,
-            }
-
-    finally:
-        await searxng.close()
-        await scraper.close()
-        await llm.close()
+) -> AsyncGenerator[ResearchEvent, None]:
+    """Expose events from the canonical research engine for SSE adaptation."""
+    async for event in _run_research_events(
+        prompt,
+        urls,
+        schema,
+        searxng_url,
+        scraper_url,
+        llm_base_url,
+        llm_api_key,
+        llm_model,
+        requested_model,
+        max_searches_per_request,
+        include_images,
+        citation_style,
+        search_type,
+        stream_tokens=True,
+    ):
+        yield event
 
 
 async def run_extract(

--- a/agent-svc/agent/research/memory.py
+++ b/agent-svc/agent/research/memory.py
@@ -1,0 +1,59 @@
+"""Best-effort admission of completed research into Research Memory."""
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def admit_research_memory(
+    research_memory: Any,
+    *,
+    prompt: str,
+    artifact: str,
+    source_details: list[dict[str, Any]] | list[str],
+    model: str,
+    citation_style: str,
+    requested_model: str | None = None,
+    latency_ms: int = 0,
+    user_id: str | None = None,
+) -> str | None:
+    """Store a valid final artifact, treating unavailable memory as non-fatal."""
+    if (
+        research_memory is None
+        or not artifact
+        or artifact.startswith("Error:")
+        or not source_details
+    ):
+        return None
+
+    memory_scope = os.environ.get("RESEARCH_MEMORY_SCOPE", "global")
+    if memory_scope == "per_user" and user_id is None:
+        user_id = "anonymous"
+    metadata: dict[str, Any] = {
+        "model": model,
+        "citation_style": citation_style,
+        "latency_ms": latency_ms,
+    }
+    if requested_model and requested_model != "default":
+        metadata["requested_model"] = requested_model
+
+    try:
+        artifact_id = await research_memory.store(
+            prompt=prompt,
+            artifact=artifact,
+            sources=source_details,
+            model=model,
+            user_id=user_id if memory_scope == "per_user" else None,
+            metadata=metadata,
+        )
+        logger.info(
+            "Stored research memory artifact %s (scope=%s)", artifact_id, memory_scope
+        )
+        return artifact_id
+    except Exception:
+        logger.warning(
+            "Failed to store research memory (service may be down)", exc_info=True
+        )
+        return None

--- a/agent-svc/agent/research/streaming.py
+++ b/agent-svc/agent/research/streaming.py
@@ -12,6 +12,7 @@ from typing import Any
 from ..models import CitationStyle
 from .citations import _apply_citation_style
 from .loop import run_research_stream
+from .memory import admit_research_memory
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,8 @@ async def stream_research_live(
     include_images: bool,
     citation_style: CitationStyle,
     search_type: str = "deep",
+    research_memory: Any = None,
+    user_id: str | None = None,
 ) -> Any:
     """Orchestrate full research SSE pipeline for cache-miss or force-fresh.
 
@@ -118,6 +121,18 @@ async def stream_research_live(
             transformed_result, _ = _apply_citation_style(
                 event["result"], source_details, cs
             )
+            if research_memory is not None:
+                await admit_research_memory(
+                    research_memory,
+                    prompt=prompt,
+                    artifact=transformed_result,
+                    source_details=source_details,
+                    model=llm_model,
+                    citation_style=cs.value,
+                    requested_model=requested_model,
+                    latency_ms=event["latency_ms"],
+                    user_id=user_id,
+                )
 
             done_payload: dict = {
                 "type": "done",

--- a/agent-svc/agent/routes/agent.py
+++ b/agent-svc/agent/routes/agent.py
@@ -145,6 +145,8 @@ async def _handle_agent_streaming(
                 include_images=body.include_images,
                 citation_style=body.citation_style,
                 search_type=body.search_type,
+                research_memory=request.app.state.research_memory,
+                user_id=_derive_user_id(request),
             ),
             media_type="text/event-stream",
             headers=headers,

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from .metrics import METRICS
 from .research import run_extract, run_research
+from .research.memory import admit_research_memory
 from .scraper_client import ScraperClient
 from .settings import load_settings
 from .store import JobStore
@@ -204,7 +205,8 @@ async def _process_agent_async(
 
         # Save rich source_details for memory storage BEFORE compactifying
         # the API response. Cache-hit paths expect sources as list[dict].
-        rich_source_details = source_details or result.get("source_details", [])
+        rich_source_details = source_details
+        memory_sources = rich_source_details or result.get("sources", [])
 
         # When citation_style is compact, replace full source_details with
         # a compact citations mapping (index → {url}) to reduce
@@ -222,58 +224,19 @@ async def _process_agent_async(
             # Drop the full source_details from the API response to save payload size
             result["source_details"] = []
 
-        # ── Store fresh result in research memory ──────────────────
-        try:
-            answer = result.get("result", "")
-            # Use rich_source_details (preserved before compactification) for memory
-            store_sources = rich_source_details or result.get("sources", [])
-            if not store_sources:
-                store_sources = result.get("sources", [])
-
-            # ── Cache-admission guard ──────────────────────────
-            # Skip store for empty answers, handled LLM errors,
-            # or sourceless results (#432).
-            if answer and not answer.startswith("Error:") and store_sources:
-                metadata: dict[str, Any] = {
-                    "model": llm_model,
-                    "citation_style": cs.value,
-                }
-                if requested_model and requested_model != "default":
-                    metadata["requested_model"] = requested_model
-                if hasattr(result, "get"):
-                    metadata["latency_ms"] = result.get("latency_ms", 0)
-
-                memory_user_id = user_id if memory_scope == "per_user" else None
-                artifact_id = await research_memory.store(
-                    prompt=prompt,
-                    artifact=answer,
-                    sources=store_sources,
-                    model=llm_model,
-                    user_id=memory_user_id,
-                    metadata=metadata,
-                )
-                logger.info(
-                    "Stored research memory artifact %s for agent %s (scope=%s)",
-                    artifact_id,
-                    job_id,
-                    memory_scope,
-                )
-                result["research_memory_id"] = artifact_id
-            else:
-                logger.info(
-                    "Skipping research memory store for agent %s "
-                    "(empty=%s, error=%s, no_sources=%s)",
-                    job_id,
-                    not answer,
-                    answer.startswith("Error:") if answer else False,
-                    not store_sources,
-                )
-        except Exception:
-            logger.warning(
-                "Failed to store research memory for agent %s (service may be down)",
-                job_id,
-                exc_info=True,
-            )
+        artifact_id = await admit_research_memory(
+            research_memory,
+            prompt=prompt,
+            artifact=result.get("result", ""),
+            source_details=memory_sources,
+            model=llm_model,
+            citation_style=cs.value,
+            requested_model=requested_model,
+            latency_ms=result.get("latency_ms", 0),
+            user_id=user_id,
+        )
+        if artifact_id:
+            result["research_memory_id"] = artifact_id
 
         # Note stale cache existence if applicable
         if stale_cache_hit:

--- a/tests/integration/test_research.py
+++ b/tests/integration/test_research.py
@@ -145,6 +145,42 @@ class TestScrapeUrls:
 
 
 class TestRunResearch:
+    @pytest.mark.asyncio
+    async def test_consumes_terminal_event_from_canonical_engine(self):
+        """Polling adapts the shared event engine instead of running its own loop."""
+        from agent.research import run_research
+
+        async def events(*args, **kwargs):
+            yield {"type": "status", "state": "planning"}
+            yield {
+                "type": "done",
+                "result": "canonical result",
+                "sources": ["https://example.com"],
+                "source_details": [{"url": "https://example.com"}],
+                "latency_ms": 1,
+            }
+
+        with patch("agent.research.loop._run_research_events", events):
+            result = await run_research(prompt="Test", llm_model="test-model")
+
+        assert result == {
+            "result": "canonical result",
+            "sources": ["https://example.com"],
+            "source_details": [{"url": "https://example.com"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_fails_when_canonical_engine_has_no_terminal_event(self):
+        """A broken event engine must not be presented as an empty success."""
+        from agent.research import run_research
+
+        async def events(*args, **kwargs):
+            yield {"type": "status", "state": "planning"}
+
+        with patch("agent.research.loop._run_research_events", events):
+            with pytest.raises(RuntimeError, match="without a terminal done event"):
+                await run_research(prompt="Test", llm_model="test-model")
+
     @pytest.fixture
     def mocks(self):
         """Patch all three clients used by run_research."""
@@ -220,7 +256,9 @@ class TestRunResearch:
             patch("agent.research.loop.ScraperClient", return_value=scraper),
             patch("agent.research.loop.LLMClient", return_value=llm),
         ):
-            result = await run_research(prompt="Tell me about AI", llm_model="test-model")
+            result = await run_research(
+                prompt="Tell me about AI", llm_model="test-model"
+            )
 
         assert result["result"] == "Answer from search."
         searxng.search.assert_called_once()
@@ -654,6 +692,37 @@ class TestRunResearchStream:
         # done event
         done_events = [e for e in events if e["type"] == "done"]
         assert len(done_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_exposes_canonical_events(self):
+        """Streaming adapts the shared engine without translating its events."""
+        from agent.research import run_research_stream
+
+        expected = [
+            {"type": "status", "state": "planning"},
+            {
+                "type": "done",
+                "result": "complete",
+                "sources": [],
+                "source_details": [],
+                "latency_ms": 1,
+            },
+        ]
+
+        async def events(*args, **kwargs):
+            assert kwargs["stream_tokens"] is True
+            for event in expected:
+                yield event
+
+        with patch("agent.research.loop._run_research_events", events):
+            actual = [
+                event
+                async for event in run_research_stream(
+                    prompt="Test", llm_model="test-model"
+                )
+            ]
+
+        assert actual == expected
 
     @pytest.mark.asyncio
     async def test_schema_mode_no_tokens(self):

--- a/tests/service/test_research_streaming.py
+++ b/tests/service/test_research_streaming.py
@@ -1,0 +1,130 @@
+"""Focused tests for research SSE memory admission."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestResearchMemoryAdmission:
+    @pytest.mark.asyncio
+    async def test_stores_only_valid_sourced_artifacts(self):
+        from agent.research.memory import admit_research_memory
+
+        memory = MagicMock()
+        memory.store = AsyncMock(return_value="memory-id")
+        sources = [{"url": "https://example.com", "title": "Example"}]
+
+        artifact_id = await admit_research_memory(
+            memory,
+            prompt="Question",
+            artifact="Answer [1](https://example.com)",
+            source_details=sources,
+            model="test-model",
+            citation_style="inline",
+        )
+
+        assert artifact_id == "memory-id"
+        assert memory.store.call_args.kwargs["sources"] == sources
+        assert (
+            memory.store.call_args.kwargs["artifact"]
+            == "Answer [1](https://example.com)"
+        )
+
+        for artifact, source_details in (
+            ("", sources),
+            ("Error: handled", sources),
+            ("Answer", []),
+        ):
+            await admit_research_memory(
+                memory,
+                prompt="Question",
+                artifact=artifact,
+                source_details=source_details,
+                model="test-model",
+                citation_style="inline",
+            )
+        memory.store.assert_called_once()
+
+
+class TestLiveResearchStreamingAdmission:
+    @staticmethod
+    async def _events(*args, **kwargs):
+        yield {"type": "status", "state": "planning"}
+        yield {
+            "type": "done",
+            "result": "Answer [1]",
+            "sources": ["https://example.com"],
+            "source_details": [
+                {"url": "https://example.com", "title": "Example", "source": "test"}
+            ],
+            "latency_ms": 4,
+        }
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_stores_transformed_result_and_rich_sources(self):
+        from agent.models import CitationStyle
+        from agent.research.streaming import stream_research_live
+
+        memory = MagicMock()
+        memory.store = AsyncMock(return_value="memory-id")
+        with patch("agent.research.streaming.run_research_stream", self._events):
+            chunks = [
+                chunk
+                async for chunk in stream_research_live(
+                    prompt="Question",
+                    urls=None,
+                    schema=None,
+                    searxng_url="http://searxng",
+                    scraper_url="http://scraper",
+                    llm_base_url="http://llm",
+                    llm_api_key="key",
+                    llm_model="test-model",
+                    requested_model=None,
+                    max_searches_per_request=5,
+                    include_images=False,
+                    citation_style=CitationStyle.compact,
+                    research_memory=memory,
+                )
+            ]
+
+        assert chunks[-1] == "data: [DONE]\n\n"
+        assert (
+            memory.store.call_args.kwargs["artifact"]
+            == "Answer [1](https://example.com)"
+        )
+        assert memory.store.call_args.kwargs["sources"] == [
+            {"url": "https://example.com", "title": "Example", "source": "test"}
+        ]
+        done = json.loads(chunks[-2].removeprefix("data: "))
+        assert done["type"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_memory_store_failure_does_not_truncate_stream(self):
+        from agent.models import CitationStyle
+        from agent.research.streaming import stream_research_live
+
+        memory = MagicMock()
+        memory.store = AsyncMock(side_effect=RuntimeError("memory unavailable"))
+        with patch("agent.research.streaming.run_research_stream", self._events):
+            chunks = [
+                chunk
+                async for chunk in stream_research_live(
+                    prompt="Question",
+                    urls=None,
+                    schema=None,
+                    searxng_url="http://searxng",
+                    scraper_url="http://scraper",
+                    llm_base_url="http://llm",
+                    llm_api_key="key",
+                    llm_model="test-model",
+                    requested_model=None,
+                    max_searches_per_request=5,
+                    include_images=False,
+                    citation_style=CitationStyle.compact,
+                    research_memory=memory,
+                )
+            ]
+
+        assert any('"type": "done"' in chunk for chunk in chunks)
+        assert chunks[-1] == "data: [DONE]\n\n"

--- a/tests/service/test_worker.py
+++ b/tests/service/test_worker.py
@@ -197,6 +197,21 @@ class TestProcessAgentAsync:
         assert call_args.kwargs["artifact"] == "This is a valid research result."
 
     @pytest.mark.asyncio
+    async def test_success_result_with_url_sources_is_cached(self):
+        """Keep the legacy admission fallback when rich details are unavailable."""
+        mocks = await self._run_worker_with(
+            {
+                "result": "This is a valid research result.",
+                "sources": ["https://a.com"],
+            },
+            job_id="test-job-url-sources-cache",
+        )
+
+        assert mocks["research_memory"].store.call_args.kwargs["sources"] == [
+            "https://a.com"
+        ]
+
+    @pytest.mark.asyncio
     async def test_default_valkey_url(self):
         """Verify JobStore is constructed with the default VALKEY_URL."""
         from agent.worker import _process_agent_async


### PR DESCRIPTION
## Summary

- replace the duplicated polling and streaming research loops with one internal event-producing engine
- preserve the existing polling result and SSE event contracts through thin adapters
- share Research Memory admission between polling jobs and live streaming cache misses
- keep invalid, empty, sourceless, and failed memory writes non-fatal

## Related Issue

Closes #457

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [x] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` — Docker is unavailable in the local execution environment; CI must run this gate
- [x] New tests added for the change
- [x] Manual verification done: audited every `run_research()` and `run_research_stream()` caller, preserved both public signatures, and independently reviewed the event, citation, memory-scope, error, and resource-cleanup paths

Additional checks run:

- `uv run pytest -q --no-cov tests/integration/test_research.py tests/service/test_worker.py tests/service/test_research_streaming.py` — 73 passed
- `uv run ruff check ...` — passed
- `uv run ruff format --check ...` — passed
- `python3 scripts/check-cli-coverage.py` — all 46 API endpoints covered
- `python3 scripts/check-docs-surface.py` — passed
- `gitleaks dir <changed-files>` — no leaks found

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — N/A; internal refactor with unchanged public contracts and documented surfaces
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — N/A; no endpoint added
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — N/A; no endpoint added

## Notes for Reviewers

The internal event contract is intentionally a stdlib `TypedDict`. This PR does not add persistent event storage, checkpointing, a graph runtime, or `ResearchState`; #460 covers the separate state-projection question.

The new tests fail against `origin/main` because the canonical event engine, shared admission helper, and streaming admission hook do not yet exist there.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
