### PR TITLE
test: govern skip, xfail, and xpass lifecycle

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -319,6 +319,7 @@ jobs:
           docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 -q
           set +e
           docker compose exec -T agent-svc env \
+            QA_OUTCOME_PATH=/app/qa-outcomes-critical.json \
             PYTHONPATH=/app/agent-svc:/app/scraper-svc:/app/llm-svc:/app/parse-svc:/app/portal-svc:/app/browser-svc:/app \
             SCRAPER_BASE_URL=http://scraper-svc:8001 \
             SEARCH_BASE_URL=http://slopsearx:8080 \
@@ -328,6 +329,9 @@ jobs:
             SEMANTIC_BASE_URL=http://semantic-svc:8003 \
             python3 -m pytest /app/tests/integration/test_critical_journey.py -vv -rA
           pytest_status=$?
+          svc=$(docker compose ps -q agent-svc)
+          docker cp "$svc:/app/qa-outcomes-critical.json" qa-outcomes-critical.json || true
+          docker cp "$svc:/app/qa-outcomes-critical.md" qa-outcomes-critical.md || true
           if [ "$pytest_status" -ne 0 ]; then
             docker compose logs --tail 50 test-site scraper-svc || true
           fi
@@ -340,7 +344,9 @@ jobs:
       - name: Run integration tests
         run: |
           docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 PyYAML -q
+          set +e
           docker compose exec -T agent-svc env \
+            QA_OUTCOME_PATH=/app/qa-outcomes-integration.json \
             PYTHONPATH=/app/agent-svc:/app/scraper-svc:/app/llm-svc:/app/parse-svc:/app/portal-svc:/app/browser-svc:/app \
             SCRAPER_BASE_URL=http://scraper-svc:8001 \
             SEARCH_BASE_URL=http://slopsearx:8080 \
@@ -349,7 +355,24 @@ jobs:
             TIER3_FIXTURE_BASE_URL=http://tier3-fixture:8000 \
             SEMANTIC_BASE_URL=http://semantic-svc:8003 \
             python3 -m pytest /app/tests/integration/ /app/tests/service/ --timeout=120 --ignore-glob='*observability*' --ignore=/app/tests/integration/test_critical_journey.py -m 'not external'
+          pytest_status=$?
+          svc=$(docker compose ps -q agent-svc)
+          docker cp "$svc:/app/qa-outcomes-integration.json" qa-outcomes-integration.json || true
+          docker cp "$svc:/app/qa-outcomes-integration.md" qa-outcomes-integration.md || true
+          exit "$pytest_status"
         timeout-minutes: 20
+
+      - name: Publish integration outcome summary
+        if: always()
+        run: cat qa-outcomes-*.md >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Upload integration outcome reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-test-outcomes
+          path: qa-outcomes-*
+          if-no-files-found: warn
 
       - name: Collect diagnostics on failure
         if: failure()

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -343,7 +343,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 PyYAML -q
+          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-xdist pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 PyYAML -q
           set +e
           docker compose exec -T agent-svc env \
             QA_OUTCOME_PATH=/app/qa-outcomes-integration.json \

--- a/.github/workflows/fast-tests.yml
+++ b/.github/workflows/fast-tests.yml
@@ -20,6 +20,25 @@ jobs:
       - name: Install declared test dependencies
         run: uv sync --locked --no-dev --group fast-tests
       - name: Run unit and service tests
+        env:
+          QA_OUTCOME_PATH: ${{ github.workspace }}/qa-outcomes-fast.json
         run: >-
           PYTHONPATH=agent-svc:scraper-svc:llm-svc:parse-svc:portal-svc:browser-svc:semantic-svc:.
           uv run --no-sync pytest tests/unit/ tests/service/ --no-cov
+
+      - name: Publish test outcome summary
+        if: always()
+        run: |
+          if [ -f qa-outcomes-fast.md ]; then
+            cat qa-outcomes-fast.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "QA outcome report unavailable; pytest did not reach session finish." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload test outcome reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fast-test-outcomes
+          path: qa-outcomes-fast.*
+          if-no-files-found: warn

--- a/docs/testing-outcome-governance.md
+++ b/docs/testing-outcome-governance.md
@@ -70,28 +70,33 @@ xfail markers were removed:
 - `tests/integration/test_stack.py::test_gutenberg_adapter_cache_url`
 - `tests/integration/test_stack.py::test_gutenberg_adapter_invalid_id`
 
-The remaining seven declared strict xfails are `quarantined` and retain
+The remaining six declared strict xfails are `quarantined` and retain
 explicit owner, issue, reason, and environment metadata:
 
 - `tests/integration/test_stack.py::test_scraper_uses_llms_txt`
 - `tests/integration/test_stack.py::test_shodan_adapter_source`
-- `tests/integration/test_stack.py::test_crtsh_adapter_domain`
 - `tests/integration/test_stack.py::test_abuseipdb_adapter_ip`
 - `tests/integration/test_stack.py::test_censys_adapter_ip`
 - `tests/integration/test_stack.py::test_hibp_adapter_breach`
 - `tests/integration/test_stack.py::test_crawl_semantic_indexing`
 
-The exact `7daac65` Docker run observed five of these as xfailed; the
-Qdrant-dependent case was conditionally skipped by its Docker/environment gate,
-and CRT.sh appeared as an XPASS. A subsequent exact `2931797` run received a
-502 Bad Gateway response from CRT.sh, so the XPASS was correctly treated as
-external instability rather than a fixed/re-enabled test, and its strict
-quarantine was restored. The two setup errors were caused by passing
-governance-only keyword arguments into pytest's native skip markers; the
-governance hook now validates and retains those fields on the collected item,
-then strips only the native-marker-incompatible fields before pytest evaluates
-the marker. Shared class-level markers are sanitized only after all collected
-items have been validated.
+`tests/integration/test_stack.py::test_crtsh_adapter_domain` is classified as
+`retained`, not `fixed/re-enabled`: exact CI runs observed both a 502 failure and
+a successful response from CRT.sh. It is skipped by default as an explicit
+environment-dependent case and can be run with `RUN_EXTERNAL_TESTS=1` when a
+caller accepts the third-party availability risk.
+
+The exact `7daac65` Docker run observed five of the original quarantines as
+xfailed; the Qdrant-dependent case was conditionally skipped by its
+Docker/environment gate, and CRT.sh appeared as an XPASS. A subsequent exact
+run received a 502 Bad Gateway response from CRT.sh, confirming that the
+unexpected pass was external instability rather than a fixed/re-enabled test.
+The two setup errors were caused by passing governance-only keyword arguments
+into pytest's native skip markers; the governance hook now validates and
+retains those fields on the collected item, then strips only the
+native-marker-incompatible fields before pytest evaluates the marker. Shared
+class-level markers are sanitized only after all collected items have been
+validated.
 
 Outcome mapping is:
 

--- a/docs/testing-outcome-governance.md
+++ b/docs/testing-outcome-governance.md
@@ -40,16 +40,36 @@ to the GitHub Actions Job Summary.
 
 ## Baseline and Classification
 
-The observed baseline for the current main lineage was **147 skipped, 6
-xfailing, and 13 xpassing** in the reported integration run. The issue body
-also cites an earlier **147 skipped, 4 xfailed, and 15 xpassed** run. These are
-different runs, not interchangeable counts; dependency state and selected
-tests changed between them.
+The issue body cites an earlier **147 skipped, 4 xfailed, and 15 xpassed** run.
+A later exact-head run on PR #509 at `41d13c5` selected a different set and
+reported **951 passed, 144 skipped, 6 xfailed, 13 xpassed, and 2 setup
+errors**. These are different runs, not interchangeable counts. The exact
+node IDs from the later run are the authoritative input for this triage.
 
-This change does not claim that the baseline is fully classified because CI
-has not supplied exact xpass node IDs. Strict xpass failures are triaged by
-exact node ID and metadata first. Only then may an obsolete xfail marker be
-removed and the test classified as `fixed/re-enabled` or `deleted`.
+The 13 xpasses were classified as `fixed/re-enabled` and their stale strict
+xfail markers were removed:
+
+- `tests/integration/test_stack.py::test_scraper_uses_accept_markdown`
+- `tests/integration/test_stack.py::test_mitreattack_adapter_technique`
+- `tests/integration/test_stack.py::test_virustotal_adapter_file`
+- `tests/integration/test_stack.py::test_index_structure`
+- `tests/integration/test_stack.py::test_near_dup_detection_skip_mode`
+- `tests/integration/test_stack.py::test_near_dup_detection_update_mode`
+- `tests/integration/test_stack.py::test_near_dup_different_content`
+- `tests/integration/test_stack.py::test_batch_index_endpoint`
+- `tests/integration/test_stack.py::test_batch_index_empty`
+- `tests/integration/test_stack.py::test_gutenberg_adapter_known_book`
+- `tests/integration/test_stack.py::test_gutenberg_adapter_files_url`
+- `tests/integration/test_stack.py::test_gutenberg_adapter_cache_url`
+- `tests/integration/test_stack.py::test_gutenberg_adapter_invalid_id`
+
+The remaining seven declared strict xfails are `quarantined` and retain
+explicit owner, issue, reason, and environment metadata. The two setup errors
+were caused by passing governance-only keyword arguments into pytest's native
+skip markers; the governance hook now validates and retains those fields on
+the collected item, then strips only the native-marker-incompatible fields
+before pytest evaluates the marker. Shared class-level markers are sanitized
+only after all collected items have been validated.
 
 Outcome mapping is:
 

--- a/docs/testing-outcome-governance.md
+++ b/docs/testing-outcome-governance.md
@@ -1,0 +1,59 @@
+# Test Outcome Governance
+
+## Metadata
+
+Every root `tests/` skip, skip condition, and expected failure carries these
+fields:
+
+```python
+pytest.mark.xfail(
+    strict=True,
+    reason="why this is currently expected",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="the explicit condition that justifies it",
+)
+```
+
+Runtime conditions use `tests.outcome_governance.governed_skip` with the same
+fields. `classification` is one of `retained`, `fixed/re-enabled`,
+`quarantined`, or `deleted`. Use `retained` for environment-dependent skips and
+`quarantined` for current xfails. A review date may replace `environment` when
+the condition is not environment-dependent.
+
+## Reports
+
+The pytest hooks write `test-outcomes.json` and `test-outcomes.md` locally.
+Set `QA_OUTCOME_PATH` to choose the JSON path; the Markdown report uses the
+same stem. For example:
+
+```bash
+PYTHONPATH=agent-svc:scraper-svc:llm-svc:parse-svc:portal-svc:browser-svc:semantic-svc:. \
+QA_OUTCOME_PATH=artifacts/qa-outcomes.json \
+python -m pytest tests/unit/ tests/service/ --no-cov
+```
+
+Fast Tests uploads `fast-test-outcomes`. Docker Integration uploads
+`integration-test-outcomes`. Both workflows also publish the Markdown report
+to the GitHub Actions Job Summary.
+
+## Baseline and Classification
+
+The observed baseline for the current main lineage was **147 skipped, 6
+xfailing, and 13 xpassing** in the reported integration run. The issue body
+also cites an earlier **147 skipped, 4 xfailed, and 15 xpassed** run. These are
+different runs, not interchangeable counts; dependency state and selected
+tests changed between them.
+
+This change does not claim that the baseline is fully classified because CI
+has not supplied exact xpass node IDs. Strict xpass failures are triaged by
+exact node ID and metadata first. Only then may an obsolete xfail marker be
+removed and the test classified as `fixed/re-enabled` or `deleted`.
+
+Outcome mapping is:
+
+- `retained`: a justified environment-dependent skip remains necessary.
+- `fixed/re-enabled`: the expected failure is fixed and the test runs normally.
+- `quarantined`: the test remains an explicitly tracked strict xfail.
+- `deleted`: the test or marker is obsolete and removed with its tracking record.

