### PR TITLE
feat(agent): add portable research state projection

### DIFF
--- a/agent-svc/agent/research/state.py
+++ b/agent-svc/agent/research/state.py
@@ -1,0 +1,187 @@
+"""Pure, compact projection of normalized research events.
+
+The projection retains only facts present in the event contract. It excludes token,
+result, and evidence bodies and does not invent gap, budget, or artifact identifiers.
+"""
+
+from collections.abc import Mapping
+from typing import Any, TypedDict, cast
+
+from .events import ResearchEvent
+
+
+class CompactSource(TypedDict, total=False):
+    """Whitelisted source metadata; never scraped content."""
+
+    url: str
+    title: str
+    relevance: str
+    source: str
+    chars: int
+
+
+class ResearchPlanState(TypedDict):
+    """Planning facts emitted by a ``research_plan`` event."""
+
+    strategy: str
+    queries: list[str]
+    reasoning: str
+
+
+class ResearchState(TypedDict):
+    """Replayable execution facts projected from ``ResearchEvent`` values."""
+
+    objective: str
+    status: str | None
+    plan: ResearchPlanState | None
+    pass_number: int | None
+    total_passes: int | None
+    pending_sources: list[CompactSource]
+    source_metadata: list[CompactSource]
+    source_urls: list[str]
+    completed: bool
+    error: str | None
+
+
+def initial_research_state(objective: str) -> ResearchState:
+    """Create an empty projection for a research objective."""
+    return {
+        "objective": objective,
+        "status": None,
+        "plan": None,
+        "pass_number": None,
+        "total_passes": None,
+        "pending_sources": [],
+        "source_metadata": [],
+        "source_urls": [],
+        "completed": False,
+        "error": None,
+    }
+
+
+def apply_research_event(state: ResearchState, event: ResearchEvent) -> ResearchState:
+    """Return a new state after applying one event; never mutate ``state``."""
+    next_state: ResearchState = {
+        "objective": state["objective"],
+        "status": state["status"],
+        "plan": _copy_plan(state["plan"]),
+        "pass_number": state["pass_number"],
+        "total_passes": state["total_passes"],
+        "pending_sources": [
+            cast(CompactSource, dict(source)) for source in state["pending_sources"]
+        ],
+        "source_metadata": [
+            cast(CompactSource, dict(source)) for source in state["source_metadata"]
+        ],
+        "source_urls": list(state["source_urls"]),
+        "completed": state["completed"],
+        "error": state["error"],
+    }
+
+    event_type = event["type"]
+    if event_type == "status":
+        next_state["status"] = event.get("state")
+    elif event_type == "research_plan":
+        next_state["plan"] = {
+            "strategy": event.get("strategy", ""),
+            "queries": list(event.get("queries", [])),
+            "reasoning": event.get("reasoning", ""),
+        }
+    elif event_type == "research_pass":
+        next_state["pass_number"] = event.get("pass")
+        next_state["total_passes"] = event.get("total_passes")
+    elif event_type == "sources_pending":
+        next_state["pending_sources"] = _compact_sources(event.get("sources", []))
+    elif event_type == "source_scraped":
+        source = _compact_source(event)
+        pending: CompactSource = {}
+        source_url = source.get("url")
+        if source_url:
+            for index, item in enumerate(next_state["pending_sources"]):
+                if item.get("url") == source_url:
+                    pending = next_state["pending_sources"].pop(index)
+                    break
+        combined = cast(CompactSource, {**pending, **source})
+        next_state["source_metadata"] = _merge_sources(
+            next_state["source_metadata"], [combined]
+        )
+        _add_source_urls(next_state["source_urls"], [source])
+    elif event_type == "sources":
+        sources = event.get("sources", [])
+        _add_source_urls(next_state["source_urls"], _compact_sources(sources))
+        _add_url_values(next_state["source_urls"], sources)
+        next_state["pending_sources"] = []
+    elif event_type == "done":
+        source_details = _compact_sources(event.get("source_details", []))
+        next_state["source_metadata"] = _merge_sources(
+            next_state["source_metadata"], source_details
+        )
+        _add_source_urls(next_state["source_urls"], source_details)
+        _add_url_values(next_state["source_urls"], event.get("sources", []))
+        next_state["pending_sources"] = []
+        next_state["status"] = "completed"
+        next_state["completed"] = True
+        next_state["error"] = None
+    elif event_type == "error":
+        next_state["status"] = "failed"
+        next_state["completed"] = False
+        next_state["error"] = event.get("content", "")
+
+    return next_state
+
+
+def _copy_plan(plan: ResearchPlanState | None) -> ResearchPlanState | None:
+    if plan is None:
+        return None
+    return {
+        "strategy": plan["strategy"],
+        "queries": list(plan["queries"]),
+        "reasoning": plan["reasoning"],
+    }
+
+
+def _compact_sources(sources: list[Any]) -> list[CompactSource]:
+    return [
+        compact
+        for source in sources
+        if isinstance(source, Mapping) and (compact := _compact_source(source))
+    ]
+
+
+def _compact_source(source: Mapping[str, Any]) -> CompactSource:
+    compact = {
+        field: source[field]
+        for field in ("url", "title", "relevance", "source", "chars")
+        if field in source
+    }
+    if "char_count" in source:
+        compact["chars"] = source["char_count"]
+    return cast(CompactSource, compact)
+
+
+def _merge_sources(
+    existing: list[CompactSource], additions: list[CompactSource]
+) -> list[CompactSource]:
+    merged: list[CompactSource] = [
+        cast(CompactSource, dict(source)) for source in existing
+    ]
+    for source in additions:
+        if not source:
+            continue
+        url = source.get("url")
+        match = next((item for item in merged if url and item.get("url") == url), None)
+        if match is None:
+            merged.append(cast(CompactSource, dict(source)))
+        else:
+            match.update(source)
+    return merged
+
+
+def _add_source_urls(urls: list[str], sources: list[CompactSource]) -> None:
+    _add_url_values(urls, [source.get("url") for source in sources])
+
+
+def _add_url_values(urls: list[str], values: list[Any]) -> None:
+    for value in values:
+        if isinstance(value, str) and value and value not in urls:
+            urls.append(value)

