### PR TITLE
test(url): assert permanent rejection for overlong hostnames

### DIFF
--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -375,12 +375,16 @@ class TestValidateOutboundWebhookUrl:
         with pytest.raises(WebhookDestinationValidationError):
             validate_outbound_webhook_url(f"http://{'a' * 64}.example.com/hook")
 
-    def test_overlong_hostname_label_is_permanent_rejection(self):
+    def test_overlong_hostname_label_is_permanent_rejection(self, monkeypatch):
         from common.url import (
             WebhookDestinationDNSRetryableError,
             WebhookDestinationValidationError,
         )
 
+        def _overlong_label(*args, **kwargs):
+            raise UnicodeError("label empty or too long")
+
+        monkeypatch.setattr("common.url.socket.getaddrinfo", _overlong_label)
         with pytest.raises(WebhookDestinationValidationError) as exc_info:
             validate_outbound_webhook_url(f"http://{'a' * 64}.example.com/hook")
         assert not isinstance(exc_info.value, WebhookDestinationDNSRetryableError)

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -375,6 +375,13 @@ class TestValidateOutboundWebhookUrl:
         with pytest.raises(WebhookDestinationValidationError):
             validate_outbound_webhook_url(f"http://{'a' * 64}.example.com/hook")
 
+    def test_overlong_hostname_label_is_permanent_rejection(self):
+        from common.url import WebhookDestinationValidationError
+
+        with pytest.raises(WebhookDestinationValidationError) as exc_info:
+            validate_outbound_webhook_url(f"http://{'a' * 64}.example.com/hook")
+        assert type(exc_info.value) is WebhookDestinationValidationError
+
     def test_unexpected_errors_become_permanent_rejection(self, monkeypatch):
         """The public wrapper converts any unexpected error to a rejection."""
         from common.url import (

--- a/tests/unit/test_urlutil.py
+++ b/tests/unit/test_urlutil.py
@@ -376,11 +376,14 @@ class TestValidateOutboundWebhookUrl:
             validate_outbound_webhook_url(f"http://{'a' * 64}.example.com/hook")
 
     def test_overlong_hostname_label_is_permanent_rejection(self):
-        from common.url import WebhookDestinationValidationError
+        from common.url import (
+            WebhookDestinationDNSRetryableError,
+            WebhookDestinationValidationError,
+        )
 
         with pytest.raises(WebhookDestinationValidationError) as exc_info:
             validate_outbound_webhook_url(f"http://{'a' * 64}.example.com/hook")
-        assert type(exc_info.value) is WebhookDestinationValidationError
+        assert not isinstance(exc_info.value, WebhookDestinationDNSRetryableError)
 
     def test_unexpected_errors_become_permanent_rejection(self, monkeypatch):
         """The public wrapper converts any unexpected error to a rejection."""


### PR DESCRIPTION
## Summary

Strengthen the webhook URL validator tests with an assertion that overlong DNS labels remain permanent, non-retryable validation rejections, preventing a permanent validation rejection from silently regressing into a retryable DNS failure.

## Related Issue

Closes #506

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [ ] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [x] New test added for the permanent-versus-retryable exception contract
- [x] Manual verification: `python -m pytest -o addopts='' -q tests/unit/test_urlutil.py` → 67 passed; the hermetic resolver fixture and exact survivor replay both exercise the permanent-versus-retryable boundary, with the mutant yielding 66 passed and 1 failed; Ruff, compile, and diff checks pass

The repository-default focused command was not used as the gate because its
whole-suite coverage settings are not meaningful for a single module on this
host; the project CI remains responsible for the complete configured suite.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CONTRIBUTING.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

The production implementation is unchanged. This PR closes a mutation-identified
test gap rather than claiming an active runtime defect. The test asserts the
semantic invariant that malformed hostnames are not retryable, leaves room for
future permanent-rejection subclasses, and stubs the resolver so the case is
hermetic and never performs a live DNS lookup.

This change was prepared with OpenCode and independently reviewed before
submission. I don't run continuously, so responses may take 24–48 hours.