--- a/docs/testing-outcome-governance.md
+++ b/docs/testing-outcome-governance.md
@@ -46,7 +46,7 @@ reported **951 passed, 144 skipped, 6 xfailed, 13 xpassed, and 2 setup
 errors**. These are different runs, not interchangeable counts. The exact
 node IDs from the later run are the authoritative input for this triage.
 
-The 14 xpasses were classified as `fixed/re-enabled` and their stale strict
+The 13 xpasses were classified as `fixed/re-enabled` and their stale strict
 xfail markers were removed:
 
 - `tests/integration/test_stack.py::test_scraper_uses_accept_markdown`
@@ -62,28 +62,29 @@ xfail markers were removed:
 - `tests/integration/test_stack.py::test_gutenberg_adapter_files_url`
 - `tests/integration/test_stack.py::test_gutenberg_adapter_cache_url`
 - `tests/integration/test_stack.py::test_gutenberg_adapter_invalid_id`
-- `tests/integration/test_stack.py::test_crtsh_adapter_domain`
 
-The remaining six declared strict xfails are `quarantined` and retain
+The remaining seven declared strict xfails are `quarantined` and retain
 explicit owner, issue, reason, and environment metadata:
 
 - `tests/integration/test_stack.py::test_scraper_uses_llms_txt`
 - `tests/integration/test_stack.py::test_shodan_adapter_source`
+- `tests/integration/test_stack.py::test_crtsh_adapter_domain`
 - `tests/integration/test_stack.py::test_abuseipdb_adapter_ip`
 - `tests/integration/test_stack.py::test_censys_adapter_ip`
 - `tests/integration/test_stack.py::test_hibp_adapter_breach`
 - `tests/integration/test_stack.py::test_crawl_semantic_indexing`
 
 The exact `7daac65` Docker run observed five of these as xfailed; the
-Qdrant-dependent case was conditionally skipped by its Docker/environment gate.
-That run also exposed `test_crtsh_adapter_domain` as an XPASS, so its stale
-quarantine was removed and it is now included in the fixed/re-enabled list
-above. The two setup errors were caused by passing governance-only keyword
-arguments into pytest's native skip markers; the governance hook now validates
-and retains those fields on the collected item, then strips only the
-native-marker-incompatible fields before pytest evaluates the marker. Shared
-class-level markers are sanitized only after all collected items have been
-validated.
+Qdrant-dependent case was conditionally skipped by its Docker/environment gate,
+and CRT.sh appeared as an XPASS. A subsequent exact `2931797` run received a
+502 Bad Gateway response from CRT.sh, so the XPASS was correctly treated as
+external instability rather than a fixed/re-enabled test, and its strict
+quarantine was restored. The two setup errors were caused by passing
+governance-only keyword arguments into pytest's native skip markers; the
+governance hook now validates and retains those fields on the collected item,
+then strips only the native-marker-incompatible fields before pytest evaluates
+the marker. Shared class-level markers are sanitized only after all collected
+items have been validated.
 
 Outcome mapping is:
 

--- a/docs/testing-outcome-governance.md
+++ b/docs/testing-outcome-governance.md
@@ -46,7 +46,7 @@ reported **951 passed, 144 skipped, 6 xfailed, 13 xpassed, and 2 setup
 errors**. These are different runs, not interchangeable counts. The exact
 node IDs from the later run are the authoritative input for this triage.
 
-The 13 xpasses were classified as `fixed/re-enabled` and their stale strict
+The 14 xpasses were classified as `fixed/re-enabled` and their stale strict
 xfail markers were removed:
 
 - `tests/integration/test_stack.py::test_scraper_uses_accept_markdown`
@@ -62,14 +62,28 @@ xfail markers were removed:
 - `tests/integration/test_stack.py::test_gutenberg_adapter_files_url`
 - `tests/integration/test_stack.py::test_gutenberg_adapter_cache_url`
 - `tests/integration/test_stack.py::test_gutenberg_adapter_invalid_id`
+- `tests/integration/test_stack.py::test_crtsh_adapter_domain`
 
-The remaining seven declared strict xfails are `quarantined` and retain
-explicit owner, issue, reason, and environment metadata. The two setup errors
-were caused by passing governance-only keyword arguments into pytest's native
-skip markers; the governance hook now validates and retains those fields on
-the collected item, then strips only the native-marker-incompatible fields
-before pytest evaluates the marker. Shared class-level markers are sanitized
-only after all collected items have been validated.
+The remaining six declared strict xfails are `quarantined` and retain
+explicit owner, issue, reason, and environment metadata:
+
+- `tests/integration/test_stack.py::test_scraper_uses_llms_txt`
+- `tests/integration/test_stack.py::test_shodan_adapter_source`
+- `tests/integration/test_stack.py::test_abuseipdb_adapter_ip`
+- `tests/integration/test_stack.py::test_censys_adapter_ip`
+- `tests/integration/test_stack.py::test_hibp_adapter_breach`
+- `tests/integration/test_stack.py::test_crawl_semantic_indexing`
+
+The exact `7daac65` Docker run observed five of these as xfailed; the
+Qdrant-dependent case was conditionally skipped by its Docker/environment gate.
+That run also exposed `test_crtsh_adapter_domain` as an XPASS, so its stale
+quarantine was removed and it is now included in the fixed/re-enabled list
+above. The two setup errors were caused by passing governance-only keyword
+arguments into pytest's native skip markers; the governance hook now validates
+and retains those fields on the collected item, then strips only the
+native-marker-incompatible fields before pytest evaluates the marker. Shared
+class-level markers are sanitized only after all collected items have been
+validated.
 
 Outcome mapping is:
 

--- a/docs/testing-outcome-governance.md
+++ b/docs/testing-outcome-governance.md
@@ -38,6 +38,13 @@ Fast Tests uploads `fast-test-outcomes`. Docker Integration uploads
 `integration-test-outcomes`. Both workflows also publish the Markdown report
 to the GitHub Actions Job Summary.
 
+Both reports include governed test outcomes and non-passed collection outcomes.
+Collection failures contribute to `failed`; module-level skips contribute to
+`skipped`; their node IDs and reason-encoded metadata are retained. When xdist
+causes the master and workers to report the same collection event, the merge
+keeps one entry per node ID using the same failure-over-skip-over-pass priority
+as test-phase aggregation.
+
 ## Baseline and Classification
 
 The issue body cites an earlier **147 skipped, 4 xfailed, and 15 xpassed** run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ asyncio_mode = "auto"
 markers = [
     "external: requires network access or a deployed external service",
 ]
-addopts = "-m 'not external' --cov=agent-svc/agent --cov=scraper-svc/scraper --cov=browser-svc/browser_svc --cov=parse-svc/parse_svc --cov=portal-svc/portal --cov=semantic-svc --cov-report=term-missing --cov-fail-under=20 --durations=10 -n auto"
+addopts = "-m 'not external' --strict-markers --strict-config --cov=agent-svc/agent --cov=scraper-svc/scraper --cov=browser-svc/browser_svc --cov=parse-svc/parse_svc --cov=portal-svc/portal --cov=semantic-svc --cov-report=term-missing --cov-fail-under=20 --durations=10 -n auto"
+xfail_strict = true
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,12 +31,23 @@ from tests.outcome_governance import (
     validate_metadata,
 )
 
+_GOVERNANCE_KEYS = {
+    "owner",
+    "issue",
+    "classification",
+    "review_date",
+    "environment",
+}
+
 
 def _report_path() -> Path:
     return Path(os.environ.get("QA_OUTCOME_PATH", "test-outcomes.json"))
 
 
 def _governance_metadata(item, report) -> dict[str, str]:
+    metadata = getattr(item, "_qa_governance_metadata", None)
+    if metadata:
+        return metadata
     for marker_name in ("skip", "skipif", "xfail"):
         marker = item.get_closest_marker(marker_name)
         if marker:
@@ -48,7 +59,9 @@ def _governance_metadata(item, report) -> dict[str, str]:
 
 def pytest_collection_modifyitems(config, items):
     violations = []
+    markers_to_strip = {}
     for item in items:
+        item_metadata = {}
         for marker_name in ("skip", "skipif", "xfail"):
             for marker in item.iter_markers(name=marker_name):
                 kwargs = marker.kwargs
@@ -63,12 +76,20 @@ def pytest_collection_modifyitems(config, items):
                     )
                 except (TypeError, ValueError) as exc:
                     violations.append(f"{item.nodeid} @{marker_name}: {exc}")
+                else:
+                    item_metadata.update(metadata_from_marker(marker))
+                    markers_to_strip[id(marker)] = marker
                 if marker_name == "xfail" and kwargs.get("strict") is not True:
                     violations.append(f"{item.nodeid} @xfail: strict=True is required")
+        if item_metadata:
+            item._qa_governance_metadata = item_metadata
     if violations:
         raise pytest.UsageError(
             "Ungoverned skip/xfail markers:\n" + "\n".join(violations)
         )
+    for marker in markers_to_strip.values():
+        for key in _GOVERNANCE_KEYS:
+            marker.kwargs.pop(key, None)
 
 
 def _outcome_entry(nodeid, report, metadata=None) -> dict:
@@ -103,7 +124,9 @@ def _outcome_entry(nodeid, report, metadata=None) -> dict:
 def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
