### PR TITLE
fix(semantic): narrow Qdrant readiness client type

### DIFF
--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -250,6 +250,7 @@ def _is_qdrant_ready() -> bool:
     temporary_client = client is None
     if temporary_client:
         client = QdrantClient(url=QDRANT_URL, timeout=5)
+    assert client is not None
     try:
         client.get_collections()
     except Exception:


### PR DESCRIPTION
## Summary

Restore the Python Checks gate after #485 by narrowing the temporary Qdrant readiness client before it is used or closed. This preserves the resource-cleanup behavior added by #485.

Closes #486

## Verification

- `PYTHONPATH=semantic-svc:. uv run --project semantic-svc --with pytest --with pytest-asyncio --with pyyaml pytest -o addopts='' tests/unit/test_semantic_svc_unit.py tests/service/test_resource_envelope_contract.py -q` → 89 passed
- `PYTHONPATH=agent-svc:scraper-svc:llm-svc:parse-svc:portal-svc:browser-svc:. uv run --with mypy mypy semantic-svc` → Success: no issues found in 8 source files

AI assistance was used for investigation, implementation, and verification.
