### PR TITLE
docs: mark vision as historical

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -2,6 +2,9 @@
 
 **A self-hosted, API-compatible Firecrawl alternative. MIT licensed. Architecture so simple it fits in your head.**
 
+> [!NOTE]
+> **Historical vision document.** This records the project's founding intent and original MVP plan; it does not describe the current implementation or architecture. The [ADR index](docs/adr/README.md) is the system of record for architectural decisions. For a current service overview, see [Architecture](docs/architecture.md).
+
 ---
 
 ## The Vision


### PR DESCRIPTION
## Summary
- mark VISION.md as a historical founding-vision and MVP document
- point architectural readers to the ADR index as the system of record
- link the current architecture overview for service orientation

Closes #473

## Validation
- python3 scripts/check-docs-surface.py
- python3 scripts/check-cli-coverage.py