-    if call.when != "call" and not (call.when == "setup" and report.skipped):
+    if call.when != "call" and not (
+        call.when == "setup" and (report.skipped or report.failed)
+    ):
         return
     entry = _outcome_entry(item.nodeid, report, _governance_metadata(item, report))
     _record_outcome(item.config, entry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,6 +199,9 @@ def _write_outcome_reports(config, entries=None, path=None) -> None:
 
 
 def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "external: requires network access or a deployed external service"
+    )
     config._qa_outcomes = []
     config._qa_outcome_by_nodeid = {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ def _outcome_entry(nodeid, report, metadata=None) -> dict:
         reason = str(report.longrepr[2]) if isinstance(report.longrepr, tuple) else None
     else:
         status = "failed"
-        reason = None
+        reason = str(report.longrepr) if report.longrepr else None
     if status == "passed":
         metadata = {}
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,7 @@ def pytest_sessionfinish(session, exitstatus):
             for worker_report in worker_reports:
                 entries.extend(json.loads(worker_report.read_text()).get("tests", []))
                 worker_report.unlink()
+                worker_report.with_suffix(".md").unlink(missing_ok=True)
             _write_outcome_reports(config, entries=entries)
         else:
             _write_outcome_reports(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,9 @@ def _outcome_entry(nodeid, report, metadata=None) -> dict:
     report_text = str(getattr(report, "longrepr", ""))
     if report.failed and "XPASS(strict)" in report_text:
         status = "xpassed"
-        reason = getattr(report, "wasxfail", None) or report_text
+        reason = getattr(report, "wasxfail", None) or report_text.removeprefix(
+            "[XPASS(strict)] "
+        )
     elif report.skipped and hasattr(report, "wasxfail"):
         status = "xfailed"
         reason = report.wasxfail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,7 @@ def _worker_report_path(path: Path, worker_id: str) -> Path:
     return path.with_name(f"{path.stem}.{worker_id}{path.suffix}")
 
 
+@pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node, error):
     """Collect each xdist worker's report before the master finishes."""
     config = node.config
@@ -200,6 +201,7 @@ def pytest_testnodedown(node, error):
 
 
 def pytest_sessionfinish(session, exitstatus):
+    _ = exitstatus
     config = session.config
     path = _report_path()
     if getattr(config, "workerinput", None) is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,29 +39,35 @@ _GOVERNANCE_KEYS = {
     "environment",
 }
 
+_collection_outcomes = []
+
 
 def _report_path() -> Path:
     return Path(os.environ.get("QA_OUTCOME_PATH", "test-outcomes.json"))
 
 
 def _governance_metadata(item, report) -> dict[str, str]:
-    metadata = getattr(item, "_qa_governance_metadata", None)
+    reason = _skip_reason(report)
+    metadata = metadata_from_reason(reason)
     if metadata:
         return metadata
-    for marker_name in ("skip", "skipif", "xfail"):
-        marker = item.get_closest_marker(marker_name)
-        if marker:
-            metadata = metadata_from_marker(marker)
-            if metadata:
-                return metadata
-    return metadata_from_reason(getattr(report, "wasxfail", None))
+
+    marker_metadata = getattr(item, "_qa_governance_metadata_by_marker", {})
+    report_text = str(getattr(report, "longrepr", ""))
+    if hasattr(report, "wasxfail") or (
+        report.failed and "XPASS(strict)" in report_text
+    ):
+        return marker_metadata.get("xfail", {})
+    if report.skipped:
+        return marker_metadata.get("skipif", {}) or marker_metadata.get("skip", {})
+    return {}
 
 
 def pytest_collection_modifyitems(config, items):
     violations = []
     markers_to_strip = {}
     for item in items:
-        item_metadata = {}
+        item_metadata_by_marker = {}
         for marker_name in ("skip", "skipif", "xfail"):
             for marker in item.iter_markers(name=marker_name):
                 kwargs = marker.kwargs
@@ -77,12 +83,14 @@ def pytest_collection_modifyitems(config, items):
                 except (TypeError, ValueError) as exc:
                     violations.append(f"{item.nodeid} @{marker_name}: {exc}")
                 else:
-                    item_metadata.update(metadata_from_marker(marker))
+                    item_metadata_by_marker.setdefault(
+                        marker_name, metadata_from_marker(marker)
+                    )
                     markers_to_strip[id(marker)] = marker
                 if marker_name == "xfail" and kwargs.get("strict") is not True:
                     violations.append(f"{item.nodeid} @xfail: strict=True is required")
-        if item_metadata:
-            item._qa_governance_metadata = item_metadata
+        if item_metadata_by_marker:
+            item._qa_governance_metadata_by_marker = item_metadata_by_marker
     if violations:
         raise pytest.UsageError(
             "Ungoverned skip/xfail markers:\n" + "\n".join(violations)
@@ -112,14 +120,49 @@ def _outcome_entry(nodeid, report, metadata=None) -> dict:
     else:
         status = "failed"
         reason = None
+    if status == "passed":
+        metadata = {}
+    else:
+        metadata = (
+            metadata
+            or metadata_from_reason(reason if isinstance(reason, str) else None)
+            or metadata_from_reason(getattr(report, "wasxfail", None))
+        )
     return {
         "nodeid": nodeid,
         "status": status,
         "reason": reason,
-        "metadata": metadata
-        or metadata_from_reason(reason if isinstance(reason, str) else None)
-        or metadata_from_reason(getattr(report, "wasxfail", None)),
+        "metadata": metadata,
     }
+
+
+def _skip_reason(report) -> str | None:
+    if not report.skipped:
+        return None
+    longrepr = getattr(report, "longrepr", None)
+    if isinstance(longrepr, tuple) and len(longrepr) >= 3:
+        return str(longrepr[2])
+    return str(longrepr) if longrepr else None
+
+
+def _collection_entry(report) -> dict:
+    status = "skipped" if report.outcome == "skipped" else "failed"
+    longrepr = getattr(report, "longrepr", None)
+    if status == "skipped" and isinstance(longrepr, tuple) and len(longrepr) >= 3:
+        reason = str(longrepr[2])
+    else:
+        reason = str(longrepr) if longrepr else None
+    return {
+        "nodeid": report.nodeid,
+        "status": status,
+        "reason": reason,
+        "metadata": metadata_from_reason(reason),
+    }
+
+
+def pytest_collectreport(report):
+    if report.outcome != "passed":
+        _collection_outcomes.append(_collection_entry(report))
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -155,12 +198,23 @@ def _outcome_priority(status: str) -> int:
     }.get(status, 0)
 
 
+def _merge_outcomes(entries):
+    by_nodeid = {}
+    for entry in entries:
+        existing = by_nodeid.get(entry["nodeid"])
+        if existing is None or _outcome_priority(entry["status"]) > _outcome_priority(
+            existing["status"]
+        ):
+            by_nodeid[entry["nodeid"]] = entry
+    return list(by_nodeid.values())
+
+
 def _write_outcome_reports(config, entries=None, path=None) -> None:
     if entries is None:
         entries = getattr(config, "_qa_outcomes", [])
     if path is None:
         path = _report_path()
-    entries = sorted(entries, key=lambda entry: entry["nodeid"])
+    entries = sorted(_merge_outcomes(entries), key=lambda entry: entry["nodeid"])
     observed = Counter(entry["status"] for entry in entries)
     counts = {
         status: observed.get(status, 0)
@@ -232,6 +286,9 @@ def pytest_testnodedown(node, error):
 def pytest_sessionfinish(session, exitstatus):
     _ = exitstatus
     config = session.config
+    for entry in _collection_outcomes:
+        _record_outcome(config, entry)
+    _collection_outcomes.clear()
     path = _report_path()
     if getattr(config, "workerinput", None) is not None:
         worker_id = config.workerinput.get("workerid", "worker")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,9 @@ def _outcome_entry(nodeid, report, metadata=None) -> dict:
         "nodeid": nodeid,
         "status": status,
         "reason": reason,
-        "metadata": metadata or metadata_from_reason(getattr(report, "wasxfail", None)),
+        "metadata": metadata
+        or metadata_from_reason(reason if isinstance(reason, str) else None)
+        or metadata_from_reason(getattr(report, "wasxfail", None)),
     }
 
 
@@ -125,7 +127,7 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
     if call.when != "call" and not (
-        call.when == "setup" and (report.skipped or report.failed)
+        call.when in {"setup", "teardown"} and (report.skipped or report.failed)
     ):
         return
     entry = _outcome_entry(item.nodeid, report, _governance_metadata(item, report))
@@ -221,6 +223,7 @@ def pytest_testnodedown(node, error):
     config._qa_worker_entries = getattr(config, "_qa_worker_entries", [])
     config._qa_worker_entries.extend(entries)
     worker_path.unlink()
+    worker_path.with_suffix(".md").unlink(missing_ok=True)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,14 @@ can import the agent modules directly.
 
 from __future__ import annotations
 
+import json
+import os
 import sys
+from collections import Counter
+from datetime import UTC, datetime
 from pathlib import Path
+
+import pytest
 
 # Add project root to path (for common.* imports)
 _root = Path(__file__).resolve().parent.parent
@@ -18,3 +24,224 @@ if str(_root) not in sys.path:
 _agent_svc = _root / "agent-svc"
 if _agent_svc.exists() and str(_agent_svc) not in sys.path:
     sys.path.insert(0, str(_agent_svc))
+
+from tests.outcome_governance import (
+    metadata_from_marker,
+    metadata_from_reason,
+    validate_metadata,
+)
+
+
+def _report_path() -> Path:
+    return Path(os.environ.get("QA_OUTCOME_PATH", "test-outcomes.json"))
+
+
+def _governance_metadata(item, report) -> dict[str, str]:
+    for marker_name in ("skip", "skipif", "xfail"):
+        marker = item.get_closest_marker(marker_name)
+        if marker:
+            metadata = metadata_from_marker(marker)
+            if metadata:
+                return metadata
+    return metadata_from_reason(getattr(report, "wasxfail", None))
+
+
+def pytest_collection_modifyitems(config, items):
+    violations = []
+    for item in items:
+        for marker_name in ("skip", "skipif", "xfail"):
+            for marker in item.iter_markers(name=marker_name):
+                kwargs = marker.kwargs
+                try:
+                    validate_metadata(
+                        reason=str(kwargs.get("reason", "")),
+                        owner=str(kwargs.get("owner", "")),
+                        issue=str(kwargs.get("issue", "")),
+                        classification=str(kwargs.get("classification", "")),
+                        review_date=kwargs.get("review_date"),
+                        environment=kwargs.get("environment"),
+                    )
+                except (TypeError, ValueError) as exc:
+                    violations.append(f"{item.nodeid} @{marker_name}: {exc}")
+                if marker_name == "xfail" and kwargs.get("strict") is not True:
+                    violations.append(f"{item.nodeid} @xfail: strict=True is required")
+    if violations:
+        raise pytest.UsageError(
+            "Ungoverned skip/xfail markers:\n" + "\n".join(violations)
+        )
+
+
+def _outcome_entry(nodeid, report, metadata=None) -> dict:
+    report_text = str(getattr(report, "longrepr", ""))
+    if report.failed and "XPASS(strict)" in report_text:
+        status = "xpassed"
+        reason = getattr(report, "wasxfail", None) or report_text
+    elif report.skipped and hasattr(report, "wasxfail"):
+        status = "xfailed"
+        reason = report.wasxfail
+    elif hasattr(report, "wasxfail"):
+        status = "xpassed"
+        reason = report.wasxfail
+    elif report.passed:
+        status = "passed"
+        reason = None
+    elif report.skipped:
+        status = "skipped"
+        reason = str(report.longrepr[2]) if isinstance(report.longrepr, tuple) else None
+    else:
+        status = "failed"
+        reason = None
+    return {
+        "nodeid": nodeid,
+        "status": status,
+        "reason": reason,
+        "metadata": metadata or metadata_from_reason(getattr(report, "wasxfail", None)),
+    }
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if call.when != "call" and not (call.when == "setup" and report.skipped):
+        return
+    entry = _outcome_entry(item.nodeid, report, _governance_metadata(item, report))
+    _record_outcome(item.config, entry)
+
+
+def _record_outcome(config, entry) -> None:
+    by_nodeid = getattr(config, "_qa_outcome_by_nodeid", {})
+    existing = by_nodeid.get(entry["nodeid"])
+    if existing is None or _outcome_priority(entry["status"]) > _outcome_priority(
+        existing["status"]
+    ):
+        by_nodeid[entry["nodeid"]] = entry
+    config._qa_outcome_by_nodeid = by_nodeid
+    config._qa_outcomes = list(by_nodeid.values())
+
+
+def _outcome_priority(status: str) -> int:
+    return {
+        "passed": 1,
+        "skipped": 2,
+        "xfailed": 3,
+        "xpassed": 4,
+        "failed": 5,
+    }.get(status, 0)
+
+
+def _write_outcome_reports(config, entries=None, path=None) -> None:
+    if entries is None:
+        entries = getattr(config, "_qa_outcomes", [])
+    if path is None:
+        path = _report_path()
+    entries = sorted(entries, key=lambda entry: entry["nodeid"])
+    observed = Counter(entry["status"] for entry in entries)
+    counts = {
+        status: observed.get(status, 0)
+        for status in ("passed", "failed", "skipped", "xfailed", "xpassed")
+    }
+    payload = {
+        "schema_version": 1,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "counts": counts,
+        "tests": entries,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    markdown = [
+        "# Pytest Outcome Report",
+        "",
+        f"Schema version: `{payload['schema_version']}`",
+        "",
+        "## Counts",
+        "",
+    ]
+    markdown.extend(f"- {status}: {counts.get(status, 0)}" for status in sorted(counts))
+    governed_entries = [entry for entry in entries if entry["status"] != "passed"]
+    markdown.extend(["", "## Governed outcomes", ""])
+    if not governed_entries:
+        markdown.append("- none")
+    for entry in governed_entries:
+        metadata = ", ".join(
+            f"{key}={value}" for key, value in sorted(entry["metadata"].items())
+        )
+        detail = f"; {entry['reason']}" if entry["reason"] else ""
+        markdown.append(
+            f"- `{entry['status']}` `{entry['nodeid']}`{detail} ({metadata})"
+        )
+    path.with_suffix(".md").write_text("\n".join(markdown) + "\n")
+
+
+def pytest_configure(config):
+    config._qa_outcomes = []
+    config._qa_outcome_by_nodeid = {}
+
+
+def _worker_report_path(path: Path, worker_id: str) -> Path:
+    return path.with_name(f"{path.stem}.{worker_id}{path.suffix}")
+
+
+def pytest_testnodedown(node, error):
+    """Collect each xdist worker's report before the master finishes."""
+    config = node.config
+    if getattr(config, "workerinput", None) is not None:
+        return
+    worker_id = getattr(node, "workerid", None)
+    if worker_id is None:
+        worker_id = getattr(getattr(node, "gateway", None), "id", "worker")
+    worker_path = _worker_report_path(_report_path(), worker_id)
+    if not worker_path.exists():
+        return
+    entries = json.loads(worker_path.read_text()).get("tests", [])
+    config._qa_worker_entries = getattr(config, "_qa_worker_entries", [])
+    config._qa_worker_entries.extend(entries)
+    worker_path.unlink()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    config = session.config
+    path = _report_path()
+    if getattr(config, "workerinput", None) is not None:
+        worker_id = config.workerinput.get("workerid", "worker")
+        _write_outcome_reports(config, path=_worker_report_path(path, worker_id))
+        return
+
+    entries = getattr(config, "_qa_worker_entries", [])
+    if entries:
+        _write_outcome_reports(config, entries=entries)
+    else:
+        worker_reports = sorted(path.parent.glob(f"{path.stem}.gw*.json"))
+        if worker_reports:
+            for worker_report in worker_reports:
+                entries.extend(json.loads(worker_report.read_text()).get("tests", []))
+                worker_report.unlink()
+            _write_outcome_reports(config, entries=entries)
+        else:
+            _write_outcome_reports(config)
+
+
+def pytest_terminal_summary(terminalreporter):
+    config = terminalreporter.config
+    if getattr(config, "workerinput", None) is not None:
+        return
+    entries = getattr(config, "_qa_outcomes", [])
+    report_path = _report_path()
+    if report_path.exists():
+        entries = json.loads(report_path.read_text()).get("tests", entries)
+    counts = Counter(entry["status"] for entry in entries)
+    terminalreporter.write_line(
+        "QA outcomes: "
+        + ", ".join(
+            f"{status}={counts.get(status, 0)}"
+            for status in ("passed", "failed", "skipped", "xfailed", "xpassed")
+        )
+    )
+    for entry in entries:
+        if entry["status"] in {"xpassed", "xfailed"}:
+            metadata = ", ".join(
+                f"{key}={value}" for key, value in sorted(entry["metadata"].items())
+            )
+            terminalreporter.write_line(
+                f"{entry['status']}: {entry['nodeid']} [{metadata}] {entry['reason']}"
+            )

--- a/tests/integration/m1_tests.py
+++ b/tests/integration/m1_tests.py
@@ -6,9 +6,12 @@
 import json
 import os
 import time
+from contextlib import suppress
 
 import httpx
 import pytest
+
+from tests.outcome_governance import governed_skip
 
 AGENT = os.getenv("AGENT_BASE_URL", "http://localhost:8080")
 TEST_SITE = os.getenv("TEST_SITE_BASE_URL", "http://localhost:8005")
@@ -31,7 +34,13 @@ def _post_agent(body: dict, timeout: int = 30) -> httpx.Response:
 def _assert_agent_created(r: httpx.Response):
     """Assert agent job was created, or skip if rate-limited."""
     if r.status_code == 429:
-        pytest.skip("Rate limited by agent endpoint")
+        governed_skip(
+            "Rate limited by agent endpoint",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text[:200]}"
 
 
@@ -375,10 +384,8 @@ def test_answer_output_schema_num_sources_one():
 
     answer_text = payload["answer"]
     if not answer_text.startswith("I was unable to find"):
-        try:
+        with suppress(json.JSONDecodeError):
             json.loads(answer_text)
-        except json.JSONDecodeError:
-            pass
 
 
 def test_answer_non_json_fallback():
@@ -792,10 +799,8 @@ def test_cross_endpoint_citation_style_consistency():
     if not answer_text.startswith("I was unable to find") and answer_payload.get(
         "sources"
     ):
-        try:
+        with suppress(json.JSONDecodeError):
             json.loads(answer_text)
-        except json.JSONDecodeError:
-            pass  # May be prose with markdown citations
 
     # Citations/resolve with compact style
     resolve_r = httpx.post(

--- a/tests/integration/test_browser_svc_integration.py
+++ b/tests/integration/test_browser_svc_integration.py
@@ -16,6 +16,8 @@ import re
 import httpx
 import pytest
 
+from tests.outcome_governance import governed_skip
+
 # ── Configuration ──────────────────────────────────────────────────────────
 
 BROWSER_SVC_BASE = os.environ.get("BROWSER_SVC_URL", "http://localhost:8012")
@@ -49,6 +51,10 @@ def _docker_available() -> bool:
 require_docker = pytest.mark.skipif(
     not _docker_available(),
     reason="Docker stack not running — start with `docker compose up --build -d`",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="retained",
+    environment="Docker stack is not running",
 )
 
 
@@ -58,8 +64,12 @@ require_docker = pytest.mark.skipif(
 def _skip_if_no_docker():
     """Skip the current test if Docker is not available."""
     if not _docker_available():
-        pytest.skip(
-            "Docker stack not running — start with `docker compose up --build -d`"
+        governed_skip(
+            "Docker stack not running — start with `docker compose up --build -d`",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="Docker stack is not running",
         )
 
 
@@ -73,7 +83,13 @@ def _check_service():
         data = resp.json()
         assert data["status"] == "ok"
     except httpx.ConnectError as e:
-        pytest.skip(f"browser-svc unreachable at {BROWSER_SVC_BASE}: {e}")
+        governed_skip(
+            f"browser-svc unreachable at {BROWSER_SVC_BASE}: {e}",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="browser-svc health endpoint is unreachable",
+        )
 
 
 @pytest.fixture

--- a/tests/integration/test_crawler.py
+++ b/tests/integration/test_crawler.py
@@ -1684,7 +1684,13 @@ class TestCrawlRequestValidation:
 class TestJobStoreExpiresAt:
     """Tests for JobStore expires_at field."""
 
-    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    @pytest.mark.skip(
+        reason="Requires running valkey/redis server",
+        owner="repository-maintainer",
+        issue="#502",
+        classification="retained",
+        environment="valkey/redis is not running",
+    )
     def test_create_job_includes_expires_at(self):
         """JobStore.create_job sets expires_at in job metadata."""
         from agent.store import JobStore
@@ -1713,7 +1719,13 @@ class TestJobStoreExpiresAt:
         finally:
             store.redis.delete(f"job:{job_id}:meta")
 
-    @pytest.mark.skip(reason="Requires running valkey/redis server")
+    @pytest.mark.skip(
+        reason="Requires running valkey/redis server",
+        owner="repository-maintainer",
+        issue="#502",
+        classification="retained",
+        environment="valkey/redis is not running",
+    )
     def test_complete_job_sets_completed_at(self):
         """JobStore.complete_job sets completed_at in metadata."""
         from agent.store import JobStore

--- a/tests/integration/test_semantic_svc_integration.py
+++ b/tests/integration/test_semantic_svc_integration.py
@@ -18,6 +18,8 @@ import time
 import httpx
 import pytest
 
+from tests.outcome_governance import governed_skip
+
 SEMANTIC = os.getenv("SEMANTIC_BASE_URL", "http://localhost:8003")
 
 
@@ -50,9 +52,21 @@ def skip_if_not_running():
     try:
         r = httpx.get(f"{SEMANTIC}/health", timeout=5)
         if r.status_code != 200:
-            pytest.skip(f"semantic-svc not ready: {r.status_code}")
+            governed_skip(
+                f"semantic-svc not ready: {r.status_code}",
+                owner="repository-maintainer",
+                issue="#502",
+                classification="retained",
+                environment="semantic-svc health endpoint is not ready",
+            )
     except Exception as e:
-        pytest.skip(f"semantic-svc not reachable: {e}")
+        governed_skip(
+            f"semantic-svc not reachable: {e}",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="semantic-svc health endpoint is unreachable",
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -603,6 +617,10 @@ class TestMigration:
     os.getenv("VECTOR_INDEX_MAX_DOCS") is None,
     reason="Set VECTOR_INDEX_MAX_DOCS=5 and restart semantic-svc to test eviction. "
     "Run: VECTOR_INDEX_MAX_DOCS=5 docker compose up -d semantic-svc",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="retained",
+    environment="VECTOR_INDEX_MAX_DOCS is unset",
 )
 class TestEviction:
     """Eviction when index exceeds capacity."""

--- a/tests/integration/test_stack.py
+++ b/tests/integration/test_stack.py
@@ -838,6 +838,14 @@ def test_shodan_adapter_source():
     assert "shodan" in src, f"Expected shodan source, got {src}"
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
+)
 def test_crtsh_adapter_domain():
     """CRT.sh domain lookup should return certificate data."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": CRTSH_DOMAIN}, timeout=120)

--- a/tests/integration/test_stack.py
+++ b/tests/integration/test_stack.py
@@ -838,13 +838,13 @@ def test_shodan_adapter_source():
     assert "shodan" in src, f"Expected shodan source, got {src}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Requires reaching third-party sites from CI runner",
+@pytest.mark.skipif(
+    not os.getenv("RUN_EXTERNAL_TESTS"),
+    reason="CRT.sh access is opt-in because the third-party service is intermittent from CI",
     owner="repository-maintainer",
     issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reliably reach third-party sites",
+    classification="retained",
+    environment="Third-party CRT.sh access is opt-in via RUN_EXTERNAL_TESTS=1",
 )
 def test_crtsh_adapter_domain():
     """CRT.sh domain lookup should return certificate data."""

--- a/tests/integration/test_stack.py
+++ b/tests/integration/test_stack.py
@@ -163,14 +163,6 @@ def test_scraper_uses_llms_txt():
     assert "llms.txt entrypoint" in payload["data"]["markdown"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="scraper cannot extract from minimal HTML test pages",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="minimal HTML fixture is not extractable",
-)
 def test_scraper_uses_accept_markdown():
     # Disable llms.txt by targeting a page that doesn't match the llms.txt listing.
     r = httpx.post(
@@ -873,14 +865,6 @@ def test_exploitdb_adapter_exploit():
     assert len(md) > 50, f"Expected >50 chars, got {len(md)}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Requires reaching third-party sites from CI runner",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reliably reach third-party sites",
-)
 def test_mitreattack_adapter_technique():
     """MITRE ATT&CK technique page should return content via STIX adapter."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": MITRE_TECHNIQUE}, timeout=120)
@@ -925,14 +909,6 @@ def test_censys_adapter_ip():
     assert len(md) > 20, f"Expected >20 chars, got {len(md)}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Requires reaching third-party sites from CI runner",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reliably reach third-party sites",
-)
 def test_virustotal_adapter_file():
     """VirusTotal file page should be handled by the adapter."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": VT_FILE}, timeout=120)
@@ -1478,14 +1454,6 @@ def _index_batch(pages: list[dict]) -> httpx.Response:
     return r
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Qdrant unstable under CI memory pressure",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner memory pressure destabilizes Qdrant",
-)
 def test_index_structure():
     """POST /index on semantic-svc returns valid structure."""
     r = _index(
@@ -1501,14 +1469,6 @@ def test_index_structure():
     return payload
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Qdrant unstable under CI memory pressure",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner memory pressure destabilizes Qdrant",
-)
 def test_near_dup_detection_skip_mode():
     """Indexing the same content at a different URL returns 'duplicate' status.
 
@@ -1540,14 +1500,6 @@ def test_near_dup_detection_skip_mode():
     assert isinstance(payload["url_hash"], int)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Qdrant unstable under CI memory pressure",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner memory pressure destabilizes Qdrant",
-)
 def test_near_dup_detection_update_mode():
     """Requesting near_dup_mode='update' always indexes even when duplicated."""
     r = _index(
@@ -1563,14 +1515,6 @@ def test_near_dup_detection_update_mode():
     assert isinstance(payload["url_hash"], int)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Qdrant unstable under CI memory pressure",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner memory pressure destabilizes Qdrant",
-)
 def test_near_dup_different_content():
     """Completely different content at different URL should index normally."""
     r = _index(
@@ -1586,14 +1530,6 @@ def test_near_dup_different_content():
     assert isinstance(payload["url_hash"], int)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Qdrant unstable under CI memory pressure",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner memory pressure destabilizes Qdrant",
-)
 def test_batch_index_endpoint():
     """POST /index/batch on semantic-svc returns valid structure.
 
@@ -1622,14 +1558,6 @@ def test_batch_index_endpoint():
     assert payload["count"] == 2
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Qdrant unstable under CI memory pressure",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner memory pressure destabilizes Qdrant",
-)
 def test_batch_index_empty():
     """POST /index/batch with no pages should return count=0."""
     r = _index_batch([])
@@ -1646,14 +1574,6 @@ GUTENBERG_FILES = "https://www.gutenberg.org/files/11/"
 GUTENBERG_CACHE = "https://gutenberg.org/cache/epub/11/"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="gutenberg.org may be unreachable in CI",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reach gutenberg.org",
-)
 def test_gutenberg_adapter_known_book():
     """Known Gutenberg book (Alice in Wonderland) returns structured markdown with frontmatter."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_ALICE}, timeout=180)
