### PR TITLE
fix(security): validate webhook destinations to prevent SSRF

### DIFF
--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -13,13 +13,13 @@ import difflib
 import json
 import logging
 import os
-import sys
-from datetime import datetime, timezone
 from datetime import UTC, datetime
 from typing import Any
 
 import httpx
 from redis import Redis
+
+from common.url import validate_outbound_webhook_url
 
 logger = logging.getLogger(__name__)
 
@@ -145,19 +145,37 @@ async def check_monitor(monitor_id: str, config: dict) -> dict:
     # Notify via webhook
     if webhook_url and result.get("changed"):
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                await client.post(
-                    webhook_url,
-                    json={
-                        "event": "monitor.changed",
-                        "monitor_id": monitor_id,
-                        "url": url,
-                        "diff": result["diff"],
-                        "checked_at": result["checked_at"],
-                    },
+            # SSRF guard: reject private/restricted webhook destinations
+            # before attempting delivery (issue #469).
+            await asyncio.to_thread(validate_outbound_webhook_url, webhook_url)
+        except ValueError as e:
+            logger.warning(
+                "Webhook skipped for monitor %s: %s (url=%r)",
+                monitor_id,
+                e,
+                webhook_url,
+            )
+        else:
+            try:
+                # Redirects disabled so a validated public destination
+                # cannot be redirected to a restricted host.
+                async with httpx.AsyncClient(
+                    timeout=10, follow_redirects=False
+                ) as client:
+                    await client.post(
+                        webhook_url,
+                        json={
+                            "event": "monitor.changed",
+                            "monitor_id": monitor_id,
+                            "url": url,
+                            "diff": result["diff"],
+                            "checked_at": result["checked_at"],
+                        },
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Webhook delivery failed for monitor %s: %s", monitor_id, e
                 )
-        except Exception as e:
-            logger.warning("Webhook delivery failed for monitor %s: %s", monitor_id, e)
 
     _store_check(monitor_id, result)
     return result
@@ -188,7 +206,7 @@ async def run_search_monitor(monitor_id: str, config: dict) -> dict:
     r = _get_redis()
     searxng = SearXNGClient(SEARXNG_URL)
     try:
-        search_results, health = await searxng.search(
+        search_results, _ = await searxng.search(
             query=query,
             limit=num_results,
             categories=categories,
@@ -235,29 +253,54 @@ async def run_search_monitor(monitor_id: str, config: dict) -> dict:
 
     # Update stored config
     config["last_checked"] = _now_iso()
-    config["last_result"] = f"{len(new_urls)} new results" if new_urls else "no new results"
+    config["last_result"] = (
+        f"{len(new_urls)} new results" if new_urls else "no new results"
+    )
     save_monitor(monitor_id, config)
 
     # Notify via webhook (only new results)
     if webhook_url and new_urls:
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                await client.post(webhook_url, json={
-                    "event": "monitor.changed",
-                    "monitor_id": monitor_id,
-                    "monitor_type": "search",
-                    "query": query,
-                    "new_results": result["new_results"],
-                    "checked_at": result["checked_at"],
-                })
-        except Exception as e:
-            logger.warning("Webhook delivery failed for search monitor %s: %s", monitor_id, e)
+            # SSRF guard: reject private/restricted webhook destinations
+            # before attempting delivery (issue #469).
+            await asyncio.to_thread(validate_outbound_webhook_url, webhook_url)
+        except ValueError as e:
+            logger.warning(
+                "Webhook skipped for search monitor %s: %s (url=%r)",
+                monitor_id,
+                e,
+                webhook_url,
+            )
+        else:
+            try:
+                # Redirects disabled so a validated public destination
+                # cannot be redirected to a restricted host.
+                async with httpx.AsyncClient(
+                    timeout=10, follow_redirects=False
+                ) as client:
+                    await client.post(
+                        webhook_url,
+                        json={
+                            "event": "monitor.changed",
+                            "monitor_id": monitor_id,
+                            "monitor_type": "search",
+                            "query": query,
+                            "new_results": result["new_results"],
+                            "checked_at": result["checked_at"],
+                        },
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Webhook delivery failed for search monitor %s: %s", monitor_id, e
+                )
 
     _store_check(monitor_id, result)
     return result
 
 
-async def run_monitor(monitor_id: str, scraper_url: str = "http://scraper-svc:8001") -> dict:
+async def run_monitor(
+    monitor_id: str, scraper_url: str = "http://scraper-svc:8001"
+) -> dict:
     """Run a single monitor check immediately, regardless of schedule.
 
     Loads the monitor config, dispatches to the appropriate check function
@@ -281,12 +324,20 @@ async def check_all_async() -> list[dict]:
     for mid, config in monitors.items():
         mt = config.get("monitor_type", "scrape")
         if mt == "search":
-            logger.info("Checking search monitor %s: %s", mid, config.get("search_config", {}).get("query"))
+            logger.info(
+                "Checking search monitor %s: %s",
+                mid,
+                config.get("search_config", {}).get("query"),
+            )
             try:
                 result = await run_search_monitor(mid, config)
                 results.append(result)
                 if result.get("changed"):
-                    logger.info("Search monitor %s: %d new results", mid, result.get("new_count", 0))
+                    logger.info(
+                        "Search monitor %s: %d new results",
+                        mid,
+                        result.get("new_count", 0),
+                    )
             except Exception as e:
                 logger.error("Search monitor %s failed: %s", mid, e)
         else:
@@ -316,7 +367,9 @@ def check_all() -> None:
         )
         for r in changed:
             if r.get("monitor_type") == "search":
-                print(f"  NEW RESULTS: {r.get('query', '?')} ({r['monitor_id']}) — {r.get('new_count', 0)} new")
+                print(
+                    f"  NEW RESULTS: {r.get('query', '?')} ({r['monitor_id']}) — {r.get('new_count', 0)} new"
+                )
             else:
                 print(f"  CHANGED: {r['url']} ({r['monitor_id']})")
             logger.info("  CHANGED: %s (%s)", r["url"], r["monitor_id"])

--- a/agent-svc/agent/monitor.py
+++ b/agent-svc/agent/monitor.py
@@ -19,7 +19,7 @@ from typing import Any
 import httpx
 from redis import Redis
 
-from common.url import validate_outbound_webhook_url
+from .webhook import ensure_deliverable_webhook_destination
 
 logger = logging.getLogger(__name__)
 
@@ -144,18 +144,11 @@ async def check_monitor(monitor_id: str, config: dict) -> dict:
 
     # Notify via webhook
     if webhook_url and result.get("changed"):
-        try:
-            # SSRF guard: reject private/restricted webhook destinations
-            # before attempting delivery (issue #469).
-            await asyncio.to_thread(validate_outbound_webhook_url, webhook_url)
-        except ValueError as e:
-            logger.warning(
-                "Webhook skipped for monitor %s: %s (url=%r)",
-                monitor_id,
-                e,
-                webhook_url,
-            )
-        else:
+        # SSRF guard (issue #469): same validation policy as job webhooks —
+        # public HTTP(S) destinations only, transient DNS failures retried.
+        if await ensure_deliverable_webhook_destination(
+            webhook_url, context=f"monitor {monitor_id}"
+        ):
             try:
                 # Redirects disabled so a validated public destination
                 # cannot be redirected to a restricted host.
@@ -260,18 +253,11 @@ async def run_search_monitor(monitor_id: str, config: dict) -> dict:
 
     # Notify via webhook (only new results)
     if webhook_url and new_urls:
-        try:
-            # SSRF guard: reject private/restricted webhook destinations
-            # before attempting delivery (issue #469).
-            await asyncio.to_thread(validate_outbound_webhook_url, webhook_url)
-        except ValueError as e:
-            logger.warning(
-                "Webhook skipped for search monitor %s: %s (url=%r)",
-                monitor_id,
-                e,
-                webhook_url,
-            )
-        else:
+        # SSRF guard (issue #469): same validation policy as job webhooks —
+        # public HTTP(S) destinations only, transient DNS failures retried.
+        if await ensure_deliverable_webhook_destination(
+            webhook_url, context=f"search monitor {monitor_id}"
+        ):
             try:
                 # Redirects disabled so a validated public destination
                 # cannot be redirected to a restricted host.

--- a/agent-svc/agent/webhook.py
+++ b/agent-svc/agent/webhook.py
@@ -57,6 +57,68 @@ def _sign_body(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+async def ensure_deliverable_webhook_destination(
+    url: str,
+    *,
+    context: str = "",
+    max_retries: int = MAX_RETRIES,
+) -> bool:
+    """Validate a webhook destination, retrying transient DNS failures.
+
+    Shared by the job delivery path (``deliver_webhook``) and the monitor
+    notify paths (``agent.monitor``) so every outbound webhook POST is
+    gated by the same policy (issue #469): public HTTP(S) destinations
+    only, transient DNS failures retried with exponential backoff, and
+    permanent rejections skipped without attempting a request.
+
+    Args:
+        url: The webhook destination URL.
+        context: Optional label (e.g. ``"job abc"`` / ``"monitor m1"``)
+            included in log messages.
+        max_retries: Number of validation attempts for transient DNS
+            failures (backoff ``2**attempt`` seconds between attempts).
+
+    Returns:
+        ``True`` when the destination passed validation and may be posted
+        to; ``False`` when it was permanently rejected or validation gave
+        up after exhausting retries on transient DNS failures. Never
+        raises.
+    """
+    prefix = f"{context}: " if context else ""
+    for attempt in range(1, max_retries + 1):
+        try:
+            await asyncio.to_thread(validate_outbound_webhook_url, url)
+            return True
+        except WebhookDestinationDNSRetryableError:
+            if attempt < max_retries:
+                logger.warning(
+                    "%sWebhook attempt %d/%d: DNS resolution temporarily "
+                    "failed (url=%r)",
+                    prefix,
+                    attempt,
+                    max_retries,
+                    url,
+                )
+                await asyncio.sleep(2**attempt)
+            else:
+                logger.error(
+                    "%sWebhook delivery failed after %d attempts: DNS "
+                    "resolution temporarily failed (url=%r)",
+                    prefix,
+                    max_retries,
+                    url,
+                )
+        except WebhookDestinationValidationError as e:
+            logger.warning(
+                "%sWebhook skipped: %s (url=%r)",
+                prefix,
+                e,
+                url,
+            )
+            return False
+    return False
+
+
 async def deliver_webhook(
     webhook_config: dict | None,
     event: str,
@@ -126,72 +188,55 @@ async def deliver_webhook(
         )
 
     async def _do_deliver() -> None:
+        # SSRF guard (issue #469): skip permanently rejected destinations;
+        # transient DNS failures are retried inside the shared validator.
+        if not await ensure_deliverable_webhook_destination(
+            url, context=f"job {job_id}"
+        ):
+            return
+
         for attempt in range(1, MAX_RETRIES + 1):
-            # SSRF guard: reject destinations that are not public HTTP(S)
-            # hosts before any request is attempted (issue #469). Permanent
-            # rejections skip delivery; transient DNS failures retry so a
-            # momentary resolver error does not drop the webhook.
             try:
-                await asyncio.to_thread(validate_outbound_webhook_url, url)
-            except WebhookDestinationDNSRetryableError:
+                # Redirects are disabled so a validated public destination
+                # can never be redirected to a restricted host (issue #469).
+                async with httpx.AsyncClient(
+                    timeout=TIMEOUT_SECONDS, follow_redirects=False
+                ) as client:
+                    resp = await client.post(url, content=body, headers=headers)
+                    if resp.status_code < 500:
+                        logger.info(
+                            "Webhook delivered %s for job %s (webhookId=%s, status %d)",
+                            event,
+                            job_id,
+                            webhook_id,
+                            resp.status_code,
+                        )
+                        return
+                    logger.warning(
+                        "Webhook attempt %d/%d returned %d for job %s (webhookId=%s)",
+                        attempt,
+                        MAX_RETRIES,
+                        resp.status_code,
+                        job_id,
+                        webhook_id,
+                    )
+            except httpx.TimeoutException:
                 logger.warning(
-                    "Webhook attempt %d/%d: DNS resolution temporarily failed "
-                    "for job %s (url=%r)",
+                    "Webhook attempt %d/%d timed out for job %s (webhookId=%s)",
                     attempt,
                     MAX_RETRIES,
                     job_id,
-                    url,
+                    webhook_id,
                 )
-            except WebhookDestinationValidationError as e:
+            except Exception as e:
                 logger.warning(
-                    "Webhook skipped for job %s: %s (url=%r)",
+                    "Webhook attempt %d/%d failed for job %s: %s (webhookId=%s)",
+                    attempt,
+                    MAX_RETRIES,
                     job_id,
                     e,
-                    url,
+                    webhook_id,
                 )
-                return
-            else:
-                try:
-                    # Redirects are disabled so a validated public destination
-                    # can never be redirected to a restricted host (issue #469).
-                    async with httpx.AsyncClient(
-                        timeout=TIMEOUT_SECONDS, follow_redirects=False
-                    ) as client:
-                        resp = await client.post(url, content=body, headers=headers)
-                        if resp.status_code < 500:
-                            logger.info(
-                                "Webhook delivered %s for job %s (webhookId=%s, status %d)",
-                                event,
-                                job_id,
-                                webhook_id,
-                                resp.status_code,
-                            )
-                            return
-                        logger.warning(
-                            "Webhook attempt %d/%d returned %d for job %s (webhookId=%s)",
-                            attempt,
-                            MAX_RETRIES,
-                            resp.status_code,
-                            job_id,
-                            webhook_id,
-                        )
-                except httpx.TimeoutException:
-                    logger.warning(
-                        "Webhook attempt %d/%d timed out for job %s (webhookId=%s)",
-                        attempt,
-                        MAX_RETRIES,
-                        job_id,
-                        webhook_id,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Webhook attempt %d/%d failed for job %s: %s (webhookId=%s)",
-                        attempt,
-                        MAX_RETRIES,
-                        job_id,
-                        e,
-                        webhook_id,
-                    )
 
             if attempt < MAX_RETRIES:
                 await asyncio.sleep(2**attempt)  # 2s, 4s

--- a/agent-svc/agent/webhook.py
+++ b/agent-svc/agent/webhook.py
@@ -25,6 +25,8 @@ import uuid
 
 import httpx
 
+from common.url import validate_outbound_webhook_url
+
 from .settings import load_settings
 
 logger = logging.getLogger(__name__)
@@ -100,6 +102,19 @@ async def deliver_webhook(
     if events_filter and event not in events_filter:
         return
 
+    # SSRF guard: reject webhook destinations that are not public HTTP(S)
+    # hosts before any request is attempted (issue #469).
+    try:
+        await asyncio.to_thread(validate_outbound_webhook_url, url)
+    except ValueError as e:
+        logger.warning(
+            "Webhook skipped for job %s: %s (url=%r)",
+            job_id,
+            e,
+            url,
+        )
+        return
+
     webhook_id = _next_webhook_id()
 
     payload = {
@@ -122,7 +137,11 @@ async def deliver_webhook(
     async def _do_deliver() -> None:
         for attempt in range(1, MAX_RETRIES + 1):
             try:
-                async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+                # Redirects are disabled so a validated public destination
+                # can never be redirected to a restricted host (issue #469).
+                async with httpx.AsyncClient(
+                    timeout=TIMEOUT_SECONDS, follow_redirects=False
+                ) as client:
                     resp = await client.post(url, content=body, headers=headers)
                     if resp.status_code < 500:
                         logger.info(

--- a/agent-svc/agent/webhook.py
+++ b/agent-svc/agent/webhook.py
@@ -25,7 +25,11 @@ import uuid
 
 import httpx
 
-from common.url import validate_outbound_webhook_url
+from common.url import (
+    WebhookDestinationDNSRetryableError,
+    WebhookDestinationValidationError,
+    validate_outbound_webhook_url,
+)
 
 from .settings import load_settings
 
@@ -102,19 +106,6 @@ async def deliver_webhook(
     if events_filter and event not in events_filter:
         return
 
-    # SSRF guard: reject webhook destinations that are not public HTTP(S)
-    # hosts before any request is attempted (issue #469).
-    try:
-        await asyncio.to_thread(validate_outbound_webhook_url, url)
-    except ValueError as e:
-        logger.warning(
-            "Webhook skipped for job %s: %s (url=%r)",
-            job_id,
-            e,
-            url,
-        )
-        return
-
     webhook_id = _next_webhook_id()
 
     payload = {
@@ -136,47 +127,71 @@ async def deliver_webhook(
 
     async def _do_deliver() -> None:
         for attempt in range(1, MAX_RETRIES + 1):
+            # SSRF guard: reject destinations that are not public HTTP(S)
+            # hosts before any request is attempted (issue #469). Permanent
+            # rejections skip delivery; transient DNS failures retry so a
+            # momentary resolver error does not drop the webhook.
             try:
-                # Redirects are disabled so a validated public destination
-                # can never be redirected to a restricted host (issue #469).
-                async with httpx.AsyncClient(
-                    timeout=TIMEOUT_SECONDS, follow_redirects=False
-                ) as client:
-                    resp = await client.post(url, content=body, headers=headers)
-                    if resp.status_code < 500:
-                        logger.info(
-                            "Webhook delivered %s for job %s (webhookId=%s, status %d)",
-                            event,
+                await asyncio.to_thread(validate_outbound_webhook_url, url)
+            except WebhookDestinationDNSRetryableError:
+                logger.warning(
+                    "Webhook attempt %d/%d: DNS resolution temporarily failed "
+                    "for job %s (url=%r)",
+                    attempt,
+                    MAX_RETRIES,
+                    job_id,
+                    url,
+                )
+            except WebhookDestinationValidationError as e:
+                logger.warning(
+                    "Webhook skipped for job %s: %s (url=%r)",
+                    job_id,
+                    e,
+                    url,
+                )
+                return
+            else:
+                try:
+                    # Redirects are disabled so a validated public destination
+                    # can never be redirected to a restricted host (issue #469).
+                    async with httpx.AsyncClient(
+                        timeout=TIMEOUT_SECONDS, follow_redirects=False
+                    ) as client:
+                        resp = await client.post(url, content=body, headers=headers)
+                        if resp.status_code < 500:
+                            logger.info(
+                                "Webhook delivered %s for job %s (webhookId=%s, status %d)",
+                                event,
+                                job_id,
+                                webhook_id,
+                                resp.status_code,
+                            )
+                            return
+                        logger.warning(
+                            "Webhook attempt %d/%d returned %d for job %s (webhookId=%s)",
+                            attempt,
+                            MAX_RETRIES,
+                            resp.status_code,
                             job_id,
                             webhook_id,
-                            resp.status_code,
                         )
-                        return
+                except httpx.TimeoutException:
                     logger.warning(
-                        "Webhook attempt %d/%d returned %d for job %s (webhookId=%s)",
+                        "Webhook attempt %d/%d timed out for job %s (webhookId=%s)",
                         attempt,
                         MAX_RETRIES,
-                        resp.status_code,
                         job_id,
                         webhook_id,
                     )
-            except httpx.TimeoutException:
-                logger.warning(
-                    "Webhook attempt %d/%d timed out for job %s (webhookId=%s)",
-                    attempt,
-                    MAX_RETRIES,
-                    job_id,
-                    webhook_id,
-                )
-            except Exception as e:
-                logger.warning(
-                    "Webhook attempt %d/%d failed for job %s: %s (webhookId=%s)",
-                    attempt,
-                    MAX_RETRIES,
-                    job_id,
-                    e,
-                    webhook_id,
-                )
+                except Exception as e:
+                    logger.warning(
+                        "Webhook attempt %d/%d failed for job %s: %s (webhookId=%s)",
+                        attempt,
+                        MAX_RETRIES,
+                        job_id,
+                        e,
+                        webhook_id,
+                    )
 
             if attempt < MAX_RETRIES:
                 await asyncio.sleep(2**attempt)  # 2s, 4s

--- a/agent-svc/agent/webhook.py
+++ b/agent-svc/agent/webhook.py
@@ -59,16 +59,19 @@ def _sign_body(body: bytes, secret: str) -> str:
 
 
 def _redact_webhook_url(url: str) -> str:
-    """Mask the path and query of a webhook URL for log messages.
+    """Mask the path, query, and credentials of a webhook URL for logs.
 
     Webhook URLs commonly embed secret tokens in the path or query (e.g.
-    Slack/Discord hooks), so logs must only expose ``scheme://host``.
+    Slack/Discord hooks) and may carry userinfo credentials, so logs must
+    only expose ``scheme://host[:port]``.
     """
     try:
         parsed = urlparse(url)
         if not parsed.hostname:
             return "<redacted>"
-        return f"{parsed.scheme}://{parsed.netloc}/***"
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        return f"{parsed.scheme}://{host}{port}/***"
     except Exception:
         return "<redacted>"
 

--- a/agent-svc/agent/webhook.py
+++ b/agent-svc/agent/webhook.py
@@ -22,6 +22,7 @@ import hmac
 import json
 import logging
 import uuid
+from urllib.parse import urlparse
 
 import httpx
 
@@ -55,6 +56,21 @@ def _next_webhook_id() -> str:
 def _sign_body(body: bytes, secret: str) -> str:
     """HMAC-SHA256 sign the request body."""
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _redact_webhook_url(url: str) -> str:
+    """Mask the path and query of a webhook URL for log messages.
+
+    Webhook URLs commonly embed secret tokens in the path or query (e.g.
+    Slack/Discord hooks), so logs must only expose ``scheme://host``.
+    """
+    try:
+        parsed = urlparse(url)
+        if not parsed.hostname:
+            return "<redacted>"
+        return f"{parsed.scheme}://{parsed.netloc}/***"
+    except Exception:
+        return "<redacted>"
 
 
 async def ensure_deliverable_webhook_destination(
@@ -93,27 +109,27 @@ async def ensure_deliverable_webhook_destination(
             if attempt < max_retries:
                 logger.warning(
                     "%sWebhook attempt %d/%d: DNS resolution temporarily "
-                    "failed (url=%r)",
+                    "failed (url=%s)",
                     prefix,
                     attempt,
                     max_retries,
-                    url,
+                    _redact_webhook_url(url),
                 )
                 await asyncio.sleep(2**attempt)
             else:
                 logger.error(
                     "%sWebhook delivery failed after %d attempts: DNS "
-                    "resolution temporarily failed (url=%r)",
+                    "resolution temporarily failed (url=%s)",
                     prefix,
                     max_retries,
-                    url,
+                    _redact_webhook_url(url),
                 )
         except WebhookDestinationValidationError as e:
             logger.warning(
-                "%sWebhook skipped: %s (url=%r)",
+                "%sWebhook skipped: %s (url=%s)",
                 prefix,
                 e,
-                url,
+                _redact_webhook_url(url),
             )
             return False
     return False

--- a/common/url.py
+++ b/common/url.py
@@ -161,6 +161,11 @@ def _resolve_to_ips_with_transient(
     except socket.gaierror as exc:
         logger.warning("DNS resolution failed for %s — treating as private", hostname)
         return [], exc.errno == getattr(socket, "EAI_AGAIN", -3)
+    except UnicodeError:
+        # Non-IDNA hostnames (e.g. >63-char labels) are permanently
+        # unresolvable, not transiently failing.
+        logger.warning("DNS resolution failed for %s — treating as private", hostname)
+        return [], False
 
 
 def _addr_is_restricted(addr: IPv4Address | IPv6Address) -> bool:
@@ -235,6 +240,11 @@ def validate_outbound_webhook_url(url: str) -> None:
     explicit ``http``/``https`` schemes are allowed, and the host must
     resolve to a public, non-restricted address.
 
+    This function never raises exceptions other than the documented
+    contract below; malformed URLs (bad IPv6 brackets, non-IDNA
+    hostnames, etc.) are treated as permanent rejections rather than
+    leaking parser or resolver errors to callers.
+
     Raises:
         WebhookDestinationValidationError: If the URL is missing, uses a
             non-HTTP(S) scheme, has no hostname, or its host is
@@ -249,6 +259,24 @@ def validate_outbound_webhook_url(url: str) -> None:
     link-local, multicast, metadata endpoints, Docker internal
     hostnames), and unresolvable hostnames fail closed.
     """
+    try:
+        _validate_outbound_webhook_url_inner(url)
+    except WebhookDestinationValidationError:
+        raise
+    except Exception as exc:  # pragma: no cover - defense in depth
+        raise WebhookDestinationValidationError(
+            f"webhook URL could not be validated: {exc}"
+        ) from exc
+
+
+def _validate_outbound_webhook_url_inner(url: str) -> None:
+    """Implementation of :func:`validate_outbound_webhook_url`.
+
+    Raises ``WebhookDestinationValidationError`` /
+    ``WebhookDestinationDNSRetryableError`` for every rejection; the
+    public wrapper converts any unexpected exception to the permanent
+    rejection contract.
+    """
     if not isinstance(url, str) or not url.strip():
         raise WebhookDestinationValidationError("webhook URL is missing")
 
@@ -258,7 +286,12 @@ def validate_outbound_webhook_url(url: str) -> None:
             f"webhook URL must use http or https, got {parsed.scheme!r}"
         )
 
-    hostname = parsed.hostname
+    try:
+        hostname = parsed.hostname
+    except ValueError:
+        raise WebhookDestinationValidationError(
+            "webhook URL has an invalid host"
+        ) from None
     if not hostname:
         raise WebhookDestinationValidationError("webhook URL has no hostname")
 

--- a/common/url.py
+++ b/common/url.py
@@ -110,14 +110,34 @@ def is_same_origin(url1: str, url2: str) -> bool:
     )
 
 
+def _unmap_ipv4_mapped(
+    addr: IPv4Address | IPv6Address,
+) -> IPv4Address | IPv6Address:
+    """Unwrap IPv4-mapped IPv6 addresses to their embedded IPv4 form.
+
+    ``::ffff:a.b.c.d`` addresses (RFC 4291 section 2.2) represent IPv4
+    destinations, so they must be checked against IPv4 private ranges —
+    e.g. ``::ffff:127.0.0.1`` is loopback. Without unmapping, the
+    address matches no IPv6 private network and the SSRF guard is
+    bypassed.
+    """
+    if isinstance(addr, IPv6Address) and addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+    return addr
+
+
 def _resolve_to_ips(hostname: str) -> list[IPv4Address | IPv6Address]:
-    """Resolve a hostname to all IP addresses (IPv4 and IPv6)."""
+    """Resolve a hostname to all IP addresses (IPv4 and IPv6).
+
+    IPv4-mapped IPv6 results are unwrapped so downstream checks evaluate
+    the embedded IPv4 address against IPv4 private ranges.
+    """
     try:
         addrinfo = socket.getaddrinfo(hostname, None)
         ips: set[IPv4Address | IPv6Address] = set()
         for _family, _stype, _proto, _canonname, sockaddr in addrinfo:
             try:
-                ips.add(ip_address(sockaddr[0]))
+                ips.add(_unmap_ipv4_mapped(ip_address(sockaddr[0])))
             except ValueError:
                 continue
         return list(ips)
@@ -151,7 +171,7 @@ def is_private_host(url: str) -> bool:
 
     # Check if hostname is itself a private IP literal
     try:
-        addr = ip_address(hostname)
+        addr = _unmap_ipv4_mapped(ip_address(hostname))
         for net in _PRIVATE_NETWORKS:
             if addr in net:
                 return True
@@ -167,6 +187,7 @@ def is_private_host(url: str) -> bool:
         return True
 
     for addr in ips:
+        addr = _unmap_ipv4_mapped(addr)
         for net in _PRIVATE_NETWORKS:
             if addr in net:
                 return True

--- a/common/url.py
+++ b/common/url.py
@@ -132,6 +132,23 @@ def _resolve_to_ips(hostname: str) -> list[IPv4Address | IPv6Address]:
     IPv4-mapped IPv6 results are unwrapped so downstream checks evaluate
     the embedded IPv4 address against IPv4 private ranges.
     """
+    ips, _transient = _resolve_to_ips_with_transient(hostname)
+    return ips
+
+
+def _resolve_to_ips_with_transient(
+    hostname: str,
+) -> tuple[list[IPv4Address | IPv6Address], bool]:
+    """Resolve a hostname, reporting whether the failure was transient.
+
+    Returns ``(ips, transient)``. ``transient`` is True when DNS failed
+    with a temporary resolver error (``EAI_AGAIN``) that may succeed on
+    retry, so callers can distinguish retryable failures from permanent
+    ones (NXDOMAIN, misconfigured resolver, etc.).
+
+    IPv4-mapped IPv6 results are unwrapped so downstream checks evaluate
+    the embedded IPv4 address against IPv4 private ranges.
+    """
     try:
         addrinfo = socket.getaddrinfo(hostname, None)
         ips: set[IPv4Address | IPv6Address] = set()
@@ -140,10 +157,23 @@ def _resolve_to_ips(hostname: str) -> list[IPv4Address | IPv6Address]:
                 ips.add(_unmap_ipv4_mapped(ip_address(sockaddr[0])))
             except ValueError:
                 continue
-        return list(ips)
-    except socket.gaierror:
+        return list(ips), False
+    except socket.gaierror as exc:
         logger.warning("DNS resolution failed for %s — treating as private", hostname)
-        return []
+        return [], exc.errno == getattr(socket, "EAI_AGAIN", -3)
+
+
+def _addr_is_restricted(addr: IPv4Address | IPv6Address) -> bool:
+    """Return True when an IP address is private or otherwise restricted.
+
+    IPv4-mapped IPv6 addresses are unwrapped first so their embedded
+    IPv4 address is checked against IPv4 private ranges.
+    """
+    addr = _unmap_ipv4_mapped(addr)
+    for net in _PRIVATE_NETWORKS:
+        if addr in net:
+            return True
+    return addr in _METADATA_IPS
 
 
 def is_private_host(url: str) -> bool:
@@ -172,11 +202,7 @@ def is_private_host(url: str) -> bool:
     # Check if hostname is itself a private IP literal
     try:
         addr = _unmap_ipv4_mapped(ip_address(hostname))
-        for net in _PRIVATE_NETWORKS:
-            if addr in net:
-                return True
-        # It's a valid, non-private IP literal — safe to navigate
-        return addr in _METADATA_IPS
+        return _addr_is_restricted(addr)
     except ValueError:
         pass  # Not an IP literal, treat as hostname
 
@@ -186,15 +212,20 @@ def is_private_host(url: str) -> bool:
         # Can't resolve — _resolve_to_ips already logged at WARNING
         return True
 
-    for addr in ips:
-        addr = _unmap_ipv4_mapped(addr)
-        for net in _PRIVATE_NETWORKS:
-            if addr in net:
-                return True
-        if addr in _METADATA_IPS:
-            return True
+    return any(_addr_is_restricted(addr) for addr in ips)
 
-    return False
+
+class WebhookDestinationValidationError(ValueError):
+    """A webhook destination was permanently rejected by the SSRF guard."""
+
+
+class WebhookDestinationDNSRetryableError(WebhookDestinationValidationError):
+    """Webhook destination validation failed due to a transient DNS error.
+
+    Raised when the hostname could not be resolved because of a
+    temporary resolver failure (``EAI_AGAIN``). Callers should retry
+    rather than treat the destination as permanently rejected.
+    """
 
 
 def validate_outbound_webhook_url(url: str) -> None:
@@ -202,28 +233,62 @@ def validate_outbound_webhook_url(url: str) -> None:
 
     Enforces the shared SSRF policy for outbound webhook POSTs: only
     explicit ``http``/``https`` schemes are allowed, and the host must
-    resolve to a public, non-restricted address. Raises ``ValueError``
-    with a human-readable reason when the URL is not deliverable, so
-    callers can reject it without attempting a request.
+    resolve to a public, non-restricted address.
+
+    Raises:
+        WebhookDestinationValidationError: If the URL is missing, uses a
+            non-HTTP(S) scheme, has no hostname, or its host is
+            private/restricted — a permanent rejection.
+        WebhookDestinationDNSRetryableError: If the hostname could not
+            be resolved due to a transient DNS failure (``EAI_AGAIN``);
+            a subclass of ``WebhookDestinationValidationError`` so
+            callers may retry or treat it as a rejection.
 
     DNS resolution and host checks use the same private/hostile network
     definitions as :func:`is_private_host` (RFC 1918, loopback,
     link-local, multicast, metadata endpoints, Docker internal
     hostnames), and unresolvable hostnames fail closed.
-
-    Raises:
-        ValueError: If the URL is missing, uses a non-HTTP(S) scheme,
-            has no hostname, or its host is private/restricted.
     """
     if not isinstance(url, str) or not url.strip():
-        raise ValueError("webhook URL is missing")
+        raise WebhookDestinationValidationError("webhook URL is missing")
 
     parsed = urlparse(url)
     if parsed.scheme.lower() not in ("http", "https"):
-        raise ValueError(f"webhook URL must use http or https, got {parsed.scheme!r}")
+        raise WebhookDestinationValidationError(
+            f"webhook URL must use http or https, got {parsed.scheme!r}"
+        )
 
-    if not parsed.hostname:
-        raise ValueError("webhook URL has no hostname")
+    hostname = parsed.hostname
+    if not hostname:
+        raise WebhookDestinationValidationError("webhook URL has no hostname")
 
-    if is_private_host(url):
-        raise ValueError("webhook URL resolves to a private or restricted destination")
+    hostname_lower = hostname.lower()
+    for suffix in _PRIVATE_HOSTNAME_SUFFIXES:
+        if hostname_lower.endswith(suffix):
+            raise WebhookDestinationValidationError(
+                "webhook URL resolves to a private or restricted destination"
+            )
+
+    # IP literal (deterministic — includes IPv4-mapped IPv6 literals)
+    try:
+        addr = _unmap_ipv4_mapped(ip_address(hostname))
+    except ValueError:
+        addr = None
+    if addr is not None:
+        if _addr_is_restricted(addr):
+            raise WebhookDestinationValidationError(
+                "webhook URL resolves to a private or restricted destination"
+            )
+        return
+
+    # Hostname: resolve and check every address; transient DNS failures
+    # are retryable rather than permanent rejections.
+    ips, transient = _resolve_to_ips_with_transient(hostname)
+    if transient:
+        raise WebhookDestinationDNSRetryableError(
+            "webhook URL DNS resolution temporarily failed"
+        )
+    if not ips or any(_addr_is_restricted(addr) for addr in ips):
+        raise WebhookDestinationValidationError(
+            "webhook URL resolves to a private or restricted destination"
+        )

--- a/common/url.py
+++ b/common/url.py
@@ -35,6 +35,7 @@ _PRIVATE_NETWORKS: list[IPv4Network | IPv6Network] = [
     ip_network("fc00::/7"),  # IPv6 unique-local (ULA)
     ip_network("fe80::/10"),  # IPv6 link-local
     ip_network("ff00::/8"),  # IPv6 multicast
+    ip_network("64:ff9b::/32"),  # NAT64 WKP + local-use (RFC 6052/7050)
 ]
 
 _METADATA_IPS: list[IPv4Address | IPv6Address] = [
@@ -47,12 +48,10 @@ _PRIVATE_HOSTNAME_SUFFIXES: list[str] = [
     ".docker.internal",
 ]
 
-# IPv6 networks that embed an IPv4 destination (RFC 4291, RFC 3056, RFC 4380,
-# RFC 6052)
+# IPv6 networks that embed an IPv4 destination (RFC 4291, RFC 3056, RFC 4380)
 _IPV4_COMPATIBLE_NET = ip_network("::/96")  # deprecated IPv4-compatible
 _6TO4_NET = ip_network("2002::/16")  # 6to4 relay prefix
 _TEREDO_NET = ip_network("2001::/32")  # Teredo service prefix
-_NAT64_NET = ip_network("64:ff9b::/96")  # NAT64 well-known prefix (RFC 6052)
 
 
 # ── Public API ─────────────────────────────────────────────────────
@@ -131,10 +130,12 @@ def _unmap_embedded_ipv4(
     * ``::a.b.c.d`` — deprecated IPv4-compatible (RFC 4291 section 2.5.5.1)
     * ``2002:a.b.c.d::/48`` — 6to4 (RFC 3056)
     * ``2001:0000::/32`` — Teredo, de-obfuscated client IPv4 (RFC 4380)
-    * ``64:ff9b::/96`` — NAT64 well-known prefix (RFC 6052)
 
     Without unmapping, e.g. ``::ffff:127.0.0.1`` or ``2002:0a00:0001::``
     matches no IPv6 private network and the SSRF guard is bypassed.
+    NAT64 addresses (``64:ff9b::/32``) are rejected outright as a
+    special-purpose range in :data:`_PRIVATE_NETWORKS`; no extraction is
+    needed for them.
     """
     if not isinstance(addr, IPv6Address):
         return addr
@@ -146,9 +147,6 @@ def _unmap_embedded_ipv4(
     if addr in _6TO4_NET:
         # IPv4 occupies hextets 2-3 (int bits 80-111)
         return IPv4Address((int_addr >> 80) & 0xFFFFFFFF)
-    if addr in _NAT64_NET:
-        # IPv4 occupies the low 32 bits
-        return IPv4Address(int_addr & 0xFFFFFFFF)
     if addr in _TEREDO_NET:
         # Destination is the Teredo client IPv4 (low 32 bits, XOR-obscured)
         return IPv4Address((int_addr & 0xFFFFFFFF) ^ 0xFFFFFFFF)
@@ -158,8 +156,8 @@ def _unmap_embedded_ipv4(
 def _resolve_to_ips(hostname: str) -> list[IPv4Address | IPv6Address]:
     """Resolve a hostname to all IP addresses (IPv4 and IPv6).
 
-    IPv4-mapped IPv6 results are unwrapped so downstream checks evaluate
-    the embedded IPv4 address against IPv4 private ranges.
+    Addresses are returned raw; :func:`_addr_is_restricted` handles
+    embedded-IPv4 forms when checked.
     """
     ips, _transient = _resolve_to_ips_with_transient(hostname)
     return ips
@@ -175,15 +173,15 @@ def _resolve_to_ips_with_transient(
     retry, so callers can distinguish retryable failures from permanent
     ones (NXDOMAIN, misconfigured resolver, etc.).
 
-    IPv4-mapped IPv6 results are unwrapped so downstream checks evaluate
-    the embedded IPv4 address against IPv4 private ranges.
+    Addresses are returned raw; :func:`_addr_is_restricted` handles
+    IPv4-embedded forms when checked.
     """
     try:
         addrinfo = socket.getaddrinfo(hostname, None)
         ips: set[IPv4Address | IPv6Address] = set()
         for _family, _stype, _proto, _canonname, sockaddr in addrinfo:
             try:
-                ips.add(_unmap_embedded_ipv4(ip_address(sockaddr[0])))
+                ips.add(ip_address(sockaddr[0]))
             except ValueError:
                 continue
         return list(ips), False
@@ -200,14 +198,24 @@ def _resolve_to_ips_with_transient(
 def _addr_is_restricted(addr: IPv4Address | IPv6Address) -> bool:
     """Return True when an IP address is private or otherwise restricted.
 
-    IPv4-mapped IPv6 addresses are unwrapped first so their embedded
-    IPv4 address is checked against IPv4 private ranges.
+    Checks the raw address first (covers special-purpose ranges like the
+    NAT64 ``64:ff9b::/32`` block and multicast), then unwraps IPv6 forms
+    that embed an IPv4 destination and checks the embedded address
+    against the same ranges.
     """
-    addr = _unmap_embedded_ipv4(addr)
     for net in _PRIVATE_NETWORKS:
         if addr in net:
             return True
-    return addr in _METADATA_IPS
+    if addr in _METADATA_IPS:
+        return True
+    unmapped = _unmap_embedded_ipv4(addr)
+    if unmapped is not addr:
+        for net in _PRIVATE_NETWORKS:
+            if unmapped in net:
+                return True
+        if unmapped in _METADATA_IPS:
+            return True
+    return False
 
 
 def is_private_host(url: str) -> bool:
@@ -235,8 +243,7 @@ def is_private_host(url: str) -> bool:
 
     # Check if hostname is itself a private IP literal
     try:
-        addr = _unmap_embedded_ipv4(ip_address(hostname))
-        return _addr_is_restricted(addr)
+        return _addr_is_restricted(ip_address(hostname))
     except ValueError:
         pass  # Not an IP literal, treat as hostname
 
@@ -333,7 +340,7 @@ def _validate_outbound_webhook_url_inner(url: str) -> None:
 
     # IP literal (deterministic — includes IPv4-embedding IPv6 literals)
     try:
-        addr = _unmap_embedded_ipv4(ip_address(hostname))
+        addr = ip_address(hostname)
     except ValueError:
         addr = None
     if addr is not None:

--- a/common/url.py
+++ b/common/url.py
@@ -30,9 +30,11 @@ _PRIVATE_NETWORKS: list[IPv4Network | IPv6Network] = [
     ip_network("100.64.0.0/10"),  # Carrier-grade NAT (RFC 6598)
     ip_network("198.18.0.0/15"),  # Benchmarking (RFC 2544)
     ip_network("240.0.0.0/4"),  # Reserved / future use
+    ip_network("224.0.0.0/4"),  # Multicast (RFC 5771)
     ip_network("::1/128"),  # IPv6 loopback
     ip_network("fc00::/7"),  # IPv6 unique-local (ULA)
     ip_network("fe80::/10"),  # IPv6 link-local
+    ip_network("ff00::/8"),  # IPv6 multicast
 ]
 
 _METADATA_IPS: list[IPv4Address | IPv6Address] = [
@@ -172,3 +174,35 @@ def is_private_host(url: str) -> bool:
             return True
 
     return False
+
+
+def validate_outbound_webhook_url(url: str) -> None:
+    """Validate a user-supplied webhook destination before delivery.
+
+    Enforces the shared SSRF policy for outbound webhook POSTs: only
+    explicit ``http``/``https`` schemes are allowed, and the host must
+    resolve to a public, non-restricted address. Raises ``ValueError``
+    with a human-readable reason when the URL is not deliverable, so
+    callers can reject it without attempting a request.
+
+    DNS resolution and host checks use the same private/hostile network
+    definitions as :func:`is_private_host` (RFC 1918, loopback,
+    link-local, multicast, metadata endpoints, Docker internal
+    hostnames), and unresolvable hostnames fail closed.
+
+    Raises:
+        ValueError: If the URL is missing, uses a non-HTTP(S) scheme,
+            has no hostname, or its host is private/restricted.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("webhook URL is missing")
+
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise ValueError(f"webhook URL must use http or https, got {parsed.scheme!r}")
+
+    if not parsed.hostname:
+        raise ValueError("webhook URL has no hostname")
+
+    if is_private_host(url):
+        raise ValueError("webhook URL resolves to a private or restricted destination")

--- a/common/url.py
+++ b/common/url.py
@@ -47,10 +47,12 @@ _PRIVATE_HOSTNAME_SUFFIXES: list[str] = [
     ".docker.internal",
 ]
 
-# IPv6 networks that embed an IPv4 destination (RFC 4291, RFC 3056, RFC 4380)
+# IPv6 networks that embed an IPv4 destination (RFC 4291, RFC 3056, RFC 4380,
+# RFC 6052)
 _IPV4_COMPATIBLE_NET = ip_network("::/96")  # deprecated IPv4-compatible
 _6TO4_NET = ip_network("2002::/16")  # 6to4 relay prefix
 _TEREDO_NET = ip_network("2001::/32")  # Teredo service prefix
+_NAT64_NET = ip_network("64:ff9b::/96")  # NAT64 well-known prefix (RFC 6052)
 
 
 # ── Public API ─────────────────────────────────────────────────────
@@ -128,7 +130,8 @@ def _unmap_embedded_ipv4(
     * ``::ffff:a.b.c.d`` — IPv4-mapped (RFC 4291 section 2.2)
     * ``::a.b.c.d`` — deprecated IPv4-compatible (RFC 4291 section 2.5.5.1)
     * ``2002:a.b.c.d::/48`` — 6to4 (RFC 3056)
-    * ``2001:0000:server:v4:...::/64`` — Teredo server IPv4 (RFC 4380)
+    * ``2001:0000::/32`` — Teredo, de-obfuscated client IPv4 (RFC 4380)
+    * ``64:ff9b::/96`` — NAT64 well-known prefix (RFC 6052)
 
     Without unmapping, e.g. ``::ffff:127.0.0.1`` or ``2002:0a00:0001::``
     matches no IPv6 private network and the SSRF guard is bypassed.
@@ -143,9 +146,12 @@ def _unmap_embedded_ipv4(
     if addr in _6TO4_NET:
         # IPv4 occupies hextets 2-3 (int bits 80-111)
         return IPv4Address((int_addr >> 80) & 0xFFFFFFFF)
+    if addr in _NAT64_NET:
+        # IPv4 occupies the low 32 bits
+        return IPv4Address(int_addr & 0xFFFFFFFF)
     if addr in _TEREDO_NET:
-        # Teredo server IPv4 occupies hextets 3-4 (int bits 64-95)
-        return IPv4Address((int_addr >> 64) & 0xFFFFFFFF)
+        # Destination is the Teredo client IPv4 (low 32 bits, XOR-obscured)
+        return IPv4Address((int_addr & 0xFFFFFFFF) ^ 0xFFFFFFFF)
     return addr
 
 

--- a/common/url.py
+++ b/common/url.py
@@ -47,6 +47,11 @@ _PRIVATE_HOSTNAME_SUFFIXES: list[str] = [
     ".docker.internal",
 ]
 
+# IPv6 networks that embed an IPv4 destination (RFC 4291, RFC 3056, RFC 4380)
+_IPV4_COMPATIBLE_NET = ip_network("::/96")  # deprecated IPv4-compatible
+_6TO4_NET = ip_network("2002::/16")  # 6to4 relay prefix
+_TEREDO_NET = ip_network("2001::/32")  # Teredo service prefix
+
 
 # ── Public API ─────────────────────────────────────────────────────
 
@@ -110,19 +115,37 @@ def is_same_origin(url1: str, url2: str) -> bool:
     )
 
 
-def _unmap_ipv4_mapped(
+def _unmap_embedded_ipv4(
     addr: IPv4Address | IPv6Address,
 ) -> IPv4Address | IPv6Address:
-    """Unwrap IPv4-mapped IPv6 addresses to their embedded IPv4 form.
+    """Unwrap IPv6 forms that embed an IPv4 destination to their IPv4 address.
 
-    ``::ffff:a.b.c.d`` addresses (RFC 4291 section 2.2) represent IPv4
-    destinations, so they must be checked against IPv4 private ranges —
-    e.g. ``::ffff:127.0.0.1`` is loopback. Without unmapping, the
-    address matches no IPv6 private network and the SSRF guard is
-    bypassed.
+    Handles the encapsulation forms that carry an IPv4 destination and
+    can reach it with the right routing, so the embedded address is
+    checked against IPv4 private ranges instead of passing as a
+    non-private IPv6 literal:
+
+    * ``::ffff:a.b.c.d`` — IPv4-mapped (RFC 4291 section 2.2)
+    * ``::a.b.c.d`` — deprecated IPv4-compatible (RFC 4291 section 2.5.5.1)
+    * ``2002:a.b.c.d::/48`` — 6to4 (RFC 3056)
+    * ``2001:0000:server:v4:...::/64`` — Teredo server IPv4 (RFC 4380)
+
+    Without unmapping, e.g. ``::ffff:127.0.0.1`` or ``2002:0a00:0001::``
+    matches no IPv6 private network and the SSRF guard is bypassed.
     """
-    if isinstance(addr, IPv6Address) and addr.ipv4_mapped is not None:
+    if not isinstance(addr, IPv6Address):
+        return addr
+    if addr.ipv4_mapped is not None:
         return addr.ipv4_mapped
+    int_addr = int(addr)
+    if addr in _IPV4_COMPATIBLE_NET:
+        return IPv4Address(int_addr & 0xFFFFFFFF)
+    if addr in _6TO4_NET:
+        # IPv4 occupies hextets 2-3 (int bits 80-111)
+        return IPv4Address((int_addr >> 80) & 0xFFFFFFFF)
+    if addr in _TEREDO_NET:
+        # Teredo server IPv4 occupies hextets 3-4 (int bits 64-95)
+        return IPv4Address((int_addr >> 64) & 0xFFFFFFFF)
     return addr
 
 
@@ -154,7 +177,7 @@ def _resolve_to_ips_with_transient(
         ips: set[IPv4Address | IPv6Address] = set()
         for _family, _stype, _proto, _canonname, sockaddr in addrinfo:
             try:
-                ips.add(_unmap_ipv4_mapped(ip_address(sockaddr[0])))
+                ips.add(_unmap_embedded_ipv4(ip_address(sockaddr[0])))
             except ValueError:
                 continue
         return list(ips), False
@@ -174,7 +197,7 @@ def _addr_is_restricted(addr: IPv4Address | IPv6Address) -> bool:
     IPv4-mapped IPv6 addresses are unwrapped first so their embedded
     IPv4 address is checked against IPv4 private ranges.
     """
-    addr = _unmap_ipv4_mapped(addr)
+    addr = _unmap_embedded_ipv4(addr)
     for net in _PRIVATE_NETWORKS:
         if addr in net:
             return True
@@ -206,7 +229,7 @@ def is_private_host(url: str) -> bool:
 
     # Check if hostname is itself a private IP literal
     try:
-        addr = _unmap_ipv4_mapped(ip_address(hostname))
+        addr = _unmap_embedded_ipv4(ip_address(hostname))
         return _addr_is_restricted(addr)
     except ValueError:
         pass  # Not an IP literal, treat as hostname
@@ -302,9 +325,9 @@ def _validate_outbound_webhook_url_inner(url: str) -> None:
                 "webhook URL resolves to a private or restricted destination"
             )
 
-    # IP literal (deterministic — includes IPv4-mapped IPv6 literals)
+    # IP literal (deterministic — includes IPv4-embedding IPv6 literals)
     try:
-        addr = _unmap_ipv4_mapped(ip_address(hostname))
+        addr = _unmap_embedded_ipv4(ip_address(hostname))
     except ValueError:
         addr = None
     if addr is not None:

--- a/docs/adr/0045-outbound-webhook-destination-validation.md
+++ b/docs/adr/0045-outbound-webhook-destination-validation.md
@@ -48,7 +48,9 @@ link-local, IPv6 ULA/loopback, multicast, cloud metadata endpoints,
 `.docker.internal`, DNS names resolving to restricted addresses, and
 unresolvable DNS fail closed). The multicast ranges `224.0.0.0/4` and
 `ff00::/8` were added to the shared private-network definitions to close the
-multicast gap.
+multicast gap. IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) are unwrapped to
+their embedded IPv4 form before checks, so `::ffff:127.0.0.1` (loopback) and
+`::ffff:169.254.169.254` (metadata) are rejected rather than treated as public.
 
 The validator is called before every webhook dispatch:
 

--- a/docs/adr/0045-outbound-webhook-destination-validation.md
+++ b/docs/adr/0045-outbound-webhook-destination-validation.md
@@ -1,0 +1,87 @@
+# Outbound Webhook Destination Validation
+
+* Status: accepted
+* Deciders: GroktoCrawl maintainers
+* Date: 2026-08-01
+
+## Context and Problem Statement
+
+Webhook delivery accepts a user-supplied URL and posts to it without applying
+the shared private-host SSRF guard used by scraping. If the API is exposed or
+authentication is misconfigured, an attacker can use the service to reach
+loopback, RFC 1918, link-local, multicast, or other restricted network
+destinations. Redirect handling could turn an initially safe URL into a
+restricted destination. The normal job webhook path (`agent/webhook.py`) and
+the monitor webhook path (`agent/monitor.py`) both have the gap.
+
+## Decision Drivers
+
+* Webhook delivery must never reach private, internal, or otherwise restricted
+  destinations, regardless of how the URL was supplied.
+* Normal job webhooks and monitor webhooks must share the same validation
+  behavior.
+* Delivery stays best effort (per ADR-0012 and ADR-0035): a rejected destination
+  must not fail the underlying job or monitor check.
+* Reuse the existing shared guard rather than duplicating policy per service.
+
+## Considered Options
+
+* **A. Dispatch-time validation in the shared webhook path** — validate the
+  destination immediately before every POST, using one shared helper that wraps
+  the existing `common.url.is_private_host` guard plus scheme and hostname
+  checks. Rejected destinations are skipped with a warning; jobs and checks
+  complete normally.
+* **B. Request-time model validation** — reject webhook configurations at API
+  request time by converting the free-form `webhook` dict into a validated
+  model. Covers only the API surface; plan, crawl-stream, and monitor
+  configuration paths still need separate handling, and rejects the request
+  itself rather than the delivery.
+* **C. No validation** — relies on API auth and operator trust. Rejected: this
+  is the vulnerability being fixed.
+
+## Decision Outcome
+
+Adopt option A. `common.url.validate_outbound_webhook_url()` is the single
+shared validator: it requires an explicit `http`/`https` scheme and a hostname,
+and rejects any host that `is_private_host()` flags (RFC 1918, loopback,
+link-local, IPv6 ULA/loopback, multicast, cloud metadata endpoints,
+`.docker.internal`, DNS names resolving to restricted addresses, and
+unresolvable DNS fail closed). The multicast ranges `224.0.0.0/4` and
+`ff00::/8` were added to the shared private-network definitions to close the
+multicast gap.
+
+The validator is called before every webhook dispatch:
+
+* `agent/webhook.py` — `deliver_webhook()` validates after the events filter and
+  before payload construction; a `ValueError` logs a warning and returns without
+  delivering (no retries, since a rejected configuration is not transient).
+* `agent/monitor.py` — both `check_monitor()` and `run_search_monitor()` validate
+  before the notify POST; a `ValueError` logs a warning and skips delivery while
+  the check result is stored normally.
+
+Because validation resolves DNS, it runs in a worker thread via
+`asyncio.to_thread()` so the event loop is not blocked. Redirects are disabled
+(`follow_redirects=False`) on all webhook HTTP clients so a validated public
+destination can never be redirected to a restricted host.
+
+## Consequences
+
+* Restricted webhook destinations are rejected on every delivery path with a
+  single shared policy, and the same policy now covers multicast for scraping
+  paths too.
+* A rejected destination is skipped silently from the perspective of the job or
+  monitor result; operators see the warning in service logs.
+* DNS-based validation performs one lookup per delivery; unresolvable
+  destinations fail closed.
+* The resolver is not rebound to the validated IP — a DNS rebinding attack
+  window remains between validation and connection, matching the behavior of
+  the existing scrape-side guard. This is accepted for now and should be
+  revisited if the outbound proxy layer or a dedicated HTTP client is added.
+* Request-time rejection of invalid webhook URLs is out of scope; delivery-time
+  validation covers every configuration path uniformly.
+
+## Links
+
+* [ADR-0012: Webhook Delivery for Async Endpoints](0012-webhook-delivery-for-async-endpoints.md)
+* [ADR-0035: Graceful Shutdown for Fire-and-Forget Tasks](0035-graceful-shutdown.md)
+* GitHub issue [#469](https://github.com/groktopus/groktocrawl/issues/469)

--- a/docs/adr/0045-outbound-webhook-destination-validation.md
+++ b/docs/adr/0045-outbound-webhook-destination-validation.md
@@ -56,19 +56,22 @@ deprecated IPv4-compatible (`::a.b.c.d`), 6to4 (`2002::/16`), Teredo
 `64:ff9b::a9fe:a9fe` (metadata) are rejected rather than treated as public,
 while public embedded destinations (e.g. `2002:5db8:d822::`) remain allowed.
 
-The validator is called before every webhook dispatch:
+One shared async gate, `ensure_deliverable_webhook_destination()`, is used
+before every webhook dispatch, so both paths share identical validation
+behavior:
 
-* `agent/webhook.py` — `deliver_webhook()` validates after the events filter and
-  before payload construction; a `ValueError` logs a warning and returns without
-  delivering (no retries, since a rejected configuration is not transient).
-* `agent/monitor.py` — both `check_monitor()` and `run_search_monitor()` validate
-  before the notify POST; a `ValueError` logs a warning and skips delivery while
-  the check result is stored normally.
+* `agent/webhook.py` — `deliver_webhook()` gates the delivery retry loop on the
+  shared gate.
+* `agent/monitor.py` — both `check_monitor()` and `run_search_monitor()` gate
+  the notify POST on the shared gate; the check result is stored normally even
+  when delivery is skipped.
 
-Because validation resolves DNS, it runs in a worker thread via
-`asyncio.to_thread()` so the event loop is not blocked. Redirects are disabled
-(`follow_redirects=False`) on all webhook HTTP clients so a validated public
-destination can never be redirected to a restricted host.
+The gate runs validation in a worker thread via `asyncio.to_thread()` so the
+event loop is not blocked; transient DNS failures (`EAI_AGAIN`) are retried
+with exponential backoff inside the gate, while permanent rejections
+(private/restricted destinations, malformed URLs) skip immediately. Redirects
+are disabled (`follow_redirects=False`) on all webhook HTTP clients so a
+validated public destination can never be redirected to a restricted host.
 
 ## Consequences
 

--- a/docs/adr/0045-outbound-webhook-destination-validation.md
+++ b/docs/adr/0045-outbound-webhook-destination-validation.md
@@ -48,9 +48,13 @@ link-local, IPv6 ULA/loopback, multicast, cloud metadata endpoints,
 `.docker.internal`, DNS names resolving to restricted addresses, and
 unresolvable DNS fail closed). The multicast ranges `224.0.0.0/4` and
 `ff00::/8` were added to the shared private-network definitions to close the
-multicast gap. IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) are unwrapped to
-their embedded IPv4 form before checks, so `::ffff:127.0.0.1` (loopback) and
-`::ffff:169.254.169.254` (metadata) are rejected rather than treated as public.
+multicast gap. IPv6 forms that embed an IPv4 destination are unwrapped to
+their embedded IPv4 before checks — IPv4-mapped (`::ffff:a.b.c.d`),
+deprecated IPv4-compatible (`::a.b.c.d`), 6to4 (`2002::/16`), and Teredo
+(`2001:0000::/32`) — so `::ffff:127.0.0.1`, `2002:0a00:0001::`, and
+`::169.254.169.254`-style destinations are rejected rather than treated as
+public, while public embedded destinations (e.g. `2002:5db8:d822::`) remain
+allowed.
 
 The validator is called before every webhook dispatch:
 

--- a/docs/adr/0045-outbound-webhook-destination-validation.md
+++ b/docs/adr/0045-outbound-webhook-destination-validation.md
@@ -50,11 +50,13 @@ unresolvable DNS fail closed). The multicast ranges `224.0.0.0/4` and
 `ff00::/8` were added to the shared private-network definitions to close the
 multicast gap. IPv6 forms that embed an IPv4 destination are unwrapped to
 their embedded IPv4 before checks — IPv4-mapped (`::ffff:a.b.c.d`),
-deprecated IPv4-compatible (`::a.b.c.d`), 6to4 (`2002::/16`), Teredo
-(`2001:0000::/32`, de-obfuscated client IPv4), and NAT64 well-known prefix
-(`64:ff9b::/96`) — so `::ffff:127.0.0.1`, `2002:0a00:0001::`, and
-`64:ff9b::a9fe:a9fe` (metadata) are rejected rather than treated as public,
-while public embedded destinations (e.g. `2002:5db8:d822::`) remain allowed.
+deprecated IPv4-compatible (`::a.b.c.d`), 6to4 (`2002::/16`), and Teredo
+(`2001:0000::/32`, de-obfuscated client IPv4) — so `::ffff:127.0.0.1` and
+`2002:0a00:0001::` are rejected rather than treated as public, while public
+embedded destinations (e.g. `2002:5db8:d822::`) remain allowed. The entire
+NAT64 special-purpose block `64:ff9b::/32` (well-known prefix, local-use
+prefix, and any prefix length) is rejected outright as a restricted range;
+no legitimate public host exists there.
 
 One shared async gate, `ensure_deliverable_webhook_destination()`, is used
 before every webhook dispatch, so both paths share identical validation

--- a/docs/adr/0045-outbound-webhook-destination-validation.md
+++ b/docs/adr/0045-outbound-webhook-destination-validation.md
@@ -50,11 +50,11 @@ unresolvable DNS fail closed). The multicast ranges `224.0.0.0/4` and
 `ff00::/8` were added to the shared private-network definitions to close the
 multicast gap. IPv6 forms that embed an IPv4 destination are unwrapped to
 their embedded IPv4 before checks — IPv4-mapped (`::ffff:a.b.c.d`),
-deprecated IPv4-compatible (`::a.b.c.d`), 6to4 (`2002::/16`), and Teredo
-(`2001:0000::/32`) — so `::ffff:127.0.0.1`, `2002:0a00:0001::`, and
-`::169.254.169.254`-style destinations are rejected rather than treated as
-public, while public embedded destinations (e.g. `2002:5db8:d822::`) remain
-allowed.
+deprecated IPv4-compatible (`::a.b.c.d`), 6to4 (`2002::/16`), Teredo
+(`2001:0000::/32`, de-obfuscated client IPv4), and NAT64 well-known prefix
+(`64:ff9b::/96`) — so `::ffff:127.0.0.1`, `2002:0a00:0001::`, and
+`64:ff9b::a9fe:a9fe` (metadata) are rejected rather than treated as public,
+while public embedded destinations (e.g. `2002:5db8:d822::`) remain allowed.
 
 The validator is called before every webhook dispatch:
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ An Architecture Decision Record captures an important architectural decision mad
 
 **Status legend:** accepted ADRs describe decisions used by the current implementation. Proposed ADRs are design work, not promises of current behavior. Superseded ADRs are historical context only; use their successor when documenting current behavior.
 
-**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, and 0044.
+**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, and 0045.
 
 **Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, and 0040–0042.
 
@@ -69,5 +69,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0042 | [MCP Server Architecture](0042-mcp-server-architecture.md) | proposed |
 | 0043 | [Migration from SearXNG to SlopSearX](0043-migration-to-slopsearx.md) | accepted |
 | 0044 | [Autonomous CAPTCHA Recovery](0044-autonomous-captcha-recovery.md) | accepted |
+| 0045 | [Outbound Webhook Destination Validation](0045-outbound-webhook-destination-validation.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -24,6 +24,8 @@ Persistent state is not restart-safe execution. Valkey preserves job status and 
 
 Every asynchronous creation request accepts webhook configuration. Completion and failure delivery is best effort and is not persisted for retry after process loss; verify the endpoint’s OpenAPI model for the exact field shape and sign requests with `WEBHOOK_SECRET` where configured.
 
+Webhook destinations are validated before delivery: only `http`/`https` URLs resolving to public hosts are accepted, and private, loopback, link-local, multicast, metadata, and other restricted destinations are skipped with a warning in the service log. Redirects are not followed during delivery, so a validated destination cannot be redirected to a restricted host. Monitor webhooks follow the same policy.
+
 ## Common workflows
 
 ### Research or answer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ ignore = [
 "tests/**" = ["T20"]
 "scripts/*" = ["T20"]
 "groktocrawl" = ["T20"]  # CLI output is the product interface.
+"agent-svc/agent/monitor.py" = ["T20"]  # scheduler CLI output consumed by Ofelia logs.
 "scraper-svc/scraper/app.py" = ["N815"]  # Firecrawl-compatible camelCase fields.
 "scraper-svc/scraper/adapters/github_social.py" = ["E741"]
 

--- a/tests/service/test_monitor_ssrf.py
+++ b/tests/service/test_monitor_ssrf.py
@@ -17,8 +17,8 @@ def _public_dns(monkeypatch):
     from ipaddress import ip_address
 
     monkeypatch.setattr(
-        "common.url._resolve_to_ips",
-        lambda hostname: [ip_address("93.184.216.34")],
+        "common.url._resolve_to_ips_with_transient",
+        lambda hostname: ([ip_address("93.184.216.34")], False),
     )
 
 

--- a/tests/service/test_monitor_ssrf.py
+++ b/tests/service/test_monitor_ssrf.py
@@ -123,6 +123,75 @@ class TestScrapeMonitorWebhookSsrf:
         assert len(calls) == 2
         assert calls[1].kwargs["follow_redirects"] is False
 
+    @pytest.mark.asyncio
+    async def test_transient_dns_retried_then_delivers(self, monkeypatch):
+        """Transient DNS is retried by the shared validator before delivery."""
+        from agent.monitor import check_monitor
+
+        # Skip the exponential backoff so the test does not sleep
+        monkeypatch.setattr("agent.webhook.asyncio.sleep", AsyncMock())
+
+        calls = {"n": 0}
+
+        def _flaky_resolve(hostname):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return ([], True)  # transient failure on first attempt
+            from ipaddress import ip_address
+
+            return ([ip_address("93.184.216.34")], False)
+
+        monkeypatch.setattr("common.url._resolve_to_ips_with_transient", _flaky_resolve)
+
+        config = _changed_config("https://hook.example.com/changed")
+        with (
+            patch("agent.monitor._get_redis", return_value=_fake_redis()),
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post = AsyncMock(return_value=_scrape_response())
+
+            result = await check_monitor("m1", config)
+
+        assert result["changed"] is True
+        # DNS was retried, then the webhook was delivered (scrape + webhook)
+        assert calls["n"] >= 2
+        assert mock_client.post.await_count == 2
+        assert mock_client.post.await_args.args[0] == "https://hook.example.com/changed"
+
+    @pytest.mark.asyncio
+    async def test_persistent_transient_dns_gives_up_without_posting(
+        self,
+        monkeypatch,
+    ):
+        """Persistent transient DNS never posts; the check still succeeds."""
+        from agent.monitor import check_monitor
+
+        monkeypatch.setattr("agent.webhook.asyncio.sleep", AsyncMock())
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips_with_transient", lambda hostname: ([], True)
+        )
+
+        config = _changed_config("https://hook.example.com/changed")
+        with (
+            patch("agent.monitor._get_redis", return_value=_fake_redis()),
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post = AsyncMock(return_value=_scrape_response())
+
+            result = await check_monitor("m1", config)
+
+        assert result["changed"] is True
+        # Only the scrape POST happened; the webhook validation gave up
+        mock_client.post.assert_awaited_once()
+        call_args = mock_client.post.await_args.args[0]
+        assert call_args.endswith("/scrape")
+
 
 class TestSearchMonitorWebhookSsrf:
     def _search_results(self):

--- a/tests/service/test_monitor_ssrf.py
+++ b/tests/service/test_monitor_ssrf.py
@@ -1,0 +1,229 @@
+"""SSRF guard tests for monitor webhook delivery (issue #469).
+
+Both monitor paths (scrape and search) post to a user-supplied ``webhook``
+URL when a change is detected. These tests verify that private/restricted
+destinations are rejected before any HTTP request is attempted, and that
+public destinations still deliver with redirects disabled.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Make DNS resolution hermetic: every hostname resolves to a public IP."""
+    from ipaddress import ip_address
+
+    monkeypatch.setattr(
+        "common.url._resolve_to_ips",
+        lambda hostname: [ip_address("93.184.216.34")],
+    )
+
+
+def _fake_redis():
+    r = MagicMock()
+    r.sismember.return_value = False
+    r.sadd.return_value = 1
+    r.expire.return_value = True
+    return r
+
+
+def _scrape_response():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "success": True,
+        "data": {"markdown": "NEW CONTENT"},
+    }
+    return resp
+
+
+def _changed_config(webhook_url: str) -> dict:
+    return {
+        "url": "https://example.com/page",
+        "webhook": webhook_url,
+        "last_content": "OLD CONTENT",
+        "scraper_url": "http://scraper-svc:8001",
+    }
+
+
+class TestScrapeMonitorWebhookSsrf:
+    @pytest.mark.asyncio
+    async def test_private_webhook_destination_not_posted(self):
+        """A loopback monitor webhook is skipped; the check still succeeds."""
+        from agent.monitor import check_monitor
+
+        config = _changed_config("http://127.0.0.1:8080/hook")
+
+        with (
+            patch("agent.monitor._get_redis", return_value=_fake_redis()),
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post = AsyncMock(return_value=_scrape_response())
+
+            result = await check_monitor("m1", config)
+
+        assert result["changed"] is True
+        # Only the scrape request was made — the webhook was rejected
+        mock_client.post.assert_awaited_once()
+        call_args = mock_client.post.await_args.args[0]
+        assert call_args.endswith("/scrape")
+
+    @pytest.mark.asyncio
+    async def test_rfc1918_webhook_destination_not_posted(self):
+        """A private RFC 1918 monitor webhook is skipped."""
+        from agent.monitor import check_monitor
+
+        config = _changed_config("http://192.168.1.10/hook")
+
+        with (
+            patch("agent.monitor._get_redis", return_value=_fake_redis()),
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post = AsyncMock(return_value=_scrape_response())
+
+            result = await check_monitor("m1", config)
+
+        assert result["changed"] is True
+        mock_client.post.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_public_webhook_destination_delivers_with_redirects_disabled(self):
+        """A public monitor webhook still delivers; redirects are disabled."""
+        from agent.monitor import check_monitor
+
+        config = _changed_config("https://hook.example.com/changed")
+
+        with (
+            patch("agent.monitor._get_redis", return_value=_fake_redis()),
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post = AsyncMock(return_value=_scrape_response())
+
+            result = await check_monitor("m1", config)
+
+        assert result["changed"] is True
+        # Scrape + webhook delivery
+        assert mock_client.post.await_count == 2
+        webhook_call = mock_client.post.await_args
+        assert webhook_call.args[0] == "https://hook.example.com/changed"
+        # Webhook client (second AsyncClient construction) disables redirects
+        calls = mock_client_cls.call_args_list
+        assert len(calls) == 2
+        assert calls[1].kwargs["follow_redirects"] is False
+
+
+class TestSearchMonitorWebhookSsrf:
+    def _search_results(self):
+        return [
+            {
+                "url": "https://news.example.com/article/1",
+                "title": "Example article",
+                "description": "A new result.",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_private_webhook_destination_not_posted(self):
+        """A private search-monitor webhook is skipped."""
+        from agent.monitor import run_search_monitor
+
+        config = {
+            "monitor_type": "search",
+            "search_config": {"query": "breaking news", "numResults": 10},
+            "webhook": "http://10.0.0.5/hook",
+        }
+
+        with (
+            patch("agent.monitor._get_redis", return_value=_fake_redis()),
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+            patch("agent.searxng_client.SearXNGClient") as mock_searxng_cls,
+        ):
+            mock_searxng = MagicMock()
+            mock_searxng.search = AsyncMock(
+                return_value=(self._search_results(), "healthy")
+            )
+            mock_searxng.close = AsyncMock()
+            mock_searxng_cls.return_value = mock_searxng
+
+            result = await run_search_monitor("m1", config)
+
+        assert result["changed"] is True
+        assert result["new_count"] == 1
+        # No webhook HTTP request was attempted at all
+        mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_public_webhook_destination_delivers_with_redirects_disabled(self):
+        """A public search-monitor webhook still delivers; redirects disabled."""
+        from agent.monitor import run_search_monitor
+
+        config = {
+            "monitor_type": "search",
+            "search_config": {"query": "breaking news", "numResults": 10},
+            "webhook": "https://hook.example.com/changed",
+        }
+
+        with (
+            patch("agent.monitor._get_redis", return_value=_fake_redis()),
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+            patch("agent.searxng_client.SearXNGClient") as mock_searxng_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client_cls.return_value.__aenter__.return_value = mock_client
+            mock_client.post = AsyncMock(return_value=MagicMock())
+
+            mock_searxng = MagicMock()
+            mock_searxng.search = AsyncMock(
+                return_value=(self._search_results(), "healthy")
+            )
+            mock_searxng.close = AsyncMock()
+            mock_searxng_cls.return_value = mock_searxng
+
+            result = await run_search_monitor("m1", config)
+
+        assert result["changed"] is True
+        mock_client.post.assert_awaited_once()
+        assert mock_client.post.await_args.args[0] == "https://hook.example.com/changed"
+        assert mock_client_cls.call_args.kwargs["follow_redirects"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_new_results_skips_webhook(self):
+        """Search monitor with no new results does not fire the webhook."""
+        from agent.monitor import run_search_monitor
+
+        config = {
+            "monitor_type": "search",
+            "search_config": {"query": "breaking news", "numResults": 10},
+            "webhook": "https://hook.example.com/changed",
+        }
+
+        with (
+            patch("agent.monitor.httpx.AsyncClient") as mock_client_cls,
+            patch("agent.searxng_client.SearXNGClient") as mock_searxng_cls,
+        ):
+            mock_searxng = MagicMock()
+            # All URLs already seen → no new results
+            r = _fake_redis()
+            r.sismember.return_value = True
+            mock_searxng.search = AsyncMock(return_value=([], "healthy"))
+            mock_searxng.close = AsyncMock()
+            mock_searxng_cls.return_value = mock_searxng
+
+            with patch("agent.monitor._get_redis", return_value=r):
+                result = await run_search_monitor("m1", config)
+
+        assert result["changed"] is False
+        mock_client_cls.assert_not_called()

--- a/tests/service/test_webhook.py
+++ b/tests/service/test_webhook.py
@@ -896,3 +896,37 @@ class TestWebhookSsrfGuard:
             )
         kwargs = mock_client_cls.call_args.kwargs
         assert kwargs["follow_redirects"] is False
+
+    @pytest.mark.asyncio
+    async def test_rejection_logs_redact_path_tokens(self, caplog):
+        """Rejected webhook URLs are logged without their path/query tokens."""
+        import logging
+
+        from agent.webhook import deliver_webhook
+
+        with (
+            patch("agent.webhook.httpx.AsyncClient") as mock_client_cls,
+            caplog.at_level(logging.WARNING, logger="agent.webhook"),
+        ):
+            await deliver_webhook(
+                {"url": "http://127.0.0.1:8080/services/T0000/secret-token/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+        assert "secret-token" not in caplog.text
+        assert "services" not in caplog.text
+        assert "127.0.0.1:8080" in caplog.text  # host is still useful in logs
+
+    def test_redact_webhook_url_masks_path_and_query(self):
+        from agent.webhook import _redact_webhook_url
+
+        redacted = _redact_webhook_url(
+            "https://hooks.slack.com/services/T0000/B0000/token123?x=1"
+        )
+        assert "token123" not in redacted
+        assert "hooks.slack.com" in redacted
+        assert redacted.endswith("/***")
+        assert _redact_webhook_url("not-a-url") == "<redacted>"

--- a/tests/service/test_webhook.py
+++ b/tests/service/test_webhook.py
@@ -24,14 +24,15 @@ def _public_dns(monkeypatch):
     """Make DNS resolution hermetic: every hostname resolves to a public IP.
 
     Webhook destination validation (issue #469) resolves hostnames via
-    ``common.url._resolve_to_ips``. Real lookups would be slow and
-    nondeterministic in CI, so tests stub them to a public address.
+    ``common.url._resolve_to_ips_with_transient``. Real lookups would be
+    slow and nondeterministic in CI, so tests stub them to a public
+    address.
     """
     from ipaddress import ip_address
 
     monkeypatch.setattr(
-        "common.url._resolve_to_ips",
-        lambda hostname: [ip_address("93.184.216.34")],
+        "common.url._resolve_to_ips_with_transient",
+        lambda hostname: ([ip_address("93.184.216.34")], False),
     )
 
 
@@ -738,8 +739,8 @@ class TestWebhookSsrfGuard:
         from agent.webhook import deliver_webhook
 
         monkeypatch.setattr(
-            "common.url._resolve_to_ips",
-            lambda hostname: [ip_address("192.168.1.99")],
+            "common.url._resolve_to_ips_with_transient",
+            lambda hostname: ([ip_address("192.168.1.99")], False),
         )
         with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
             await deliver_webhook(
@@ -755,7 +756,9 @@ class TestWebhookSsrfGuard:
         """An unresolvable webhook hostname is rejected (fail closed)."""
         from agent.webhook import deliver_webhook
 
-        monkeypatch.setattr("common.url._resolve_to_ips", lambda hostname: [])
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips_with_transient", lambda hostname: ([], False)
+        )
         with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
             await deliver_webhook(
                 {"url": "https://unresolvable.example.invalid/hook"},
@@ -764,6 +767,63 @@ class TestWebhookSsrfGuard:
                 data=[],
             )
             mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transient_dns_failure_retries_validation(self, monkeypatch):
+        """A transient DNS failure retries instead of dropping the webhook."""
+        from agent.webhook import deliver_webhook
+
+        calls = {"n": 0}
+
+        def _flaky_resolve(hostname):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # First attempt: transient resolver failure
+                return ([], True)
+            from ipaddress import ip_address
+
+            return ([ip_address("93.184.216.34")], False)
+
+        monkeypatch.setattr("common.url._resolve_to_ips_with_transient", _flaky_resolve)
+
+        mock_client_cls, mock_client = self._mock_client_cls()
+        with patch("agent.webhook.httpx.AsyncClient", mock_client_cls):
+            await deliver_webhook(
+                {"url": "https://hook.example.com"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+        # Transient failure was retried; the second attempt delivered
+        assert calls["n"] >= 2
+        mock_client.post.assert_called_once()
+        assert mock_client.post.call_args.args[0] == "https://hook.example.com"
+
+    @pytest.mark.asyncio
+    async def test_persistent_transient_dns_failure_gives_up_after_retries(
+        self, monkeypatch
+    ):
+        """A persistent transient DNS failure retries, then gives up silently."""
+        from agent.webhook import deliver_webhook
+
+        calls = {"n": 0}
+
+        def _always_fail(hostname):
+            calls["n"] += 1
+            return ([], True)
+
+        monkeypatch.setattr("common.url._resolve_to_ips_with_transient", _always_fail)
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "https://hook.example.com"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+        # One validation per attempt; no HTTP request was ever made
+        assert calls["n"] == 3
+        mock_client_cls.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_public_ip_literal_still_delivers(self):

--- a/tests/service/test_webhook.py
+++ b/tests/service/test_webhook.py
@@ -19,6 +19,22 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Make DNS resolution hermetic: every hostname resolves to a public IP.
+
+    Webhook destination validation (issue #469) resolves hostnames via
+    ``common.url._resolve_to_ips``. Real lookups would be slow and
+    nondeterministic in CI, so tests stub them to a public address.
+    """
+    from ipaddress import ip_address
+
+    monkeypatch.setattr(
+        "common.url._resolve_to_ips",
+        lambda hostname: [ip_address("93.184.216.34")],
+    )
+
+
 class TestSignBody:
     def test_signs_body_correctly(self):
         from agent.webhook import _sign_body
@@ -624,3 +640,146 @@ class TestDeliverWebhook:
             assert body["success"] is True
             assert body["error"] is None
             assert body["data"] == {"pages": [{"url": "https://example.com"}]}
+
+
+class TestWebhookSsrfGuard:
+    """SSRF guard for webhook destinations (issue #469)."""
+
+    def _mock_client_cls(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        mock_client = MagicMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        async def _post(*a, **kw):
+            return mock_resp
+
+        mock_client.post = MagicMock(side_effect=_post)
+        return mock_client_cls, mock_client
+
+    @pytest.mark.asyncio
+    async def test_rejects_loopback_destination(self):
+        """A loopback webhook destination is never posted to."""
+        from agent.webhook import deliver_webhook
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "http://127.0.0.1:8080/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_rfc1918_destination(self):
+        """A private RFC 1918 webhook destination is never posted to."""
+        from agent.webhook import deliver_webhook
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "http://10.0.0.5/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_link_local_destination(self):
+        """A link-local webhook destination is never posted to."""
+        from agent.webhook import deliver_webhook
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "http://169.254.169.254/latest/meta-data/"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_http_scheme(self):
+        """Non-HTTP(S) webhook destinations are never posted to."""
+        from agent.webhook import deliver_webhook
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "ftp://example.com/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_hostname_resolving_to_private_ip(self, monkeypatch):
+        """A public-looking hostname resolving to a private IP is rejected."""
+        from ipaddress import ip_address
+
+        from agent.webhook import deliver_webhook
+
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips",
+            lambda hostname: [ip_address("192.168.1.99")],
+        )
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "https://public.example.com/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_on_dns_failure(self, monkeypatch):
+        """An unresolvable webhook hostname is rejected (fail closed)."""
+        from agent.webhook import deliver_webhook
+
+        monkeypatch.setattr("common.url._resolve_to_ips", lambda hostname: [])
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "https://unresolvable.example.invalid/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_public_ip_literal_still_delivers(self):
+        """A public IP-literal webhook destination still delivers."""
+        from agent.webhook import deliver_webhook
+
+        mock_client_cls, mock_client = self._mock_client_cls()
+        with patch("agent.webhook.httpx.AsyncClient", mock_client_cls):
+            await deliver_webhook(
+                {"url": "http://93.184.216.34/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+        mock_client.post.assert_called_once()
+        args, _kwargs = mock_client.post.call_args
+        assert args[0] == "http://93.184.216.34/hook"
+
+    @pytest.mark.asyncio
+    async def test_redirects_disabled(self):
+        """Redirects are disabled on the webhook HTTP client."""
+        from agent.webhook import deliver_webhook
+
+        mock_client_cls, _ = self._mock_client_cls()
+        with patch("agent.webhook.httpx.AsyncClient", mock_client_cls):
+            await deliver_webhook(
+                {"url": "https://hook.example.com"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+        kwargs = mock_client_cls.call_args.kwargs
+        assert kwargs["follow_redirects"] is False

--- a/tests/service/test_webhook.py
+++ b/tests/service/test_webhook.py
@@ -18,6 +18,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+# Captured before the autouse _public_dns fixture patches the resolver, so
+# tests that need the real DNS behavior can restore it.
+from common import url as _common_url
+
+_REAL_RESOLVE = _common_url._resolve_to_ips_with_transient
+
 
 @pytest.fixture(autouse=True)
 def _public_dns(monkeypatch):
@@ -762,6 +768,39 @@ class TestWebhookSsrfGuard:
         with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
             await deliver_webhook(
                 {"url": "https://unresolvable.example.invalid/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_destination_does_not_crash_delivery(self):
+        """Malformed destinations are skipped without leaking parser errors."""
+        from agent.webhook import deliver_webhook
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            # Malformed IPv6 brackets: must not raise out of deliver_webhook
+            await deliver_webhook(
+                {"url": "http://[::1/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_overlong_label_destination_does_not_crash_delivery(
+        self, monkeypatch
+    ):
+        """A >63-char hostname label is skipped without leaking UnicodeError."""
+        from agent.webhook import deliver_webhook
+
+        # Restore real resolution so the IDNA label-too-long path is exercised
+        monkeypatch.setattr("common.url._resolve_to_ips_with_transient", _REAL_RESOLVE)
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": f"http://{'a' * 64}.example.com/hook"},
                 "crawl.completed",
                 "job-1",
                 data=[],

--- a/tests/service/test_webhook.py
+++ b/tests/service/test_webhook.py
@@ -703,6 +703,20 @@ class TestWebhookSsrfGuard:
             mock_client_cls.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_rejects_ipv4_mapped_loopback_destination(self):
+        """An IPv4-mapped IPv6 loopback destination is never posted to."""
+        from agent.webhook import deliver_webhook
+
+        with patch("agent.webhook.httpx.AsyncClient") as mock_client_cls:
+            await deliver_webhook(
+                {"url": "http://[::ffff:127.0.0.1]:8080/hook"},
+                "crawl.completed",
+                "job-1",
+                data=[],
+            )
+            mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_rejects_non_http_scheme(self):
         """Non-HTTP(S) webhook destinations are never posted to."""
         from agent.webhook import deliver_webhook

--- a/tests/service/test_webhook.py
+++ b/tests/service/test_webhook.py
@@ -930,3 +930,14 @@ class TestWebhookSsrfGuard:
         assert "hooks.slack.com" in redacted
         assert redacted.endswith("/***")
         assert _redact_webhook_url("not-a-url") == "<redacted>"
+
+    def test_redact_webhook_url_masks_userinfo(self):
+        from agent.webhook import _redact_webhook_url
+
+        redacted = _redact_webhook_url(
+            "https://user:supersecret@hooks.example.com:8443/path/token"
+        )
+        assert "user" not in redacted
+        assert "supersecret" not in redacted
+        assert "token" not in redacted
+        assert "hooks.example.com:8443" in redacted

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -133,10 +133,20 @@ class TestIsPrivateHost:
         assert not is_private_host("http://[2002:5db8:d822::]/test")
 
     def test_teredo_private(self):
-        assert is_private_host("http://[2001:0000:0a00:0001::]/test")
+        # Client IPv4 is XOR-obscured: 10.0.0.1 -> f5ff:fffe
+        assert is_private_host("http://[2001::f5ff:fffe]/test")
 
     def test_teredo_public(self):
-        assert not is_private_host("http://[2001:0000:5db8:d822::]/test")
+        # Client IPv4 is XOR-obscured: 93.184.216.34 -> a247:27dd
+        assert not is_private_host("http://[2001::a247:27dd]/test")
+
+    def test_nat64_private(self):
+        assert is_private_host("http://[64:ff9b::a00:1]/test")
+        assert is_private_host("http://[64:ff9b::7f00:1]/test")
+        assert is_private_host("http://[64:ff9b::a9fe:a9fe]/test")
+
+    def test_nat64_public(self):
+        assert not is_private_host("http://[64:ff9b::5db8:d822]/test")
 
 
 class TestConstants:
@@ -243,15 +253,19 @@ class TestValidateOutboundWebhookUrl:
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://[2002:0a00:0001::]/hook")
         with pytest.raises(ValueError):
-            validate_outbound_webhook_url("http://[2001:0000:0a00:0001::]/hook")
+            validate_outbound_webhook_url("http://[2001::f5ff:fffe]/hook")
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://[2002:7f00:0001::]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[64:ff9b::a00:1]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[64:ff9b::a9fe:a9fe]/hook")
 
     def test_accepts_encapsulated_ipv4_public(self):
         assert validate_outbound_webhook_url("https://[2002:5db8:d822::]/hook") is None
+        assert validate_outbound_webhook_url("https://[2001::a247:27dd]/hook") is None
         assert (
-            validate_outbound_webhook_url("https://[2001:0000:5db8:d822::]/hook")
-            is None
+            validate_outbound_webhook_url("https://[64:ff9b::5db8:d822]/hook") is None
         )
 
     def test_rejects_hostname_resolving_to_ipv4_mapped_private(self, monkeypatch):

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -1,5 +1,7 @@
 """Unit tests for the shared URL utility module (common/url.py)."""
 
+import pytest
+
 from common.url import (
     _METADATA_IPS,
     _PRIVATE_HOSTNAME_SUFFIXES,
@@ -8,6 +10,7 @@ from common.url import (
     is_private_host,
     is_same_origin,
     normalize_url,
+    validate_outbound_webhook_url,
 )
 
 
@@ -120,3 +123,111 @@ class TestConstants:
 
     def test_docker_hostname_suffixes(self):
         assert ".docker.internal" in _PRIVATE_HOSTNAME_SUFFIXES
+
+
+class TestValidateOutboundWebhookUrl:
+    """SSRF guard for outbound webhook destinations (issue #469)."""
+
+    def test_accepts_public_https(self):
+        assert validate_outbound_webhook_url("https://example.com/hook") is None
+
+    def test_accepts_public_http(self):
+        assert validate_outbound_webhook_url("http://example.com/hook") is None
+
+    def test_accepts_public_ip(self):
+        assert validate_outbound_webhook_url("https://93.184.216.34/hook") is None
+
+    def test_rejects_missing_url(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url(None)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("   ")
+
+    def test_rejects_non_http_schemes(self):
+        for bad in (
+            "ftp://example.com/hook",
+            "file:///etc/passwd",
+            "gopher://example.com/hook",
+            "//example.com/hook",  # scheme-less
+            "example.com/hook",  # not a URL
+        ):
+            with pytest.raises(ValueError):
+                validate_outbound_webhook_url(bad)
+
+    def test_rejects_malformed_without_hostname(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("https:///path")
+
+    def test_rejects_loopback(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://127.0.0.1:8080/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://localhost/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("https://[::1]/hook")
+
+    def test_rejects_rfc1918(self):
+        for host in ("10.0.0.1", "172.16.0.1", "192.168.1.1"):
+            with pytest.raises(ValueError):
+                validate_outbound_webhook_url(f"http://{host}/hook")
+
+    def test_rejects_link_local_and_metadata(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://169.254.1.1/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_rejects_ipv6_ula_and_link_local(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("https://[fd00::1]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("https://[fe80::1]/hook")
+
+    def test_rejects_multicast(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://224.0.0.1/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://239.255.255.250/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("https://[ff02::1]/hook")
+
+    def test_rejects_docker_internal_hostname(self, monkeypatch):
+        monkeypatch.setattr("common.url._resolve_to_ips", lambda hostname: [])
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://host.docker.internal:8080/hook")
+
+    def test_rejects_hostname_resolving_to_private_ip(self, monkeypatch):
+        from ipaddress import ip_address
+
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips",
+            lambda hostname: [ip_address("10.0.0.7")],
+        )
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://public.example.com/hook")
+
+    def test_rejects_hostname_resolving_to_metadata(self, monkeypatch):
+        from ipaddress import ip_address
+
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips",
+            lambda hostname: [ip_address("169.254.169.254")],
+        )
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://metadata.example.com/hook")
+
+    def test_fails_closed_on_dns_failure(self, monkeypatch):
+        monkeypatch.setattr("common.url._resolve_to_ips", lambda hostname: [])
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://unresolvable.example.invalid/hook")
+
+    def test_accepts_hostname_resolving_to_public_ip(self, monkeypatch):
+        from ipaddress import ip_address
+
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips",
+            lambda hostname: [ip_address("93.184.216.34")],
+        )
+        assert validate_outbound_webhook_url("http://public.example.com/hook") is None

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -123,6 +123,21 @@ class TestIsPrivateHost:
     def test_ipv4_mapped_public(self):
         assert not is_private_host("http://[::ffff:93.184.216.34]/test")
 
+    def test_ipv4_compatible_private(self):
+        assert is_private_host("http://[::10.0.0.1]/test")
+
+    def test_6to4_private(self):
+        assert is_private_host("http://[2002:0a00:0001::]/test")
+
+    def test_6to4_public(self):
+        assert not is_private_host("http://[2002:5db8:d822::]/test")
+
+    def test_teredo_private(self):
+        assert is_private_host("http://[2001:0000:0a00:0001::]/test")
+
+    def test_teredo_public(self):
+        assert not is_private_host("http://[2001:0000:5db8:d822::]/test")
+
 
 class TestConstants:
     """Verify module-level constants are well-formed."""
@@ -220,6 +235,23 @@ class TestValidateOutboundWebhookUrl:
     def test_accepts_ipv4_mapped_public(self):
         assert (
             validate_outbound_webhook_url("https://[::ffff:93.184.216.34]/hook") is None
+        )
+
+    def test_rejects_encapsulated_ipv4_private(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[::10.0.0.1]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[2002:0a00:0001::]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[2001:0000:0a00:0001::]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[2002:7f00:0001::]/hook")
+
+    def test_accepts_encapsulated_ipv4_public(self):
+        assert validate_outbound_webhook_url("https://[2002:5db8:d822::]/hook") is None
+        assert (
+            validate_outbound_webhook_url("https://[2001:0000:5db8:d822::]/hook")
+            is None
         )
 
     def test_rejects_hostname_resolving_to_ipv4_mapped_private(self, monkeypatch):

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -226,14 +226,16 @@ class TestValidateOutboundWebhookUrl:
         from ipaddress import ip_address
 
         monkeypatch.setattr(
-            "common.url._resolve_to_ips",
-            lambda hostname: [ip_address("::ffff:10.0.0.7")],
+            "common.url._resolve_to_ips_with_transient",
+            lambda hostname: ([ip_address("::ffff:10.0.0.7")], False),
         )
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://public.example.com/hook")
 
     def test_rejects_docker_internal_hostname(self, monkeypatch):
-        monkeypatch.setattr("common.url._resolve_to_ips", lambda hostname: [])
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips_with_transient", lambda hostname: ([], False)
+        )
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://host.docker.internal:8080/hook")
 
@@ -241,8 +243,8 @@ class TestValidateOutboundWebhookUrl:
         from ipaddress import ip_address
 
         monkeypatch.setattr(
-            "common.url._resolve_to_ips",
-            lambda hostname: [ip_address("10.0.0.7")],
+            "common.url._resolve_to_ips_with_transient",
+            lambda hostname: ([ip_address("10.0.0.7")], False),
         )
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://public.example.com/hook")
@@ -251,22 +253,49 @@ class TestValidateOutboundWebhookUrl:
         from ipaddress import ip_address
 
         monkeypatch.setattr(
-            "common.url._resolve_to_ips",
-            lambda hostname: [ip_address("169.254.169.254")],
+            "common.url._resolve_to_ips_with_transient",
+            lambda hostname: ([ip_address("169.254.169.254")], False),
         )
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://metadata.example.com/hook")
 
     def test_fails_closed_on_dns_failure(self, monkeypatch):
-        monkeypatch.setattr("common.url._resolve_to_ips", lambda hostname: [])
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips_with_transient", lambda hostname: ([], False)
+        )
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://unresolvable.example.invalid/hook")
+
+    def test_transient_dns_failure_raises_retryable_error(self, monkeypatch):
+        from common.url import WebhookDestinationDNSRetryableError
+
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips_with_transient", lambda hostname: ([], True)
+        )
+        with pytest.raises(WebhookDestinationDNSRetryableError):
+            validate_outbound_webhook_url("http://public.example.com/hook")
+
+    def test_transient_dns_failure_is_validation_error(self, monkeypatch):
+        from common.url import (
+            WebhookDestinationDNSRetryableError,
+            WebhookDestinationValidationError,
+        )
+
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips_with_transient", lambda hostname: ([], True)
+        )
+        try:
+            validate_outbound_webhook_url("http://public.example.com/hook")
+        except WebhookDestinationDNSRetryableError as exc:
+            assert isinstance(exc, WebhookDestinationValidationError)
+        else:
+            raise AssertionError("expected retryable DNS error")
 
     def test_accepts_hostname_resolving_to_public_ip(self, monkeypatch):
         from ipaddress import ip_address
 
         monkeypatch.setattr(
-            "common.url._resolve_to_ips",
-            lambda hostname: [ip_address("93.184.216.34")],
+            "common.url._resolve_to_ips_with_transient",
+            lambda hostname: ([ip_address("93.184.216.34")], False),
         )
         assert validate_outbound_webhook_url("http://public.example.com/hook") is None

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -109,6 +109,20 @@ class TestIsPrivateHost:
     def test_relative_url(self):
         assert is_private_host("/relative/path")
 
+    def test_ipv4_mapped_loopback(self):
+        assert is_private_host("http://[::ffff:127.0.0.1]/test")
+
+    def test_ipv4_mapped_rfc1918(self):
+        assert is_private_host("http://[::ffff:10.0.0.1]/test")
+        assert is_private_host("http://[::ffff:172.16.5.5]/test")
+        assert is_private_host("http://[::ffff:192.168.1.1]/test")
+
+    def test_ipv4_mapped_metadata(self):
+        assert is_private_host("http://[::ffff:169.254.169.254]/")
+
+    def test_ipv4_mapped_public(self):
+        assert not is_private_host("http://[::ffff:93.184.216.34]/test")
+
 
 class TestConstants:
     """Verify module-level constants are well-formed."""
@@ -192,6 +206,31 @@ class TestValidateOutboundWebhookUrl:
             validate_outbound_webhook_url("http://239.255.255.250/hook")
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("https://[ff02::1]/hook")
+
+    def test_rejects_ipv4_mapped_private(self):
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[::ffff:127.0.0.1]:8080/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[::ffff:10.0.0.1]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[::ffff:192.168.1.1]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[::ffff:169.254.169.254]/hook")
+
+    def test_accepts_ipv4_mapped_public(self):
+        assert (
+            validate_outbound_webhook_url("https://[::ffff:93.184.216.34]/hook") is None
+        )
+
+    def test_rejects_hostname_resolving_to_ipv4_mapped_private(self, monkeypatch):
+        from ipaddress import ip_address
+
+        monkeypatch.setattr(
+            "common.url._resolve_to_ips",
+            lambda hostname: [ip_address("::ffff:10.0.0.7")],
+        )
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://public.example.com/hook")
 
     def test_rejects_docker_internal_hostname(self, monkeypatch):
         monkeypatch.setattr("common.url._resolve_to_ips", lambda hostname: [])

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -145,8 +145,17 @@ class TestIsPrivateHost:
         assert is_private_host("http://[64:ff9b::7f00:1]/test")
         assert is_private_host("http://[64:ff9b::a9fe:a9fe]/test")
 
-    def test_nat64_public(self):
-        assert not is_private_host("http://[64:ff9b::5db8:d822]/test")
+    def test_nat64_range_always_rejected(self):
+        """The whole 64:ff9b::/32 special-purpose range is rejected.
+
+        Covers the /96 well-known prefix, the /48 local-use prefix, and
+        /64-length prefixes regardless of where IPv4 is embedded, since
+        no legitimate public host lives in this IANA-reserved block.
+        """
+        assert is_private_host("http://[64:ff9b::5db8:d822]/test")
+        assert is_private_host("http://[64:ff9b:1::1]/test")
+        assert is_private_host("http://[64:ff9b:1::a00:1]/test")
+        assert is_private_host("http://[64:ff9b::1:a00:1]/test")
 
 
 class TestConstants:
@@ -261,12 +270,18 @@ class TestValidateOutboundWebhookUrl:
         with pytest.raises(ValueError):
             validate_outbound_webhook_url("http://[64:ff9b::a9fe:a9fe]/hook")
 
+    def test_rejects_nat64_range_at_validator_level(self):
+        """Every 64:ff9b::/32 address is rejected, regardless of form."""
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[64:ff9b::5db8:d822]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[64:ff9b:1::1]/hook")
+        with pytest.raises(ValueError):
+            validate_outbound_webhook_url("http://[64:ff9b:1::a00:1]/hook")
+
     def test_accepts_encapsulated_ipv4_public(self):
         assert validate_outbound_webhook_url("https://[2002:5db8:d822::]/hook") is None
         assert validate_outbound_webhook_url("https://[2001::a247:27dd]/hook") is None
-        assert (
-            validate_outbound_webhook_url("https://[64:ff9b::5db8:d822]/hook") is None
-        )
 
     def test_rejects_hostname_resolving_to_ipv4_mapped_private(self, monkeypatch):
         from ipaddress import ip_address

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -299,3 +299,31 @@ class TestValidateOutboundWebhookUrl:
             lambda hostname: ([ip_address("93.184.216.34")], False),
         )
         assert validate_outbound_webhook_url("http://public.example.com/hook") is None
+
+    def test_malformed_ipv6_brackets_rejected_cleanly(self):
+        """Malformed IPv6 brackets never leak a raw ValueError."""
+        from common.url import WebhookDestinationValidationError
+
+        with pytest.raises(WebhookDestinationValidationError):
+            validate_outbound_webhook_url("http://[::1/hook")
+
+    def test_overlong_hostname_label_rejected_cleanly(self):
+        """A >63-char label never leaks a UnicodeError."""
+        from common.url import WebhookDestinationValidationError
+
+        with pytest.raises(WebhookDestinationValidationError):
+            validate_outbound_webhook_url(f"http://{'a' * 64}.example.com/hook")
+
+    def test_unexpected_errors_become_permanent_rejection(self, monkeypatch):
+        """The public wrapper converts any unexpected error to a rejection."""
+        from common.url import (
+            WebhookDestinationValidationError,
+            validate_outbound_webhook_url,
+        )
+
+        def _boom(url):
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr("common.url._validate_outbound_webhook_url_inner", _boom)
+        with pytest.raises(WebhookDestinationValidationError):
+            validate_outbound_webhook_url("https://example.com/hook")


### PR DESCRIPTION
Closes #469.

## Summary
Webhook delivery posted to user-supplied URLs without applying the shared private-host SSRF guard used by scraping. This PR applies the guard to every outbound delivery path — job webhooks (`agent/webhook.py`) and monitor webhooks (`agent/monitor.py`) — via a single shared validator.

## Changes
- **`common/url.py`**: new `validate_outbound_webhook_url()` — explicit `http`/`https` only, hostname required, rejects loopback, RFC 1918, link-local, multicast, metadata endpoints, and DNS names resolving to restricted addresses (unresolvable DNS fails closed). Also extends `_PRIVATE_NETWORKS` with multicast ranges `224.0.0.0/4` and `ff00::/8`, hardening scraper/browser/crawler paths too.
- **`agent/webhook.py`**: validates before every dispatch (after events filter, before payload build); rejected destinations log a warning and are skipped — no retries, jobs complete normally. Redirects disabled (`follow_redirects=False`) so a validated public URL cannot redirect to a restricted host.
- **`agent/monitor.py`**: both `check_monitor()` and `run_search_monitor()` validate before the notify POST, same policy, redirects disabled.
- **Tests**: validator unit tests, hermetic DNS fixture + SSRF delivery tests in `tests/service/test_webhook.py`, new `tests/service/test_monitor_ssrf.py`.
- **Docs**: ADR-0045 (accepted) + index row, note in `docs/guides/api.md`.
- **Lint**: `pyproject.toml` allows T20 for `agent/monitor.py` (scheduler CLI output consumed by Ofelia logs, same rationale as the `groktocrawl` CLI ignore); removed an unused unpacked variable flagged by RUF059.

## Acceptance criteria
- [x] Requests targeting localhost, RFC 1918, loopback IPv6, link-local, and DNS names resolving to restricted addresses are rejected
- [x] A redirect from a public-looking URL to a restricted target cannot reach that target (redirects disabled)
- [x] Valid public HTTPS webhook delivery remains covered by tests
- [x] Normal and monitor paths share the same validation behavior

## Validation
- Targeted tests: 82 passed; full `tests/unit` + `tests/service`: 877 passed (pre-existing env-only failures unrelated: `curl_cffi`/`llm_svc` imports)
- mypy clean on changed modules; pre-commit (ruff lint + format, gitleaks, etc.) passes