### PR TITLE
fix(metrics): omit invalid OpenMetrics timestamps

### DIFF
--- a/common/metrics.py
+++ b/common/metrics.py
@@ -186,7 +186,6 @@ class MetricsCollector:
 
     def generate_openmetrics(self) -> str:
         lines: list[str] = []
-        now_ms = int(time.time() * 1000)
 
         with self._lock:
             for family, counter in self._counters.values():
@@ -194,20 +193,20 @@ class MetricsCollector:
                 lines.append(f"# TYPE {family.name} counter")
                 for key, val in counter._collect():
                     label_str = _format_labels(key)
-                    lines.append(f"{family.name}{label_str} {val} {now_ms}")
+                    lines.append(f"{family.name}{label_str} {val}")
 
             for family, histogram in self._histograms.values():
                 lines.append(f"# HELP {family.name} {family.help}")
                 lines.append(f"# TYPE {family.name} histogram")
                 for key, sum_val, count, bucket_map in histogram._collect():
                     label_str = _format_labels(key)
-                    lines.append(f"{family.name}_sum{label_str} {sum_val} {now_ms}")
-                    lines.append(f"{family.name}_count{label_str} {count} {now_ms}")
+                    lines.append(f"{family.name}_sum{label_str} {sum_val}")
+                    lines.append(f"{family.name}_count{label_str} {count}")
                     for b, bcount in bucket_map.items():
                         ble = _format_labels(key, {"le": str(b)})
-                        lines.append(f"{family.name}_bucket{ble} {bcount} {now_ms}")
+                        lines.append(f"{family.name}_bucket{ble} {bcount}")
                     lines.append(
-                        f"{family.name}_bucket{_format_labels(key, {'le': '+Inf'})} {count} {now_ms}"
+                        f"{family.name}_bucket{_format_labels(key, {'le': '+Inf'})} {count}"
                     )
 
             for family, gauge in self._gauges.values():
@@ -215,7 +214,7 @@ class MetricsCollector:
                 lines.append(f"# TYPE {family.name} gauge")
                 for key, val in gauge._collect():
                     label_str = _format_labels(key)
-                    lines.append(f"{family.name}{label_str} {val} {now_ms}")
+                    lines.append(f"{family.name}{label_str} {val}")
 
         lines.append("# EOF")
         return "\n".join(lines) + "\n"

--- a/tests/service/test_analytics.py
+++ b/tests/service/test_analytics.py
@@ -174,7 +174,7 @@ class TestLogErrorsTotal:
         initial_count = 0
         for line in initial_lines:
             if 'log_errors_total{service="test_svc"}' in line:
-                initial_count = float(line.split()[-2])
+                initial_count = float(line.split()[-1])
 
         # Log an ERROR
         logger.error("This is a test error")
@@ -184,7 +184,7 @@ class TestLogErrorsTotal:
         new_count = 0
         for line in new_lines:
             if 'log_errors_total{service="test_svc"}' in line:
-                new_count = float(line.split()[-2])
+                new_count = float(line.split()[-1])
 
         assert new_count >= initial_count + 1, (
             f"Expected counter >= {initial_count + 1}, got {new_count}"
@@ -220,7 +220,7 @@ class TestLogErrorsTotal:
         initial_count = 0
         for line in initial_lines:
             if 'log_errors_total{service="test_noinc"}' in line:
-                initial_count = float(line.split()[-2])
+                initial_count = float(line.split()[-1])
 
         # Log at non-ERROR levels
         logger.warning("Warning message")
@@ -232,7 +232,7 @@ class TestLogErrorsTotal:
         new_count = 0
         for line in new_lines:
             if 'log_errors_total{service="test_noinc"}' in line:
-                new_count = float(line.split()[-2])
+                new_count = float(line.split()[-1])
 
         assert new_count == initial_count, (
             f"Expected count unchanged ({initial_count}), got {new_count}"
@@ -276,7 +276,7 @@ class TestFeatureToggleObservability:
             metrics_text = METRICS.generate_openmetrics()
             for line in metrics_text.split("\n"):
                 if 'groktocrawl_feature_enabled{feature="myfeature"}' in line:
-                    val = float(line.split()[-2])
+                    val = float(line.split()[-1])
                     assert val == 1.0, f"Expected 1.0, got {val}"
                     return
             pytest.fail("Expected groktocrawl_feature_enabled for myfeature")
@@ -298,7 +298,7 @@ class TestFeatureToggleObservability:
             metrics_text = METRICS.generate_openmetrics()
             for line in metrics_text.split("\n"):
                 if 'groktocrawl_feature_enabled{feature="offfeature"}' in line:
-                    val = float(line.split()[-2])
+                    val = float(line.split()[-1])
                     assert val == 0.0, f"Expected 0.0, got {val}"
                     return
             pytest.fail("Expected groktocrawl_feature_enabled for offreature")
@@ -365,7 +365,7 @@ class TestAnalyticsCounterPrometheusExport:
         metrics_text = METRICS.generate_openmetrics()
         for line in metrics_text.split("\n"):
             if f"groktocrawl_analytics_{name}" in line and not line.startswith("#"):
-                val = float(line.split()[-2])
+                val = float(line.split()[-1])
                 assert val == 7.0, f"Expected 7.0, got {val}"
                 return
         pytest.fail(f"Expected groktocrawl_analytics_{name} in metrics output")
@@ -385,6 +385,6 @@ class TestAnalyticsCounterPrometheusExport:
 
         for line in metrics_text.split("\n"):
             if "groktocrawl_analytics_reqs" in line and not line.startswith("#"):
-                assert float(line.split()[-2]) == 10.0
+                assert float(line.split()[-1]) == 10.0
             if "groktocrawl_analytics_errors" in line and not line.startswith("#"):
-                assert float(line.split()[-2]) == 3.0
+                assert float(line.split()[-1]) == 3.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,21 @@
+"""Tests for the shared OpenMetrics exporter."""
+
+from common.metrics import MetricsCollector
+
+
+def test_openmetrics_samples_omit_timestamps_and_end_with_eof() -> None:
+    collector = MetricsCollector()
+    collector.counter("requests_total", "Requests").inc(value=2)
+    collector.histogram("latency_seconds", "Latency", buckets=[1.0]).observe(value=0.5)
+    collector.gauge("workers", "Workers").set(value=3)
+
+    output = collector.generate_openmetrics()
+    sample_lines = [
+        line for line in output.splitlines() if line and not line.startswith("#")
+    ]
+
+    assert any(line.startswith("requests_total ") for line in sample_lines)
+    assert any(line.startswith("latency_seconds_bucket") for line in sample_lines)
+    assert any(line.startswith("workers ") for line in sample_lines)
+    assert all(len(line.split()) == 2 for line in sample_lines)
+    assert output.rstrip().endswith("# EOF")


### PR DESCRIPTION
## Summary

Removes explicit Unix-millisecond timestamps from the shared in-memory OpenMetrics exporter. Prometheus now assigns scrape timestamps instead of rejecting every exporter-provided timestamp as out of bounds.

## Related Issue

Closes #488

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` — not run locally because this macOS host intentionally has no Docker.
- [x] New tests added for the change — regression coverage exercises counter, histogram, and gauge output with two-field samples and `# EOF`.
- [x] Manual verification done (describe) — `python3 -m pytest -o addopts='' tests/unit/test_metrics.py tests/service/test_analytics.py` returned 19 passed; generated exposition has two fields on every non-comment sample.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — not needed; no public API or configuration behavior changed
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — not applicable; no endpoint was added
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — not applicable; no endpoint was added

## Notes for Reviewers

The exporter renders current in-memory values at scrape time, so omitting explicit timestamps avoids exporter-clock coupling and follows Prometheus scrape-time semantics.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