@@ -1681,14 +1601,6 @@ def test_gutenberg_adapter_known_book():
     assert "gutenberg" in src, f"Expected gutenberg source, got {src}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="gutenberg.org may be unreachable in CI",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reach gutenberg.org",
-)
 def test_gutenberg_adapter_files_url():
     """Gutenberg /files/<id>/ URL pattern should also work."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_FILES}, timeout=180)
@@ -1698,14 +1610,6 @@ def test_gutenberg_adapter_files_url():
     assert len(md) > 100, f"Expected >100 chars, got {len(md)}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="gutenberg.org may be unreachable in CI",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reach gutenberg.org",
-)
 def test_gutenberg_adapter_cache_url():
     """Gutenberg /cache/epub/<id>/ URL pattern should also work."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_CACHE}, timeout=180)
@@ -1715,14 +1619,6 @@ def test_gutenberg_adapter_cache_url():
     assert len(md) > 100, f"Expected >100 chars, got {len(md)}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="gutenberg.org may be unreachable in CI",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reach gutenberg.org",
-)
 def test_gutenberg_adapter_invalid_id():
     """Non-existent book ID should gracefully fall through or return error."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_INVALID}, timeout=180)

--- a/tests/integration/test_stack.py
+++ b/tests/integration/test_stack.py
@@ -838,14 +838,6 @@ def test_shodan_adapter_source():
     assert "shodan" in src, f"Expected shodan source, got {src}"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Requires reaching third-party sites from CI runner",
-    owner="repository-maintainer",
-    issue="#502",
-    classification="quarantined",
-    environment="CI runner cannot reliably reach third-party sites",
-)
 def test_crtsh_adapter_domain():
     """CRT.sh domain lookup should return certificate data."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": CRTSH_DOMAIN}, timeout=120)

