### PR TITLE
docs(agent): clarify async job durability contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Architecture Decision Records (ADRs) live in `docs/adr/` and capture the context
 
 ### Inline async processing (no RQ worker)
 
-Jobs are processed with `asyncio.create_task()` inside the API process. This avoids needing a separate worker container. For production deployments with high throughput, restore the RQ queue and add a worker container.
+Jobs are processed with `asyncio.create_task()` inside the API process. Valkey persists job records, not execution: interrupted jobs are not resumed after restart, partial artifacts can remain, and undelivered webhooks are not replayed. `TaskTracker` provides only a short graceful-shutdown window. Restart-safe execution is deferred until it is an explicit product requirement; any future design must define ownership, leases, retries, cancellation, artifact consistency, and webhook idempotency in an ADR before selecting queue technology.
 
 ### Three-tier smart scraper
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ flowchart LR
     parse["parse-svc"] --> agent
 ```
 
-`agent-svc` owns the public `/v2` API, authorization, request IDs, health and metrics. It composes domain routers from `agent/routes/`, owns background tasks through `TaskTracker`, and stores durable job state in Valkey. Jobs are processed in-process with `asyncio.create_task()`; there is no RQ worker container.
+`agent-svc` owns the public `/v2` API, authorization, request IDs, health and metrics. It composes domain routers from `agent/routes/`, owns background tasks through `TaskTracker`, and stores persistent job records in Valkey. Jobs are processed in-process with `asyncio.create_task()`; there is no external job owner or worker queue.
 
 ## Main execution paths
 
@@ -35,6 +35,19 @@ flowchart TD
     client --> response["Response"]
     store --> response
 ```
+
+### Asynchronous job durability contract
+
+Valkey makes job metadata, status, and completed results persistent; it does not make execution restart-safe. `TaskTracker` gives in-flight work a five-second grace period during an orderly shutdown, then cancels remaining tasks. A crash, forced termination, or restart does not resume or reclaim interrupted jobs.
+
+After process loss:
+
+- A job record may remain `processing` until its TTL expires because no recovery pass changes its state.
+- A cancellation request can update persisted state, but there is no interrupted task to resume or durable execution lease to revoke.
+- Partial artifacts already written to Valkey, Qdrant, or another downstream system can remain; there is no transaction or rollback across those stores.
+- A completion or failure webhook that was not delivered before exit is not replayed automatically.
+
+Restart-safe execution is deliberately deferred. If operational evidence establishes it as a product requirement, a new ADR and implementation issue must define the durable owner, lease and reclaim rules, retry policy, cancellation semantics, artifact consistency, and idempotent webhook delivery before selecting queue technology. This boundary extends the best-effort decision in [ADR-0035](adr/0035-graceful-shutdown.md).
 
 Research code lives in `agent/research/`: it plans a query, discovers sources, scrapes them, synthesizes with the LLM, optionally detects gaps for another pass, and can stream progress and tokens. Research memory combines Valkey metadata with semantic lookup. Crawl uses a breadth-first engine with sitemap discovery, path filters, concurrency, cache controls, robots/politeness handling, canonical/content deduplication, and SSE progress.
 

--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -16,11 +16,13 @@ curl -X POST http://localhost:8080/v2/scrape \
 
 ## Jobs, streaming, and webhooks
 
-Scrape, map, search, answer, browser, and similar lightweight operations return directly. Crawl, extraction, batch scrape, and llms.txt generation create durable jobs: create the job, poll its status route, and cancel where a DELETE route is available. Job responses include IDs suitable for polling.
+Scrape, map, search, answer, browser, and similar lightweight operations return directly. Crawl, extraction, batch scrape, and llms.txt generation create persistent job records: create the job, poll its status route, and cancel where a DELETE route is available. Job responses include IDs suitable for polling.
+
+Persistent state is not restart-safe execution. Valkey preserves job status and completed results, but `agent-svc` executes work in-process. If that process exits before a job finishes, the job is not resumed or reclaimed automatically and may remain `processing` until its record expires. Cancellation can update the stored status, but it does not recover interrupted work. Partial writes to downstream stores are not rolled back, and completion or failure webhooks are not replayed after restart. Restart-safe execution is deferred until there is an explicit product requirement for a durable job owner, retry and lease semantics, cancellation behavior, artifact consistency, and idempotent webhook delivery.
 
 `POST /v2/agent` and `POST /v2/answer` support SSE when `stream: true`; agent events include planning, source discovery, scraping, tokens, and completion. Crawls stream through `GET /v2/crawl/{job_id}/stream`, including replay for completed jobs. Consume each SSE event as JSON and treat `done`/`error` as terminal.
 
-Every asynchronous creation request accepts webhook configuration. Completion and failure delivery is best effort; verify the endpoint’s OpenAPI model for the exact field shape and sign requests with `WEBHOOK_SECRET` where configured.
+Every asynchronous creation request accepts webhook configuration. Completion and failure delivery is best effort and is not persisted for retry after process loss; verify the endpoint’s OpenAPI model for the exact field shape and sign requests with `WEBHOOK_SECRET` where configured.
 
 ## Common workflows
 


### PR DESCRIPTION
## Summary

- distinguish persistent Valkey job records from restart-safe job execution
- document process-loss behavior for job status, cancellation, partial artifacts, and webhooks
- explicitly defer recovery machinery until its product requirements and semantics are defined

This corrects language that described asynchronous jobs as durable even though execution remains owned by the `agent-svc` process. It preserves the current best-effort design without prematurely selecting a queue or workflow runtime.

## Related Issue

Closes #458

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` — not applicable; no runtime code changed
- [ ] New tests added for the change — not applicable; documentation-only
- [x] Manual verification done: traced `TaskTracker`, app shutdown, `JobStore`, worker completion, cancellation routes, and webhook delivery against every documented claim; verified the ADR link resolves
- [x] `python3 scripts/check-docs-surface.py`
- [x] `python3 scripts/check-cli-coverage.py`
- [x] `git diff --check`
- [x] `gitleaks dir` on the changed files

## Checklist

- [ ] My code follows the project's coding conventions (type hints, async/await, minimal deps) — not applicable; no code changed
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works — not applicable; documentation-only
- [ ] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — not applicable; no API changes
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — not applicable; no endpoint added

## Notes for Reviewers

The change records restart-safe execution as deferred rather than prescribing RQ, Temporal, LangGraph, or another runtime. ADR-0035 already establishes the five-second best-effort shutdown contract; this PR documents its operational consequences without changing that accepted decision.

Independent technical review found no blockers. A consistency nit was fixed before commit.

I don't run continuously; responses may take 24–48 hours.

Authored by Jasper (AI agent on behalf of Magnus Hedemark).
