### PR TITLE
ci: skip Docker integration for docs-only pull requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@
 # Tags:
 #   - main branch → latest, unstable
 #   - vX.Y.Z tag  → stable, X, X.Y, X.Y.Z
-#   - PR to main  → build-only (no push)
+#   - PR to main  → runtime integration only when changed paths require it
 
 name: Docker Build & Publish
 
@@ -22,8 +22,44 @@ env:
   REGISTRY_OWNER: groktopus
 
 jobs:
+  changes:
+    name: Classify runtime changes
+    runs-on: ubuntu-latest
+    outputs:
+      requires_full_runtime: ${{ steps.classify.outputs.requires_full_runtime }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Test change classifier
+        run: python3 tests/service/test_ci_change_classification.py
+
+      - name: Classify changed paths
+        id: classify
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+            merge_base=$(git merge-base "$base" "$head")
+            changed_paths=$(git diff --name-only "$merge_base" "$head")
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.sha }}"
+            if [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              changed_paths=$(git diff-tree --no-commit-id --name-only -r "$head")
+            else
+              changed_paths=$(git diff --name-only "$base" "$head")
+            fi
+          fi
+
+          requires_full_runtime=$(printf '%s\n' "$changed_paths" | python3 scripts/classify_ci_changes.py)
+          echo "requires_full_runtime=$requires_full_runtime" >> "$GITHUB_OUTPUT"
+
   build-and-push:
     name: ${{ matrix.service }}
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -119,7 +155,11 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    needs: build-and-push
+    needs: [changes, build-and-push]
+    if: >-
+      always() && ((github.event_name == 'pull_request' && needs.changes.result == 'success' &&
+      needs.changes.outputs.requires_full_runtime == 'true') ||
+      (github.event_name == 'push' && needs.build-and-push.result == 'success'))
     runs-on: [self-hosted, groktopus, docker]
     concurrency:
       group: groktocrawl-integration-${{ github.repository }}
@@ -262,6 +302,10 @@ jobs:
           docker compose exec -T agent-svc mkdir -p /app/tests
           docker cp tests/. "$svc":/app/tests/
           docker cp docker-compose.yml "$svc":/app/docker-compose.yml
+          docker compose exec -T agent-svc mkdir -p /app/scripts
+          docker cp scripts/classify_ci_changes.py "$svc":/app/scripts/classify_ci_changes.py
+          docker compose exec -T agent-svc mkdir -p /app/.github/workflows
+          docker cp .github/workflows/docker.yml "$svc":/app/.github/workflows/docker.yml
           # Copy service source packages so tests can import them
           # Each package_dir (e.g. scraper-svc/scraper) becomes /app/<package_dir>/
           for pkg in agent-svc/agent scraper-svc/scraper parse-svc/parse_svc portal-svc/portal browser-svc/browser_svc llm-svc/llm_svc; do
@@ -348,3 +392,40 @@ jobs:
       - name: Tear down stack
         if: always()
         run: docker compose down --remove-orphans --timeout 30
+
+  runtime-gate:
+    name: Runtime Gate
+    needs: [changes, integration-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize docs-only pull request
+        if: >-
+          github.event_name == 'pull_request' && needs.changes.result == 'success' &&
+          needs.changes.outputs.requires_full_runtime == 'false'
+        run: echo "Runtime integration was intentionally not needed for this docs-only pull request."
+
+      - name: Summarize successful runtime validation
+        if: >-
+          github.event_name == 'pull_request' && needs.changes.result == 'success' &&
+          needs.changes.outputs.requires_full_runtime == 'true' &&
+          needs.integration-tests.result == 'success'
+        run: echo "Runtime integration completed successfully for this pull request."
+
+      - name: Fail when change classification fails
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.changes.result != 'success'
+        run: |
+          echo "Change classification did not complete; no runtime-validation conclusion was made."
+          exit 1
+
+      - name: Fail when required runtime validation fails
+        if: >-
+          needs.changes.result == 'success' &&
+          !(github.event_name == 'pull_request' &&
+          needs.changes.outputs.requires_full_runtime == 'false') &&
+          needs.integration-tests.result != 'success'
+        run: |
+          echo "Required runtime integration did not complete successfully."
+          exit 1

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Classify changed paths for CI runtime validation.
+
+Pass paths as positional arguments, or provide one path per line on stdin when
+no arguments are supplied. The command prints ``true`` when full runtime
+validation is required and ``false`` only for a non-empty docs-only change.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+
+DOCS_ONLY_FILES = frozenset({"README.md", "AGENTS.md", "CONTRIBUTING.md"})
+DOCS_ONLY_PREFIXES = ("docs/", ".github/ISSUE_TEMPLATE/")
+
+
+def requires_full_runtime(paths: Iterable[str]) -> bool:
+    """Return whether changed paths require the Docker integration runtime."""
+    path_list = list(paths)
+    if not path_list:
+        return True
+
+    return any(
+        path not in DOCS_ONLY_FILES and not path.startswith(DOCS_ONLY_PREFIXES)
+        for path in path_list
+    )
+
+
+def main(argv: list[str]) -> int:
+    paths = argv or sys.stdin.read().splitlines()
+    print(str(requires_full_runtime(paths)).lower())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -1,0 +1,231 @@
+"""Contract tests for the conservative CI runtime classifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CLASSIFIER = ROOT / "scripts" / "classify_ci_changes.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "docker.yml"
+SPEC = importlib.util.spec_from_file_location("classify_ci_changes", CLASSIFIER)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class CiChangeClassificationTests(unittest.TestCase):
+    def test_docs_only_changes_do_not_require_runtime(self) -> None:
+        self.assertFalse(MODULE.requires_full_runtime(["docs/guides/ci.md"]))
+
+    def test_repository_prose_only_changes_do_not_require_runtime(self) -> None:
+        self.assertFalse(
+            MODULE.requires_full_runtime(
+                [
+                    "README.md",
+                    "AGENTS.md",
+                    "CONTRIBUTING.md",
+                    ".github/ISSUE_TEMPLATE/bug.yml",
+                    "docs/adr/README.md",
+                ]
+            )
+        )
+
+    def test_docs_plus_source_requires_runtime(self) -> None:
+        self.assertTrue(
+            MODULE.requires_full_runtime(
+                ["docs/guides/ci.md", "agent-svc/agent/app.py"]
+            )
+        )
+
+    def test_runtime_and_unrecognized_paths_require_runtime(self) -> None:
+        for path in (
+            ".github/workflows/docker.yml",
+            "docker-compose.yml",
+            "tests/service/test_health.py",
+            "scripts/check-docs-surface.py",
+            "requirements.txt",
+            "notes.txt",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(MODULE.requires_full_runtime([path]))
+
+    def test_empty_path_set_requires_runtime(self) -> None:
+        self.assertTrue(MODULE.requires_full_runtime([]))
+        self.assertTrue(MODULE.requires_full_runtime([""]))
+        self.assertTrue(MODULE.requires_full_runtime(["  "]))
+
+    def test_cli_reads_stdin_and_prints_boolean(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CLASSIFIER)],
+            input="README.md\ndocs/guides/ci.md\n",
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout, "false\n")
+        self.assertEqual(result.stderr, "")
+
+    def test_cli_accepts_positional_paths(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CLASSIFIER),
+                "docs/guides/ci.md",
+                "agent-svc/agent/app.py",
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout, "true\n")
+
+
+class RuntimeGateWorkflowContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.build_and_push = workflow.split("\n  build-and-push:\n", maxsplit=1)[
+            1
+        ].split("\n  integration-tests:\n", maxsplit=1)[0]
+        self.integration_tests = workflow.split("\n  integration-tests:\n", maxsplit=1)[
+            1
+        ].split("\n  runtime-gate:\n", maxsplit=1)[0]
+        self.integration_condition = " ".join(
+            self.integration_tests.split("if: >-\n", maxsplit=1)[1]
+            .split("\n    runs-on:", maxsplit=1)[0]
+            .split()
+        )
+        self.changes = workflow.split("\n  changes:\n", maxsplit=1)[1].split(
+            "\n  build-and-push:\n", maxsplit=1
+        )[0]
+        self.pull_request_classification = self.changes.split(
+            'if [ "${{ github.event_name }}" = "pull_request" ]; then\n',
+            maxsplit=1,
+        )[1].split("\n          else\n", maxsplit=1)[0]
+        self.runtime_gate = workflow.split("\n  runtime-gate:\n", maxsplit=1)[1]
+
+    def integration_tests_runs_for(
+        self,
+        *,
+        event_name: str,
+        changes_result: str,
+        requires_full_runtime: str,
+        build_result: str,
+    ) -> bool:
+        """Evaluate the workflow's two supported integration-test lanes."""
+        return (
+            event_name == "pull_request"
+            and changes_result == "success"
+            and requires_full_runtime == "true"
+        ) or (event_name == "push" and build_result == "success")
+
+    def test_docker_build_matrix_is_push_only(self) -> None:
+        self.assertIn("if: github.event_name == 'push'", self.build_and_push)
+        self.assertIn("matrix:\n        include:", self.build_and_push)
+        self.assertIn("- service: agent-svc", self.build_and_push)
+        self.assertIn("- service: scraper-svc", self.build_and_push)
+
+    def test_docs_only_pull_request_cannot_run_integration_tests(self) -> None:
+        self.assertEqual(
+            self.integration_condition,
+            "always() && ((github.event_name == 'pull_request' && "
+            "needs.changes.result == 'success' && "
+            "needs.changes.outputs.requires_full_runtime == 'true') || "
+            "(github.event_name == 'push' && needs.build-and-push.result == 'success'))",
+        )
+        self.assertFalse(
+            self.integration_tests_runs_for(
+                event_name="pull_request",
+                changes_result="success",
+                requires_full_runtime="false",
+                build_result="skipped",
+            )
+        )
+
+    def test_full_runtime_pull_request_can_run_integration_tests(self) -> None:
+        self.assertTrue(
+            self.integration_tests_runs_for(
+                event_name="pull_request",
+                changes_result="success",
+                requires_full_runtime="true",
+                build_result="skipped",
+            )
+        )
+
+    def test_pull_request_classification_diffs_merge_base_to_head(self) -> None:
+        self.assertIn(
+            'merge_base=$(git merge-base "$base" "$head")',
+            self.pull_request_classification,
+        )
+        self.assertIn(
+            'changed_paths=$(git diff --name-only "$merge_base" "$head")',
+            self.pull_request_classification,
+        )
+        self.assertNotIn(
+            'changed_paths=$(git diff --name-only "$base" "$head")',
+            self.pull_request_classification,
+        )
+
+    def test_integration_test_staging_copies_only_required_contract_inputs(
+        self,
+    ) -> None:
+        self.assertIn(
+            "docker compose exec -T agent-svc mkdir -p /app/scripts",
+            self.integration_tests,
+        )
+        self.assertIn(
+            'docker cp scripts/classify_ci_changes.py "$svc":/app/scripts/classify_ci_changes.py',
+            self.integration_tests,
+        )
+        self.assertNotIn(
+            'docker cp scripts/. "$svc":/app/scripts/', self.integration_tests
+        )
+        self.assertIn(
+            "docker compose exec -T agent-svc mkdir -p /app/.github/workflows",
+            self.integration_tests,
+        )
+        self.assertIn(
+            'docker cp .github/workflows/docker.yml "$svc":/app/.github/workflows/docker.yml',
+            self.integration_tests,
+        )
+        self.assertNotIn(
+            'docker cp .github/workflows/. "$svc":/app/.github/workflows/',
+            self.integration_tests,
+        )
+
+    def test_runtime_gate_only_bypasses_docs_only_pull_requests(self) -> None:
+        self.assertIn("if: always()", self.runtime_gate)
+        self.assertIn(
+            "Runtime integration was intentionally not needed for this docs-only pull request.",
+            self.runtime_gate,
+        )
+        self.assertIn(
+            "github.event_name == 'pull_request' && needs.changes.result == 'success' &&",
+            self.runtime_gate,
+        )
+        self.assertIn(
+            "needs.changes.outputs.requires_full_runtime == 'false'", self.runtime_gate
+        )
+
+    def test_runtime_gate_fails_when_classification_or_required_runtime_fails(
+        self,
+    ) -> None:
+        self.assertIn(
+            "- name: Fail when change classification fails", self.runtime_gate
+        )
+        self.assertIn(
+            "github.event_name == 'pull_request' &&\n          needs.changes.result != 'success'",
+            self.runtime_gate,
+        )
+        self.assertIn(
+            "- name: Fail when required runtime validation fails", self.runtime_gate
+        )
+        self.assertIn("needs.integration-tests.result != 'success'", self.runtime_gate)
+        self.assertEqual(self.runtime_gate.count("exit 1"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/service/test_resource_envelope_contract.py
+++ b/tests/service/test_resource_envelope_contract.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -10,9 +9,6 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def test_integration_workflow_enables_indexing_profile():
     workflow_path = ROOT / ".github/workflows/docker.yml"
-    if not workflow_path.exists():
-        pytest.skip("workflow source is not copied into the integration container")
-
     workflow = workflow_path.read_text()
     assert "docker compose --profile indexing up --build -d" in workflow
     assert "docker compose exec -T agent-svc env \\" in workflow


### PR DESCRIPTION
## Summary

Routes Docker CI conservatively by pull-request risk. Documentation/prose-only pull requests now complete a visible `Runtime Gate` no-op instead of building five images and entering the shared Compose integration queue. Runtime-affecting and unknown paths still run the existing deterministic Compose `--build` integration path.

The PR-only image matrix is removed because that same five-service build boundary is already exercised by the integration job. Pushes to `main` and tags retain the full image matrix followed by integration.

## Related Issue

Part of #494. This is the docs-only/full-runtime first slice; it does not close the service-local routing work described there.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` — not run locally because this macOS host intentionally has no Docker; required runtime changes will exercise the existing self-hosted CI path.
- [x] New tests added for the change — 12 stdlib-only classifier/workflow contract tests cover docs-only, mixed, unknown, empty, push-only matrix, integration routing, and failure-gate semantics.
- [x] Manual verification done — `python3 tests/service/test_ci_change_classification.py`; `python3 -m py_compile scripts/classify_ci_changes.py tests/service/test_ci_change_classification.py`; Ruby YAML parse; and `git diff --check` all passed.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — not needed; the externally visible application and configuration surfaces are unchanged.
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — not applicable; no API endpoint was added.
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — not applicable; no async endpoint was added.

## Notes for Reviewers

The classifier is intentionally conservative: only `docs/`, root prose files, and `.github/ISSUE_TEMPLATE/` bypass runtime work. Every other and unknown path requires full integration. The current repository-wide integration concurrency and cleanup behavior are unchanged. This reduces, but does not resolve, the trusted-runner boundary tracked in #483.

AI-assisted: Jasper used OpenCode for implementation and independent review; final diff and validation were reviewed by Jasper.