--- a/tests/integration/test_stack.py
+++ b/tests/integration/test_stack.py
@@ -6,6 +6,8 @@ import time
 import httpx
 import pytest
 
+from tests.outcome_governance import governed_skip
+
 logger = logging.getLogger(__name__)
 
 AGENT = os.getenv("AGENT_BASE_URL", "http://localhost:8080")
@@ -35,6 +37,10 @@ def _docker_available() -> bool:
 require_docker = pytest.mark.skipif(
     not _docker_available(),
     reason="Docker stack not running — start with `docker compose up --build -d`",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="retained",
+    environment="Docker stack is not running",
 )
 
 
@@ -136,7 +142,12 @@ def test_metrics_endpoint_returns_openmetrics():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="scraper cannot extract from minimal HTML test pages"
+    strict=True,
+    reason="scraper cannot extract from minimal HTML test pages",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="minimal HTML fixture is not extractable",
 )
 def test_scraper_uses_llms_txt():
     r = httpx.post(
@@ -153,7 +164,12 @@ def test_scraper_uses_llms_txt():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="scraper cannot extract from minimal HTML test pages"
+    strict=True,
+    reason="scraper cannot extract from minimal HTML test pages",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="minimal HTML fixture is not extractable",
 )
 def test_scraper_uses_accept_markdown():
     # Disable llms.txt by targeting a page that doesn't match the llms.txt listing.
@@ -532,7 +548,13 @@ def test_agent_streaming_with_output_schema_no_token_events():
     # Pre-flight LLM health check may return 503 if LLM backend is unavailable.
     # This is a pre-existing infrastructure concern, not related to output_schema.
     if r.status_code == 503:
-        pytest.skip("LLM backend unavailable — pre-existing infrastructure issue")
+        governed_skip(
+            "LLM backend unavailable — pre-existing infrastructure issue",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="LLM backend returned HTTP 503",
+        )
     assert r.status_code == 200
     assert r.headers.get("content-type", "").startswith("text/event-stream")
     body = r.text
@@ -808,7 +830,12 @@ def test_shodan_adapter_public_host():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="Requires reaching third-party sites from CI runner"
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
 )
 def test_shodan_adapter_source():
     """Shodan adapter source should be shodan-html (no API key in CI)."""
@@ -820,7 +847,12 @@ def test_shodan_adapter_source():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="Requires reaching third-party sites from CI runner"
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
 )
 def test_crtsh_adapter_domain():
     """CRT.sh domain lookup should return certificate data."""
@@ -842,7 +874,12 @@ def test_exploitdb_adapter_exploit():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="Requires reaching third-party sites from CI runner"
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
 )
 def test_mitreattack_adapter_technique():
     """MITRE ATT&CK technique page should return content via STIX adapter."""
@@ -855,7 +892,12 @@ def test_mitreattack_adapter_technique():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="Requires reaching third-party sites from CI runner"
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
 )
 def test_abuseipdb_adapter_ip():
     """AbuseIPDB IP check should return content via adapter."""
@@ -867,7 +909,12 @@ def test_abuseipdb_adapter_ip():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="Requires reaching third-party sites from CI runner"
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
 )
 def test_censys_adapter_ip():
     """Censys IP page should be handled by the adapter (scrape fallback)."""
@@ -879,7 +926,12 @@ def test_censys_adapter_ip():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="Requires reaching third-party sites from CI runner"
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
 )
 def test_virustotal_adapter_file():
     """VirusTotal file page should be handled by the adapter."""
@@ -906,7 +958,12 @@ def test_otx_adapter_indicator():
 
 
 @pytest.mark.xfail(
-    strict=False, reason="Requires reaching third-party sites from CI runner"
+    strict=True,
+    reason="Requires reaching third-party sites from CI runner",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reliably reach third-party sites",
 )
 def test_hibp_adapter_breach():
     """HIBP account page should return content via adapter."""
@@ -1421,7 +1478,14 @@ def _index_batch(pages: list[dict]) -> httpx.Response:
     return r
 
 
