### PR TITLE
ci(review): use DeepSeek V4 Flash for droid auto review

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -47,11 +47,37 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      # BYOM review model: droid exec resolves "custom:" model references from
+      # ~/.factory/settings.json on the runner. The API key is exported via
+      # GITHUB_ENV and referenced as ${DEEPSEEK_API_KEY} so the raw key never
+      # lands in the settings file (the action uploads ~/.factory/** as a debug
+      # artifact). Add the DEEPSEEK_API_KEY secret in the repo/org settings.
+      - name: Configure BYOM review model
+        shell: bash
+        run: |
+          echo "DEEPSEEK_API_KEY=${{ secrets.DEEPSEEK_API_KEY }}" >> "$GITHUB_ENV"
+          mkdir -p "$HOME/.factory"
+          cat > "$HOME/.factory/settings.json" <<'EOF'
+          {
+            "customModels": [
+              {
+                "model": "deepseek-v4-flash",
+                "displayName": "DeepSeek V4 Flash",
+                "baseUrl": "https://api.deepseek.com/v1",
+                "apiKey": "${DEEPSEEK_API_KEY}",
+                "provider": "generic-chat-completion-api",
+                "noImageSupport": true
+              }
+            ]
+          }
+          EOF
       - name: Run Droid Auto Review
         uses: Factory-AI/droid-action@7c7bfea2aa3bb7ea87579402cc1d89dbcf6b13b3
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           review_depth: ${{ needs.assess-depth.outputs.depth }}
+          review_model: custom:DeepSeek-V4-Flash-0
+          security_model: custom:DeepSeek-V4-Flash-0
           automatic_security_review: ${{ needs.assess-depth.outputs.security }}
           allowed_bots: "dependabot[bot]"


### PR DESCRIPTION
## What & why

The previous droid-review.yml change (BYOM review model) existed only as uncommitted working-tree edits and was never committed or pushed, so it never landed. This PR ships it, using **deepseek-v4-flash** for both regular and security reviews.

## Change

- Adds a `Configure BYOM review model` step that writes `~/.factory/settings.json` on the runner with the DeepSeek custom model:
  - model `deepseek-v4-flash`, baseUrl `https://api.deepseek.com/v1`, `generic-chat-completion-api` provider
  - API key comes from `DEEPSEEK_API_KEY` via `GITHUB_ENV` (`${DEEPSEEK_API_KEY}` reference), so the raw key never lands in the settings file (the action uploads `~/.factory/**` as a debug artifact)
- Passes `review_model: custom:DeepSeek-V4-Flash-0` and `security_model: custom:DeepSeek-V4-Flash-0` to the droid action
- No other workflow behavior changes (triggers, depth assessment, security review gating, dependabot skip)

## Prerequisite

**`DEEPSEEK_API_KEY` must exist as a repo or org secret.** Currently the repo has only `HF_TOKEN`; without the new secret the step writes an empty key and droid exec fails fast ("apiKey can't be empty").

## Validation

- YAML parses cleanly (checked with PyYAML)
- Pre-commit hooks (trailing-whitespace, check-yaml, gitleaks, etc.) all pass
- `custom:` reference format matches Factory BYOK docs (displayName with dashes + array index)