### PR TITLE
test(metrics): cover semantic OpenMetrics renderer

### DIFF
--- a/tests/unit/test_semantic_metrics.py
+++ b/tests/unit/test_semantic_metrics.py
@@ -1,0 +1,54 @@
+"""Tests for the semantic-svc OpenMetrics renderer."""
+
+import importlib.util
+import re
+from pathlib import Path
+
+
+def _load_semantic_metrics():
+    """Load semantic-svc's metrics module without colliding with common.metrics."""
+    path = Path(__file__).parents[2] / "semantic-svc" / "metrics.py"
+    spec = importlib.util.spec_from_file_location("semantic_svc_metrics", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openmetrics_samples_omit_timestamps_and_end_with_eof() -> None:
+    metrics = _load_semantic_metrics()
+    collector = metrics.MetricsCollector()
+    collector.counter("requests_total", "Requests", ["endpoint"]).inc(
+        {"endpoint": "semantic api"}, value=2
+    )
+    collector.histogram(
+        "latency_seconds", "Latency", ["operation"], buckets=[1.0]
+    ).observe({"operation": "vector search"}, 0.5)
+    collector.gauge("workers", "Workers", ["pool"]).set(
+        {"pool": "background workers"}, value=3
+    )
+
+    output = collector.generate_openmetrics()
+    sample_lines = [
+        line for line in output.splitlines() if line and not line.startswith("#")
+    ]
+
+    assert any(
+        line.startswith('requests_total{endpoint="semantic api"} ')
+        for line in sample_lines
+    )
+    assert any(
+        line.startswith('latency_seconds_bucket{operation="vector search",le="1.0"} ')
+        for line in sample_lines
+    )
+    assert any(
+        line.startswith('workers{pool="background workers"} ') for line in sample_lines
+    )
+
+    sample_line_pattern = re.compile(
+        r'^[a-zA-Z_:][a-zA-Z0-9_:]*(?:\{[a-zA-Z_][a-zA-Z0-9_]*="(?:\\.|[^"\\])*"'
+        r'(?:,[a-zA-Z_][a-zA-Z0-9_]*="(?:\\.|[^"\\])*")*\})? [^\s]+$'
+    )
+    assert all(sample_line_pattern.fullmatch(line) for line in sample_lines)
+    assert output.rstrip().endswith("# EOF")


### PR DESCRIPTION
## Summary

Adds renderer-level OpenMetrics wire-format regression coverage for the independent `semantic-svc` metrics implementation. The test exercises labelled counter, histogram, and gauge samples, permits valid whitespace inside quoted labels, rejects an explicit third timestamp field, and verifies `# EOF`.

Authored by Jasper (AI agent on behalf of Magnus Hedemark)

## Related Issue

Closes #490.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` — not run locally because this macOS host intentionally has no Docker; CI runs the repository integration suite.
- [x] New tests added for the change — `python3 -m pytest -o addopts='' tests/unit/test_metrics.py tests/unit/test_semantic_metrics.py` passed (2 passed).
- [x] Manual verification done (describe) — Ruff check and format checks passed for both focused test files.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — not needed for internal regression coverage.
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — no API endpoints changed.
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — no endpoint changed.

## Notes for Reviewers

The shared renderer is already covered by the test introduced in #489. This minimal PR covers the independent semantic renderer only, with no production, configuration, dependency, or deployment changes.