-@pytest.mark.xfail(strict=False, reason="Qdrant unstable under CI memory pressure")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Qdrant unstable under CI memory pressure",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner memory pressure destabilizes Qdrant",
+)
 def test_index_structure():
     """POST /index on semantic-svc returns valid structure."""
     r = _index(
@@ -1437,7 +1501,14 @@ def test_index_structure():
     return payload
 
 
-@pytest.mark.xfail(strict=False, reason="Qdrant unstable under CI memory pressure")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Qdrant unstable under CI memory pressure",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner memory pressure destabilizes Qdrant",
+)
 def test_near_dup_detection_skip_mode():
     """Indexing the same content at a different URL returns 'duplicate' status.
 
@@ -1469,7 +1540,14 @@ def test_near_dup_detection_skip_mode():
     assert isinstance(payload["url_hash"], int)
 
 
-@pytest.mark.xfail(strict=False, reason="Qdrant unstable under CI memory pressure")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Qdrant unstable under CI memory pressure",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner memory pressure destabilizes Qdrant",
+)
 def test_near_dup_detection_update_mode():
     """Requesting near_dup_mode='update' always indexes even when duplicated."""
     r = _index(
@@ -1485,7 +1563,14 @@ def test_near_dup_detection_update_mode():
     assert isinstance(payload["url_hash"], int)
 
 
-@pytest.mark.xfail(strict=False, reason="Qdrant unstable under CI memory pressure")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Qdrant unstable under CI memory pressure",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner memory pressure destabilizes Qdrant",
+)
 def test_near_dup_different_content():
     """Completely different content at different URL should index normally."""
     r = _index(
@@ -1501,7 +1586,14 @@ def test_near_dup_different_content():
     assert isinstance(payload["url_hash"], int)
 
 
-@pytest.mark.xfail(strict=False, reason="Qdrant unstable under CI memory pressure")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Qdrant unstable under CI memory pressure",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner memory pressure destabilizes Qdrant",
+)
 def test_batch_index_endpoint():
     """POST /index/batch on semantic-svc returns valid structure.
 
@@ -1530,7 +1622,14 @@ def test_batch_index_endpoint():
     assert payload["count"] == 2
 
 
-@pytest.mark.xfail(strict=False, reason="Qdrant unstable under CI memory pressure")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Qdrant unstable under CI memory pressure",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner memory pressure destabilizes Qdrant",
+)
 def test_batch_index_empty():
     """POST /index/batch with no pages should return count=0."""
     r = _index_batch([])
@@ -1547,7 +1646,14 @@ GUTENBERG_FILES = "https://www.gutenberg.org/files/11/"
 GUTENBERG_CACHE = "https://gutenberg.org/cache/epub/11/"
 
 
-@pytest.mark.xfail(strict=False, reason="gutenberg.org may be unreachable in CI")
+@pytest.mark.xfail(
+    strict=True,
+    reason="gutenberg.org may be unreachable in CI",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reach gutenberg.org",
+)
 def test_gutenberg_adapter_known_book():
     """Known Gutenberg book (Alice in Wonderland) returns structured markdown with frontmatter."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_ALICE}, timeout=180)
@@ -1575,7 +1681,14 @@ def test_gutenberg_adapter_known_book():
     assert "gutenberg" in src, f"Expected gutenberg source, got {src}"
 
 
-@pytest.mark.xfail(strict=False, reason="gutenberg.org may be unreachable in CI")
+@pytest.mark.xfail(
+    strict=True,
+    reason="gutenberg.org may be unreachable in CI",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reach gutenberg.org",
+)
 def test_gutenberg_adapter_files_url():
     """Gutenberg /files/<id>/ URL pattern should also work."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_FILES}, timeout=180)
@@ -1585,7 +1698,14 @@ def test_gutenberg_adapter_files_url():
     assert len(md) > 100, f"Expected >100 chars, got {len(md)}"
 
 
-@pytest.mark.xfail(strict=False, reason="gutenberg.org may be unreachable in CI")
+@pytest.mark.xfail(
+    strict=True,
+    reason="gutenberg.org may be unreachable in CI",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reach gutenberg.org",
+)
 def test_gutenberg_adapter_cache_url():
     """Gutenberg /cache/epub/<id>/ URL pattern should also work."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_CACHE}, timeout=180)
@@ -1595,7 +1715,14 @@ def test_gutenberg_adapter_cache_url():
     assert len(md) > 100, f"Expected >100 chars, got {len(md)}"
 
 
-@pytest.mark.xfail(strict=False, reason="gutenberg.org may be unreachable in CI")
+@pytest.mark.xfail(
+    strict=True,
+    reason="gutenberg.org may be unreachable in CI",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner cannot reach gutenberg.org",
+)
 def test_gutenberg_adapter_invalid_id():
     """Non-existent book ID should gracefully fall through or return error."""
     r = httpx.post(SCRAPER + "/scrape", json={"url": GUTENBERG_INVALID}, timeout=180)
@@ -2300,7 +2427,14 @@ def test_crawl_response_shape_parity():
 # ── VAL-CROSS-004: Crawl → Semantic Indexing ────────────────────
 
 
-@pytest.mark.xfail(strict=False, reason="Qdrant unstable under CI memory pressure")
+@pytest.mark.xfail(
+    strict=True,
+    reason="Qdrant unstable under CI memory pressure",
+    owner="repository-maintainer",
+    issue="#502",
+    classification="quarantined",
+    environment="CI runner memory pressure destabilizes Qdrant",
+)
 @require_docker
 def test_crawl_semantic_indexing():
     """Crawled pages appear in vector search after crawl completion.
@@ -4194,7 +4328,13 @@ def _post_agent(body: dict, timeout: int = 30) -> httpx.Response:
 def _assert_agent_created(r: httpx.Response):
     """Assert agent job was created, or skip if rate-limited."""
     if r.status_code == 429:
-        pytest.skip("Rate limited by agent endpoint")
+        governed_skip(
+            "Rate limited by agent endpoint",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text[:200]}"
 
 
@@ -4971,7 +5111,13 @@ def test_cross_endpoint_citation_style_consistency():
     )
     # Answer may be rate-limited if rate limit was exhausted by agent call
     if answer_r.status_code == 429:
-        pytest.skip("Rate limited on answer endpoint")
+        governed_skip(
+            "Rate limited on answer endpoint",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="answer endpoint returned HTTP 429",
+        )
     assert answer_r.status_code == 200
     answer_payload = answer_r.json()
     answer_text = answer_payload.get("answer", "")
@@ -6178,7 +6324,6 @@ def test_memory_survives_agent_svc_restart():
     This test requires SSH access to saru to restart the container.
     If SSH is not available, the test is skipped.
     """
-    pytest.importorskip("subprocess")
 
     unique_query = f"restart survival {int(time.time())}"
     store_r = httpx.post(
@@ -7995,7 +8140,13 @@ def test_deepen_isolated_to_target_ref_val_dpn_012():
     assert s1.status_code == 200, f"Search failed: {s1.text}"
     ref_count = s1.json()["result"].get("ref_count", 0)
     if ref_count == 0:
-        pytest.skip("Search returned no results (rate-limited or empty)")
+        governed_skip(
+            "Search returned no results (rate-limited or empty)",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="search returned no results or was rate-limited",
+        )
     # Get step 1 ref count
     export1 = httpx.post(AGENT + f"/v2/session/{sid}/export", json={}, timeout=10)
     step1_refs = len(
@@ -10067,9 +10218,13 @@ def test_plan_execute_empty_modifications():
     )
     # Accept rate limiting (429) — pre-existing env issue with LLM key causing many retries
     if r.status_code == 429:
-        import pytest
-
-        pytest.skip("Rate limited — cannot generate plan")
+        governed_skip(
+            "Rate limited — cannot generate plan",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Plan generation failed: {r.status_code} {r.text}"
     plan_id = r.json()["plan_id"]
 
@@ -10119,9 +10274,13 @@ def test_plan_execute_with_modifications_list_form():
         timeout=60,
     )
     if r.status_code == 429:
-        import pytest
-
-        pytest.skip("Rate limited — cannot generate plan")
+        governed_skip(
+            "Rate limited — cannot generate plan",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Plan generation failed: {r.status_code}"
     plan_id = r.json()["plan_id"]
 
@@ -10169,9 +10328,13 @@ def test_plan_execute_no_modifications():
         timeout=60,
     )
     if r.status_code == 429:
-        import pytest
-
-        pytest.skip("Rate limited — cannot generate plan")
+        governed_skip(
+            "Rate limited — cannot generate plan",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Plan generation failed: {r.status_code} {r.text}"
     plan_id = r.json()["plan_id"]
 
@@ -10215,9 +10378,13 @@ def test_plan_execute_narrow_modification():
         timeout=60,
     )
     if r.status_code == 429:
-        import pytest
-
-        pytest.skip("Rate limited — cannot generate plan")
+        governed_skip(
+            "Rate limited — cannot generate plan",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Plan generation failed: {r.status_code} {r.text}"
     plan_id = r.json()["plan_id"]
 
@@ -10269,9 +10436,13 @@ def test_plan_execute_add_dimension_modification():
         timeout=60,
     )
     if r.status_code == 429:
-        import pytest
-
-        pytest.skip("Rate limited — cannot generate plan")
+        governed_skip(
+            "Rate limited — cannot generate plan",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Plan generation failed: {r.status_code} {r.text}"
     plan_id = r.json()["plan_id"]
 
@@ -10342,9 +10513,13 @@ def test_plan_execute_full_end_to_end():
         timeout=60,
     )
     if r.status_code == 429:
-        import pytest
-
-        pytest.skip("Rate limited — cannot generate plan")
+        governed_skip(
+            "Rate limited — cannot generate plan",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="agent endpoint returned HTTP 429",
+        )
     assert r.status_code == 200, f"Plan generation failed: {r.status_code} {r.text}"
     d = r.json()
     plan_id = d["plan_id"]
@@ -10494,9 +10669,13 @@ def test_deepen_expired_session_404_val_dpn_014():
             # Session may have been refreshed by the scrape step (TTL refresh)
             # If so, step succeeded — clean up and note
             httpx.delete(AGENT + f"/v2/session/{sid}", timeout=10)
-            pytest.skip(
+            governed_skip(
                 "Session TTL was refreshed by step activity "
-                "(TTL refresh on step is valid behavior)"
+                "(TTL refresh on step is valid behavior)",
+                owner="repository-maintainer",
+                issue="#502",
+                classification="retained",
+                environment="session step refreshed its TTL",
             )
     else:
         # Other status (e.g., 4xx, 5xx) is acceptable
@@ -10519,7 +10698,13 @@ def test_plan_streaming_response_structure_val_pln_020():
     ) as r:
         # Accept 200 (streaming) or 503 (LLM unavailable)
         if r.status_code == 503:
-            pytest.skip("LLM unavailable — cannot test plan streaming")
+            governed_skip(
+                "LLM unavailable — cannot test plan streaming",
+                owner="repository-maintainer",
+                issue="#502",
+                classification="retained",
+                environment="LLM backend returned HTTP 503",
+            )
         assert r.status_code == 200, (
             f"Expected 200, got {r.status_code}: {r.text[:200]}"
         )
@@ -10691,8 +10876,12 @@ def test_cross_plan_agent_structured_output_val_cross_005():
         time.sleep(15)
 
     if answer_r.status_code == 429:
-        pytest.skip(
-            "Answer endpoint rate-limited — cannot verify cross-endpoint overlap"
+        governed_skip(
+            "Answer endpoint rate-limited — cannot verify cross-endpoint overlap",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="answer endpoint returned HTTP 429",
         )
     assert answer_r.status_code == 200, f"Answer failed: {answer_r.text}"
     answer_data = answer_r.json()
@@ -10847,7 +11036,13 @@ def test_cross_deepen_equivalent_agent_val_cross_010():
     query_data = s2.json()
     query_response = query_data.get("result", {}).get("response", "")
     if not query_response:
-        pytest.skip("Query produced no response (LLM may be unavailable)")
+        governed_skip(
+            "Query produced no response (LLM may be unavailable)",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="LLM backend produced no response",
+        )
 
     # Step 3: Take a finding and use as agent prompt (deepen equivalent)
     finding = (

--- a/tests/outcome_governance.py
+++ b/tests/outcome_governance.py
@@ -1,0 +1,95 @@
+"""Shared governance primitives for pytest skips and expected failures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+CLASSIFICATIONS = {"retained", "fixed/re-enabled", "quarantined", "deleted"}
+
+
+@dataclass(frozen=True)
+class GovernanceMetadata:
+    owner: str
+    issue: str
+    classification: str
+    review_date: str | None = None
+    environment: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        result = {
+            "owner": self.owner,
+            "issue": self.issue,
+            "classification": self.classification,
+        }
+        if self.review_date:
+            result["review_date"] = self.review_date
+        if self.environment:
+            result["environment"] = self.environment
+        return result
+
+
+def validate_metadata(
+    *,
+    reason: str,
+    owner: str,
+    issue: str,
+    classification: str,
+    review_date: str | None = None,
+    environment: str | None = None,
+) -> GovernanceMetadata:
+    """Validate the required metadata shared by runtime and marker APIs."""
+    if not reason.strip():
+        raise ValueError("governance reason must be concise and non-empty")
+    if not owner.strip() or not issue.strip():
+        raise ValueError("governance owner and issue are required")
+    if classification not in CLASSIFICATIONS:
+        raise ValueError(f"unknown governance classification: {classification}")
+    if not review_date and not environment:
+        raise ValueError("governance metadata needs review_date or environment")
+    return GovernanceMetadata(owner, issue, classification, review_date, environment)
+
+
+def format_reason(reason: str, metadata: GovernanceMetadata) -> str:
+    fields = "; ".join(f"{key}={value}" for key, value in metadata.as_dict().items())
+    return f"{reason.strip()} [governance: {fields}]"
+
+
+def governed_skip(
+    reason: str,
+    *,
+    owner: str,
+    issue: str,
+    classification: str,
+    review_date: str | None = None,
+    environment: str | None = None,
+    allow_module_level: bool = False,
+) -> None:
+    """Skip at runtime only after validating reviewable governance metadata."""
+    metadata = validate_metadata(
+        reason=reason,
+        owner=owner,
+        issue=issue,
+        classification=classification,
+        review_date=review_date,
+        environment=environment,
+    )
+    pytest.skip(format_reason(reason, metadata), allow_module_level=allow_module_level)
+
+
+def metadata_from_marker(marker) -> dict[str, str]:
+    """Return governance fields from a skip/xfail marker."""
+    return {
+        key: str(marker.kwargs[key])
+        for key in ("owner", "issue", "classification", "review_date", "environment")
+        if key in marker.kwargs
+    }
+
+
+def metadata_from_reason(reason: str | None) -> dict[str, str]:
+    """Parse the stable metadata suffix emitted by ``governed_skip``."""
+    if not reason or "[governance: " not in reason:
+        return {}
+    fields = reason.rsplit("[governance: ", 1)[1].removesuffix("]")
+    return dict(part.split("=", 1) for part in fields.split("; ") if "=" in part)