--- a/tests/service/test_research_state.py
+++ b/tests/service/test_research_state.py
@@ -1,0 +1,103 @@
+"""Tests for the compact research-event state projection."""
+
+from agent.research.events import ResearchEvent
+from agent.research.state import apply_research_event, initial_research_state
+
+
+def test_research_events_build_compact_immutable_state() -> None:
+    initial = initial_research_state("Compare renewable-energy storage options")
+    state = initial
+    events: list[ResearchEvent] = [
+        {"type": "status", "state": "planning"},
+        {
+            "type": "research_plan",
+            "strategy": "compare primary sources",
+            "queries": ["battery storage", "pumped hydro"],
+            "reasoning": "cover leading approaches",
+        },
+        {"type": "research_pass", "pass": 1, "total_passes": 2},
+        {
+            "type": "sources_pending",
+            "sources": [
+                {
+                    "url": "https://example.com/batteries",
+                    "title": "Battery report",
+                    "relevance": "cost data",
+                    "body": "must not persist",
+                }
+            ],
+        },
+        {
+            "type": "source_scraped",
+            "url": "https://example.com/batteries",
+            "source": "web",
+            "chars": 2400,
+            "content": "must not persist",
+        },
+        {"type": "sources", "sources": ["https://example.com/hydro"]},
+        {
+            "type": "token",
+            "content": "streamed answer text must not persist",
+        },
+        {
+            "type": "done",
+            "result": "final answer text must not persist",
+            "sources": ["https://example.com/batteries"],
+            "source_details": [
+                {
+                    "url": "https://example.com/hydro",
+                    "title": "Hydro report",
+                    "source": "web",
+                    "char_count": 1800,
+                    "markdown": "evidence body must not persist",
+                }
+            ],
+            "latency_ms": 42,
+        },
+    ]
+
+    for event in events[:5]:
+        state = apply_research_event(state, event)
+
+    assert state["pending_sources"] == []
+
+    for event in events[5:]:
+        state = apply_research_event(state, event)
+
+    assert initial == initial_research_state("Compare renewable-energy storage options")
+    assert state == {
+        "objective": "Compare renewable-energy storage options",
+        "status": "completed",
+        "plan": {
+            "strategy": "compare primary sources",
+            "queries": ["battery storage", "pumped hydro"],
+            "reasoning": "cover leading approaches",
+        },
+        "pass_number": 1,
+        "total_passes": 2,
+        "pending_sources": [],
+        "source_metadata": [
+            {
+                "url": "https://example.com/batteries",
+                "title": "Battery report",
+                "relevance": "cost data",
+                "source": "web",
+                "chars": 2400,
+            },
+            {
+                "url": "https://example.com/hydro",
+                "title": "Hydro report",
+                "source": "web",
+                "chars": 1800,
+            },
+        ],
+        "source_urls": [
+            "https://example.com/batteries",
+            "https://example.com/hydro",
+        ],
+        "completed": True,
+        "error": None,
+    }
+    assert "streamed answer text must not persist" not in repr(state)
+    assert "final answer text must not persist" not in repr(state)
+    assert "evidence body must not persist" not in repr(state)


