### PR TITLE
fix(semantic): require Qdrant for readiness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,9 @@ services:
       - ACTIVE_EMBED_MODEL=${ACTIVE_EMBED_MODEL:-v_bge-m3}
     volumes:
       - hf-cache:/root/.cache/huggingface
+    depends_on:
+      qdrant:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import json, urllib.request; response = urllib.request.urlopen('http://localhost:8003/health', timeout=5); assert json.load(response)['status'] == 'ok'"]
       interval: 10s
@@ -144,6 +147,20 @@ services:
       - qdrant_data:/qdrant/storage
     environment:
       - MALLOC_CONF=retain:false
+    healthcheck:
+      # The image provides bash but not curl/wget. Probe Qdrant's live readiness endpoint.
+      test:
+        - CMD
+        - bash
+        - -c
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/6333 &&
+          printf 'GET /readyz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+          IFS= read -r status <&3 &&
+          [[ "$${status}" == *200* ]]
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
   agent-svc:
     build:

--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -25,6 +25,7 @@ Phase 4 endpoints (this file):
 """
 
 import asyncio
+import contextlib
 import datetime
 import hashlib
 import logging
@@ -243,6 +244,23 @@ def _url_hash(url: str) -> int:
     return int(h[:16], 16)
 
 
+def _is_qdrant_ready() -> bool:
+    """Return whether Qdrant is reachable without initializing the collection."""
+    client = _qdrant
+    temporary_client = client is None
+    if temporary_client:
+        client = QdrantClient(url=QDRANT_URL, timeout=5)
+    try:
+        client.get_collections()
+    except Exception:
+        return False
+    finally:
+        if temporary_client:
+            with contextlib.suppress(Exception):
+                client.close()
+    return True
+
+
 def _named_vector_name(model_name: str) -> str:
     """Short name for a named vector (e.g., 'BAAI/bge-m3' -> 'v_bge-m3')."""
     short = model_name.split("/")[-1].lower()
@@ -338,7 +356,7 @@ async def _ensure_qdrant() -> QdrantClient:
             _qdrant_ready = True
         except Exception as e:
             logger.error("Qdrant init failed: %s", e)
-            raise HTTPException(503, "Vector index unavailable")  # noqa: B904
+            raise HTTPException(503, "Vector index unavailable")
     return _qdrant
 
 
@@ -375,9 +393,15 @@ async def metrics_middleware(request: Request, call_next):
 
 @app.get("/health")
 async def health():
+    if not _models_ready:
+        return {"status": "starting", "models": "loading"}
+
+    loop = asyncio.get_running_loop()
+    qdrant_ready = await loop.run_in_executor(None, _is_qdrant_ready)
     return {
-        "status": "ok" if _models_ready else "starting",
-        "models": "loaded" if _models_ready else "loading",
+        "status": "ok" if qdrant_ready else "starting",
+        "models": "loaded",
+        "qdrant": "ready" if qdrant_ready else "unavailable",
     }
 
 

--- a/tests/service/test_resource_envelope_contract.py
+++ b/tests/service/test_resource_envelope_contract.py
@@ -36,6 +36,13 @@ def test_constrained_host_compose_contract():
     assert {"semantic-svc", "qdrant"}.isdisjoint(default_services)
     assert {"semantic-svc", "qdrant"}.issubset(indexing_services)
 
+    semantic_dependencies = compose["services"]["semantic-svc"]["depends_on"]
+    assert semantic_dependencies["qdrant"]["condition"] == "service_healthy"
+    qdrant_healthcheck = compose["services"]["qdrant"]["healthcheck"]["test"]
+    assert qdrant_healthcheck[:3] == ["CMD", "bash", "-c"]
+    assert "/readyz" in qdrant_healthcheck[-1]
+    assert "$${status}" in qdrant_healthcheck[-1]
+
     agent_dependencies = compose["services"]["agent-svc"].get("depends_on", {})
     assert "semantic-svc" not in agent_dependencies
 

--- a/tests/unit/test_semantic_svc_unit.py
+++ b/tests/unit/test_semantic_svc_unit.py
@@ -88,6 +88,62 @@ def _import_build_payload():
 _build_index_payload = _import_build_payload()
 
 
+# ── Tests: health readiness ─────────────────────────────────────────
+
+
+class TestHealthReadiness:
+    """Semantic readiness requires both models and Qdrant."""
+
+    @pytest.mark.asyncio
+    async def test_health_is_ok_when_models_and_qdrant_are_ready(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import app
+
+        qdrant = MagicMock()
+        monkeypatch.setattr(app, "_models_ready", True)
+        monkeypatch.setattr(app, "_qdrant", qdrant)
+
+        response = await app.health()
+
+        assert response == {"status": "ok", "models": "loaded", "qdrant": "ready"}
+        qdrant.get_collections.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_health_is_not_ok_when_qdrant_is_unavailable(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import app
+
+        qdrant = MagicMock()
+        qdrant.get_collections.side_effect = ConnectionError("Connection refused")
+        monkeypatch.setattr(app, "_models_ready", True)
+        monkeypatch.setattr(app, "_qdrant", qdrant)
+
+        response = await app.health()
+
+        assert response == {
+            "status": "starting",
+            "models": "loaded",
+            "qdrant": "unavailable",
+        }
+
+    def test_temporary_qdrant_readiness_client_is_closed(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        import app
+
+        temporary_client = MagicMock()
+        monkeypatch.setattr(app, "_qdrant", None)
+        monkeypatch.setattr(
+            app, "QdrantClient", MagicMock(return_value=temporary_client)
+        )
+
+        assert app._is_qdrant_ready() is True
+        temporary_client.get_collections.assert_called_once_with()
+        temporary_client.close.assert_called_once_with()
+
+
 # ── Tests: _url_hash ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Make semantic readiness reflect its required Qdrant dependency.

- add a Qdrant initialization health check and require it before Compose starts `semantic-svc`;
- return a non-ready semantic health status while Qdrant cannot be reached, even if both models are loaded;
- add focused unit and Compose-contract regression coverage.

## Related Issue

Closes #484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds a feature)
- [ ] ⚠️ Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactor
- [x] 🧪 Test
- [x] ⚡ CI/DevOps

## Test Plan

- [ ] Integration tests pass: requires the full Compose stack, unavailable on the local macOS host
- [x] New tests added for loaded-model/Qdrant-unavailable readiness and Compose dependency contracts
- [x] Manual verification done: restored the stopped services on the deployment host, waited for Qdrant readiness, and verified the public health and embedding endpoints. The probe returned one 1024-dimensional vector.

Local checks:

- `PYTHONPATH=semantic-svc:. uv run --project semantic-svc --with pytest --with pytest-asyncio --with pyyaml pytest -o addopts='' tests/unit/test_semantic_svc_unit.py tests/service/test_resource_envelope_contract.py -q` → 88 passed
- `git diff --check` → passed
- Focused Ruff reported one pre-existing `RUF100` in unchanged code; no findings on changed lines.
- `docker compose config --quiet` could not run locally because Docker is not installed. CI is the complete Compose validation gate.

## Checklist

- [x] Code follows existing conventions and adds no dependencies
- [x] Tests prove the fix
- [x] No new endpoint or CLI surface
- [x] No new async endpoint

## Notes for Reviewers

Qdrant’s image provides Bash but not `curl` or `wget`; the Compose health check issues a bounded HTTP request to its live `/readyz` endpoint through Bash’s TCP socket support. Semantic health performs its Qdrant probe in an executor to avoid blocking the event loop.

AI assistance was used for investigation, implementation, tests, and drafting this pull request.