--- a/tests/service/test_cli.py
+++ b/tests/service/test_cli.py
@@ -19,11 +19,20 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.outcome_governance import governed_skip
+
 # ── Load the CLI script ──────────────────────────────────────────────────────
 
 _CLI_PATH = Path(__file__).resolve().parents[2] / "groktocrawl"
 if not _CLI_PATH.is_file():
-    pytest.skip("groktocrawl CLI not found at project root", allow_module_level=True)
+    governed_skip(
+        "groktocrawl CLI not found at project root",
+        owner="repository-maintainer",
+        issue="#502",
+        classification="retained",
+        environment="local checkout does not expose the root CLI",
+        allow_module_level=True,
+    )
 _CLI_PATH = str(_CLI_PATH)
 
 # Load the CLI module by executing it with a namespace dict

--- a/tests/service/test_outcome_governance.py
+++ b/tests/service/test_outcome_governance.py
@@ -234,12 +234,19 @@ def test_sessionfinish_fallback_removes_worker_markdown(tmp_path, monkeypatch):
     )
     worker_markdown.write_text("partial worker report\n")
     monkeypatch.setenv("QA_OUTCOME_PATH", str(report_path))
-    original_collection_outcomes = outcome_conftest._collection_outcomes
-    with monkeypatch.context() as isolated:
-        isolated.setattr(outcome_conftest, "_collection_outcomes", [])
-        config = SimpleNamespace(workerinput=None)
-        outcome_conftest.pytest_sessionfinish(SimpleNamespace(config=config), 0)
-    assert outcome_conftest._collection_outcomes is original_collection_outcomes
+    live_collection_outcomes = outcome_conftest._collection_outcomes
+    original_collection_outcomes = list(live_collection_outcomes)
+    sentinel = object()
+    live_collection_outcomes.append(sentinel)
+    try:
+        with monkeypatch.context() as isolated:
+            isolated.setattr(outcome_conftest, "_collection_outcomes", [])
+            config = SimpleNamespace(workerinput=None)
+            outcome_conftest.pytest_sessionfinish(SimpleNamespace(config=config), 0)
+        assert live_collection_outcomes == [*original_collection_outcomes, sentinel]
+    finally:
+        live_collection_outcomes[:] = original_collection_outcomes
+    assert outcome_conftest._collection_outcomes is live_collection_outcomes
     assert report_path.exists()
     assert not worker_json.exists()
     assert not worker_markdown.exists()

--- a/tests/service/test_outcome_governance.py
+++ b/tests/service/test_outcome_governance.py
@@ -214,6 +214,18 @@ def test_failed_outcome_preserves_reason():
     assert entry["reason"] == "assertion failed: expected 1, got 2"
 
 
+def test_strict_xpass_reason_removes_pytest_prefix():
+    report = SimpleNamespace(
+        passed=False,
+        skipped=False,
+        failed=True,
+        longrepr="[XPASS(strict)] declared reason",
+    )
+    entry = _outcome_entry("tests/unit/test_example.py::test_xpass", report)
+    assert entry["status"] == "xpassed"
+    assert entry["reason"] == "declared reason"
+
+
 def test_sessionfinish_fallback_removes_worker_markdown(tmp_path, monkeypatch):
     report_path = tmp_path / "outcomes.json"
     worker_json = tmp_path / "outcomes.gw0.json"

--- a/tests/service/test_outcome_governance.py
+++ b/tests/service/test_outcome_governance.py
@@ -12,10 +12,10 @@ from types import SimpleNamespace
 
 import pytest
 
+import tests.conftest as outcome_conftest
 from tests.conftest import (
     _outcome_entry,
     _write_outcome_reports,
-    pytest_sessionfinish,
 )
 from tests.outcome_governance import CLASSIFICATIONS, governed_skip, validate_metadata
 
@@ -234,8 +234,12 @@ def test_sessionfinish_fallback_removes_worker_markdown(tmp_path, monkeypatch):
     )
     worker_markdown.write_text("partial worker report\n")
     monkeypatch.setenv("QA_OUTCOME_PATH", str(report_path))
-    config = SimpleNamespace(workerinput=None)
-    pytest_sessionfinish(SimpleNamespace(config=config), 0)
+    original_collection_outcomes = outcome_conftest._collection_outcomes
+    with monkeypatch.context() as isolated:
+        isolated.setattr(outcome_conftest, "_collection_outcomes", [])
+        config = SimpleNamespace(workerinput=None)
+        outcome_conftest.pytest_sessionfinish(SimpleNamespace(config=config), 0)
+    assert outcome_conftest._collection_outcomes is original_collection_outcomes
     assert report_path.exists()
     assert not worker_json.exists()
     assert not worker_markdown.exists()