### PR DESCRIPTION
## Summary

- add a documented, stdlib-only `ResearchState` shape for compact replayable execution facts
- add a pure reducer from normalized `ResearchEvent` values to new state values
- retain objective, status, plan, pass counters, compact source metadata, source URLs, completion, and errors
- deliberately exclude token text, final result bodies, scraped evidence, and unavailable gap/budget/artifact identifiers
- add one deterministic replay test covering planning through completion and immutability

## Related Issue

Closes #460

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [x] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` — passed in PR CI
- [x] New tests added for the change
- [x] Manual verification done (describe)

Focused verification:

```text
PYTHONPATH=.:agent-svc uv run --frozen pytest -q -o addopts='' \
  tests/service/test_research_state.py \
  tests/service/test_research_adapter_parity.py \
  tests/service/test_research_streaming.py \
  tests/integration/test_research.py
```

Result: 52 passed. One existing `AsyncMock` RuntimeWarning was reproduced unchanged on `origin/main` during #459 validation.

The copied projection test fails on `origin/main` because the state module does not exist, confirming the red baseline gate. Focused Ruff and mypy checks pass. Gitleaks reports no leaks.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — not applicable; the new state shape is documented in code and changes no user-facing contract
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — not applicable; no endpoint added
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — not applicable; no endpoint added

## Notes for Reviewers

The reducer projects only facts carried by the normalized event contract established in #457. It does not synthesize gap counts, budget use, or durable artifact identifiers because current events do not carry those facts. That preserves honesty and portability while leaving those fields available for a future event-contract change if they become real.

Full result text, streamed tokens, scraped markdown, and arbitrary source fields are excluded. Source metadata is whitelisted and deduplicated by URL. A Droid review finding was fixed on the final commit: `source_scraped` now removes the matched source from `pending_sources` immediately, with an intermediate-state assertion. The reducer copies every nested mutable collection it retains, so replay does not mutate prior states.

Test-quality scorecard: 7/8. The focused test checks the replay invariant, multiple state concepts, exact final shape, input immutability, and body exclusion with no private access, mocks, mock assertions, or conditional assertions. A separate error-path test is outside this issue's single deterministic completion-sequence acceptance criterion.

No ADR is needed. This is an isolated projection module with no runtime integration, persistence, checkpoint store, graph dependency, API change, or SSE change.

AI disclosure: Implemented and reviewed by Jasper via Hermes Agent on behalf of Magnus Hedemark. OpenCode assisted with the initial implementation pass; Jasper corrected terminal status semantics, source deduplication, CI test placement, typing, and final validation.

I do not run continuously. Maintainer feedback will be handled in a later session, typically within 24–48 hours.
