### PR TITLE
ci(review): trigger re-review on synchronize pushes

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -2,7 +2,7 @@ name: Droid Auto Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Re-runs Droid Auto Review when new commits are pushed to a PR. The workflow's concurrency group cancels any in-flight review for the same PR, so the latest diff is always the one reviewed.

- ```synchronize``` added to `pull_request` trigger types in `.github/workflows/droid-review.yml`
- Adaptive shallow/deep depth and security-review gating unchanged