--- a/tests/service/test_outcome_governance.py
+++ b/tests/service/test_outcome_governance.py
@@ -1,0 +1,183 @@
+"""Contract tests for skip/xfail metadata and outcome reporting."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import _write_outcome_reports
+from tests.outcome_governance import CLASSIFICATIONS, governed_skip, validate_metadata
+
+
+def _attribute_path(node: ast.AST) -> str | None:
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _governance_violations(root: Path) -> list[str]:
+    violations = []
+    excluded = {"outcome_governance.py", "test_outcome_governance.py"}
+    for path in sorted(root.rglob("*.py")):
+        if path.name in excluded:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                function = _attribute_path(node.func)
+                if function in {"pytest.skip", "pytest.xfail", "pytest.importorskip"}:
+                    violations.append(f"{path}:{node.lineno}: direct {function}")
+                if function == "governed_skip":
+                    keywords = {keyword.arg for keyword in node.keywords}
+                    required = {"owner", "issue", "classification"}
+                    if missing := required - keywords:
+                        violations.append(
+                            f"{path}:{node.lineno}: missing {sorted(missing)}"
+                        )
+                    if "review_date" not in keywords and "environment" not in keywords:
+                        violations.append(
+                            f"{path}:{node.lineno}: missing review_date/environment"
+                        )
+                if function in {
+                    "pytest.mark.skip",
+                    "pytest.mark.skipif",
+                    "pytest.mark.xfail",
+                }:
+                    keywords = {keyword.arg for keyword in node.keywords}
+                    required = {
+                        "reason",
+                        "owner",
+                        "issue",
+                        "classification",
+                    }
+                    if missing := required - keywords:
+                        violations.append(
+                            f"{path}:{node.lineno}: missing {sorted(missing)}"
+                        )
+                    if "review_date" not in keywords and "environment" not in keywords:
+                        violations.append(
+                            f"{path}:{node.lineno}: missing review_date/environment"
+                        )
+                    if function == "pytest.mark.xfail":
+                        strict = next(
+                            (
+                                keyword.value
+                                for keyword in node.keywords
+                                if keyword.arg == "strict"
+                            ),
+                            None,
+                        )
+                        if (
+                            not isinstance(strict, ast.Constant)
+                            or strict.value is not True
+                        ):
+                            violations.append(
+                                f"{path}:{node.lineno}: xfail is not strict"
+                            )
+    return violations
+
+
+def test_all_root_test_outcomes_have_governance_metadata():
+    violations = _governance_violations(Path(__file__).parents[1])
+    assert not violations, "\n".join(violations)
+
+
+def test_metadata_validation_requires_review_or_environment():
+    with pytest.raises(ValueError, match="review_date or environment"):
+        validate_metadata(
+            reason="needs a service",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+        )
+    with pytest.raises(ValueError, match="unknown governance classification"):
+        validate_metadata(
+            reason="needs a service",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="maybe",
+            environment="service is unavailable",
+        )
+    assert {
+        "retained",
+        "fixed/re-enabled",
+        "quarantined",
+        "deleted",
+    } == CLASSIFICATIONS
+
+
+def test_ast_rejects_non_strict_xfail(tmp_path):
+    test_file = tmp_path / "test_bad.py"
+    test_file.write_text(
+        "import pytest\n\n"
+        "@pytest.mark.xfail(strict="
+        "False, reason='known', owner='o', issue='#502', "
+        "classification='quarantined', environment='ci')\n"
+        "def test_bad(): pass\n"
+    )
+    violations = _governance_violations(tmp_path)
+    assert any("xfail is not strict" in violation for violation in violations)
+
+
+def test_ast_rejects_ungoverned_runtime_skip(tmp_path):
+    test_file = tmp_path / "test_bad_runtime.py"
+    test_file.write_text(
+        "from tests.outcome_governance import governed_skip\n\n"
+        "def test_bad():\n"
+        "    governed_skip('known', owner='o', issue='#502', "
+        "environment='ci')\n"
+    )
+    violations = _governance_violations(tmp_path)
+    assert any("missing ['classification']" in violation for violation in violations)
+
+
+def test_governed_skip_preserves_reason_and_metadata(monkeypatch):
+    with pytest.raises(pytest.skip.Exception, match="Docker is unavailable") as caught:
+        governed_skip(
+            "Docker is unavailable",
+            owner="repository-maintainer",
+            issue="#502",
+            classification="retained",
+            environment="Docker daemon is unavailable",
+        )
+    assert "classification=retained" in str(caught.value)
+    assert "environment=Docker daemon is unavailable" in str(caught.value)
+
+
+def test_outcome_report_contains_counts_and_entries(tmp_path, monkeypatch):
+    path = tmp_path / "qa-outcomes.json"
+    monkeypatch.setenv("QA_OUTCOME_PATH", str(path))
+    config = type("Config", (), {})()
+    config._qa_outcomes = [
+        {
+            "nodeid": "tests/unit/test_example.py::test_ok",
+            "status": "passed",
+            "reason": None,
+            "metadata": {},
+        },
+        {
+            "nodeid": "tests/integration/test_example.py::test_skip",
+            "status": "skipped",
+            "reason": "service unavailable",
+            "metadata": {"issue": "#502"},
+        },
+    ]
+    _write_outcome_reports(config)
+    payload = json.loads(path.read_text())
+    assert payload["schema_version"] == 1
+    assert payload["counts"] == {
+        "passed": 1,
+        "failed": 0,
+        "skipped": 1,
+        "xfailed": 0,
+        "xpassed": 0,
+    }
+    assert path.with_suffix(".md").exists()

--- a/tests/service/test_outcome_governance.py
+++ b/tests/service/test_outcome_governance.py
@@ -198,6 +198,18 @@ def test_passed_outcome_drops_governance_metadata():
     assert entry["metadata"] == {}
 
 
+def test_failed_outcome_preserves_reason():
+    report = SimpleNamespace(
+        passed=False,
+        skipped=False,
+        failed=True,
+        longrepr="assertion failed: expected 1, got 2",
+    )
+    entry = _outcome_entry("tests/unit/test_example.py::test_broken", report)
+    assert entry["status"] == "failed"
+    assert entry["reason"] == "assertion failed: expected 1, got 2"
+
+
 def _run_report_fixture(tmp_path, source: str, *, xdist: bool = False):
     test_file = tmp_path / "test_report_fixture.py"
     report_file = tmp_path / "outcomes.json"

--- a/tests/service/test_outcome_governance.py
+++ b/tests/service/test_outcome_governance.py
@@ -12,7 +12,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from tests.conftest import _outcome_entry, _write_outcome_reports
+from tests.conftest import (
+    _outcome_entry,
+    _write_outcome_reports,
+    pytest_sessionfinish,
+)
 from tests.outcome_governance import CLASSIFICATIONS, governed_skip, validate_metadata
 
 
@@ -208,6 +212,33 @@ def test_failed_outcome_preserves_reason():
     entry = _outcome_entry("tests/unit/test_example.py::test_broken", report)
     assert entry["status"] == "failed"
     assert entry["reason"] == "assertion failed: expected 1, got 2"
+
+
+def test_sessionfinish_fallback_removes_worker_markdown(tmp_path, monkeypatch):
+    report_path = tmp_path / "outcomes.json"
+    worker_json = tmp_path / "outcomes.gw0.json"
+    worker_markdown = tmp_path / "outcomes.gw0.md"
+    worker_json.write_text(
+        json.dumps(
+            {
+                "tests": [
+                    {
+                        "nodeid": "tests/test_worker.py::test_ok",
+                        "status": "passed",
+                        "reason": None,
+                        "metadata": {},
+                    }
+                ]
+            }
+        )
+    )
+    worker_markdown.write_text("partial worker report\n")
+    monkeypatch.setenv("QA_OUTCOME_PATH", str(report_path))
+    config = SimpleNamespace(workerinput=None)
+    pytest_sessionfinish(SimpleNamespace(config=config), 0)
+    assert report_path.exists()
+    assert not worker_json.exists()
+    assert not worker_markdown.exists()
 
 
 def _run_report_fixture(tmp_path, source: str, *, xdist: bool = False):

--- a/tests/service/test_outcome_governance.py
+++ b/tests/service/test_outcome_governance.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import ast
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from tests.conftest import _write_outcome_reports
+from tests.conftest import _outcome_entry, _write_outcome_reports
 from tests.outcome_governance import CLASSIFICATIONS, governed_skip, validate_metadata
 
 
@@ -181,3 +185,121 @@ def test_outcome_report_contains_counts_and_entries(tmp_path, monkeypatch):
         "xpassed": 0,
     }
     assert path.with_suffix(".md").exists()
+
+
+def test_passed_outcome_drops_governance_metadata():
+    report = SimpleNamespace(passed=True, skipped=False, failed=False, longrepr=None)
+    entry = _outcome_entry(
+        "tests/unit/test_example.py::test_ok",
+        report,
+        {"owner": "repository-maintainer", "issue": "#502"},
+    )
+    assert entry["status"] == "passed"
+    assert entry["metadata"] == {}
+
+
+def _run_report_fixture(tmp_path, source: str, *, xdist: bool = False):
+    test_file = tmp_path / "test_report_fixture.py"
+    report_file = tmp_path / "outcomes.json"
+    test_file.write_text(source)
+    env = os.environ.copy()
+    env["QA_OUTCOME_PATH"] = str(report_file)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(Path(__file__).parents[2]), env.get("PYTHONPATH", "")]
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        "tests.conftest",
+    ]
+    if xdist:
+        command.extend(["-n", "2"])
+    command.extend(
+        [
+            "-o",
+            "addopts=",
+            "-q",
+            str(test_file),
+        ]
+    )
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result, json.loads(report_file.read_text())
+
+
+def test_combined_skipif_and_xfail_use_skipif_metadata(tmp_path):
+    result, payload = _run_report_fixture(
+        tmp_path,
+        """\
+import pytest
+
+@pytest.mark.skipif(
+    True,
+    reason="skip marker",
+    owner="skip-owner",
+    issue="#skip",
+    classification="retained",
+    environment="skip environment",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason="xfail marker",
+    owner="xfail-owner",
+    issue="#xfail",
+    classification="quarantined",
+    environment="xfail environment",
+)
+def test_combined_markers():
+    assert False
+""",
+    )
+    assert result.returncode == 0, result.stderr
+    entry = next(item for item in payload["tests"] if item["status"] == "skipped")
+    assert entry["metadata"] == {
+        "owner": "skip-owner",
+        "issue": "#skip",
+        "classification": "retained",
+        "environment": "skip environment",
+    }
+
+
+def test_module_level_governed_skip_is_reported(tmp_path):
+    result, payload = _run_report_fixture(
+        tmp_path,
+        """\
+from tests.outcome_governance import governed_skip
+
+governed_skip(
+    "module unavailable",
+    owner="module-owner",
+    issue="#module",
+    classification="retained",
+    environment="module environment",
+    allow_module_level=True,
+)
+""",
+        xdist=True,
+    )
+    assert result.returncode in {0, 5}, result.stderr
+    assert payload["counts"]["skipped"] == 1
+    entry = next(item for item in payload["tests"] if item["status"] == "skipped")
+    assert entry["metadata"]["issue"] == "#module"
+    assert entry["metadata"]["classification"] == "retained"
+
+
+def test_collection_failure_is_reported(tmp_path):
+    result, payload = _run_report_fixture(
+        tmp_path,
+        "raise RuntimeError('collection boom')\n",
+        xdist=True,
+    )
+    assert result.returncode != 0
+    entry = next(item for item in payload["tests"] if item["status"] == "failed")
+    assert entry["nodeid"].endswith("test_report_fixture.py")
+    assert payload["counts"]["failed"] == 1


### PR DESCRIPTION
## Summary

Adds a governed lifecycle for pytest skips, xfails, and xpasses:

- requires reason, owner, issue, classification, and review date or explicit environment condition on skip/xfail markers;
- routes runtime skips through a validating helper;
- makes xfails strict and fails collection for ungoverned markers;
- writes xdist-safe JSON and Markdown outcome reports with exact node IDs;
- publishes outcome counts in Fast Tests and Docker Integration job summaries and artifacts;
- adds contract tests and documents the baseline classification workflow.

## Related Issue

Closes #502

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [x] Test
- [x] CI/DevOps

## Test Plan

- [x] Exact current-head Docker Integration and Runtime Gate pass for `fcd2b88746e1072daed9b79952a2ac95ca81d023` (`30784072776`): 970 passed, 148 skipped, 5 xfailed, 0 xpassed, 0 failed.
- [x] Exact current-head integration artifact is valid and complete; it contains the governed CRT.sh environmental skip and the module-level `tests/service/test_cli.py` skip.
- [x] New strict-XPASS reason regression test added.
- [x] Local governance tests: 13 passed.
- [x] Local unit/service lane: 1,148 passed, 30 warnings.
- [x] Manual verification: xdist aggregation, strict-XPASS failure behavior, collection/module outcomes, report counts, YAML parsing, AST metadata inventory, targeted pre-commit, compilation, Vulture, and Graphify.

## Checklist

- [x] Code follows project conventions.
- [x] Relevant documentation is updated.
- [x] Tests prove the change works.
- [ ] New API endpoint CLI coverage (not applicable).
- [ ] New async endpoint webhook field (not applicable).

## Notes for Reviewers

The exact current head is `fcd2b88746e1072daed9b79952a2ac95ca81d023`. The Docker artifact contains no failed outcomes or unexpected passes. The retained CRT.sh case is skipped by default because exact runs alternated between HTTP 502 failure and success; callers can opt in with `RUN_EXTERNAL_TESTS=1`.

The governance reports preserve setup, teardown, and non-passing collection outcomes, deduplicate xdist entries by node ID, retain failure reasons, and omit governance metadata from passed outcomes. The worker-report cleanup regression isolates the live collection buffer while verifying JSON/Markdown cleanup. Strict-XPASS report reasons now remove pytest's `[XPASS(strict)] ` rendering prefix while preserving the declared reason.

Independent review approved the exact current head. The automated review workflow completed with 0 findings; review threads are resolved.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)