### PR TITLE
ci: enforce required QA checks and review policy on main

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -93,3 +93,39 @@ jobs:
           gitleaks version
       - name: Run gitleaks (secret scanning)
         run: gitleaks detect --no-git --verbose --redact
+
+  code-quality-gate:
+    name: Code Quality Gate
+    needs: [python-checks, duplicate-code, secret-scan]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize successful Python Checks
+        if: needs.python-checks.result == 'success'
+        run: echo "Python Checks completed successfully."
+
+      - name: Summarize successful Duplicate Code
+        if: needs.duplicate-code.result == 'success'
+        run: echo "Duplicate Code completed successfully."
+
+      - name: Summarize successful Secret Scanning
+        if: needs.secret-scan.result == 'success'
+        run: echo "Secret Scanning completed successfully."
+
+      - name: Fail when Python Checks do not succeed
+        if: needs.python-checks.result != 'success'
+        run: |
+          echo "Python Checks did not complete successfully."
+          exit 1
+
+      - name: Fail when Duplicate Code does not succeed
+        if: needs.duplicate-code.result != 'success'
+        run: |
+          echo "Duplicate Code did not complete successfully."
+          exit 1
+
+      - name: Fail when Secret Scanning does not succeed
+        if: needs.secret-scan.result != 'success'
+        run: |
+          echo "Secret Scanning did not complete successfully."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,21 @@ Open a GitHub issue with:
 5. Commit with a clear message
 6. Open a PR
 
+### Merging to `main`
+
+The `main` branch is protected by repository rulesets (see
+[ADR-0046](docs/adr/0046-enforce-qa-checks-and-review-policy-on-main.md)):
+
+- Merges require the **Code Quality Gate** and **Runtime Gate** checks to pass
+  (branches must be up to date before merging).
+- Non-automation changes require **at least one approving review**; stale
+  approvals are dismissed on push and open review conversations block merge.
+- `dependabot[bot]` and `release-please[bot]` are exempt from the review
+  requirement only — they must still pass the required checks.
+- The policy is enforced on admins; the audited emergency exception path is
+  documented in
+  [Emergency Branch Protection Bypass](docs/runbooks/emergency-branch-protection-bypass.md).
+
 ### Running Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ Set `API_KEY` for authentication, restrict network exposure, and review outbound
 ## Status
 
 Core Firecrawl-compatible workflows and GroktoCrawl extensions are actively developed. Review the [changelog](CHANGELOG.md), [ADRs](docs/adr/README.md), and [issues](https://github.com/groktopus/groktocrawl/issues) for change history and planned work.
+
+## Development policy
+
+Merges to `main` require the **Code Quality Gate** and **Runtime Gate** checks to pass and at least one approving review for non-automation changes (stale approvals are dismissed and open review conversations block merge). `dependabot[bot]` and `release-please[bot]` skip the review requirement only — they must still pass the required checks. See [ADR-0046](docs/adr/0046-enforce-qa-checks-and-review-policy-on-main.md) for the full policy and [Emergency Branch Protection Bypass](docs/runbooks/emergency-branch-protection-bypass.md) for the audited emergency exception path.

--- a/docs/adr/0046-enforce-qa-checks-and-review-policy-on-main.md
+++ b/docs/adr/0046-enforce-qa-checks-and-review-policy-on-main.md
@@ -1,0 +1,117 @@
+# Enforce QA Checks and Review Policy on main
+
+* Status: proposed
+* Deciders: GroktoCrawl maintainers
+* Date: 2026-08-03
+
+## Context and Problem Statement
+
+The `main` branch currently has a partial classic branch-protection rule:
+it requires **0** approving reviews, has no required status checks, and does
+not require resolved review conversations. The Docker Runtime Gate and the
+Code Quality results are therefore advisory at the merge boundary — a merge
+can land with failing QA or no review. Issue #499 asks to make these
+enforceable release conditions: every merge to `main` must pass the stable
+QA gates and receive an approving human review.
+
+## Decision Drivers
+
+* QA signals must be **enforced, not advisory**: the aggregate gates
+  (`Code Quality Gate`, `Runtime Gate`) must block merges that fail them.
+* Required checks must be **stable aggregate gates only** — never volatile
+  matrix or per-tool jobs that appear and disappear between runs.
+* Automation must keep shipping: `dependabot[bot]` and `release-please[bot]`
+  should not need a human approving review, but must still pass the required
+  checks.
+* The policy is **enforced on admins**: no routine bypass path.
+* The change must be **auditable** (who changed enforcement, when) and have a
+  documented emergency exception path.
+* The enforcement mechanism must be supported on a public repository on any
+  GitHub plan.
+
+## Considered Options
+
+* **A. Repository rulesets (two)** — GitHub's recommended mechanism. Supports
+  bypass actors (classic protection's API support is limited), versioned
+  ruleset history provides a per-repo audit trail, and enforcement toggling is
+  a clean audited emergency lever. Public repos have rulesets on any plan.
+  Requires a two-ruleset split because `bypass_actors` is ruleset-wide.
+* **B. Classic branch protection only** — existing mechanism, but its API
+  support for bypass actors is limited, it has no versioned history endpoint
+  for auditing, and it cannot express "bots skip review but not checks" as
+  cleanly. Rejected.
+* **C. Single combined ruleset** — would list the bots as bypass actors and
+  carry both the review rule and the required-checks rule. Because a bypass
+  actor is exempt from the **entire** ruleset, the bots would skip the
+  required checks too, letting automation merge with failing QA. Rejected.
+* **D. Do nothing** — keeps QA advisory and reviews optional. Rejected: that
+  is the problem being fixed.
+
+## Decision Outcome
+
+Enforce the policy on `main` with **two active repository rulesets**
+(option A), applied declaratively and idempotently by
+`scripts/enforce-branch-protection.py`:
+
+**Ruleset A — `main review policy`** (enforcement: `active`, target: the
+default branch, `conditions.ref_name.include: ["~DEFAULT_BRANCH"]`):
+
+* `pull_request` rule with parameters:
+  * `required_approving_review_count: 1` — at least one approving review for
+    non-automation changes,
+  * `dismiss_stale_reviews_on_push: true` — stale approvals are dismissed
+    after subsequent pushes,
+  * `require_last_push_approval: true`,
+  * `require_code_owner_review: false`,
+  * `required_review_thread_resolution: true` — open review conversations
+    block merge.
+* `bypass_actors` (exactly two, bot exemption from the review rule **only**):
+  * `{actor_type: "Integration", actor_id: 29110, bypass_mode: "pull_request"}`
+    — `dependabot[bot]`,
+  * `{actor_type: "Integration", actor_id: 40688, bypass_mode: "pull_request"}`
+    — `release-please[bot]`.
+
+**Ruleset B — `main required checks`** (enforcement: `active`, target: the
+default branch, **no bypass actors**):
+
+* `required_status_checks` rule with parameters:
+  * `strict_required_status_checks_policy: true` — branches must be up to
+    date before merging,
+  * `required_status_checks` exactly `[{context: "Code Quality Gate",
+    integration_id: null}, {context: "Runtime Gate", integration_id: null}]`.
+* `non_fast_forward` — force-pushes stay blocked,
+* `deletion` — branch deletion stays blocked.
+
+The legacy classic branch-protection rule on `main` is removed only after
+both rulesets are confirmed active (most-restrictive-wins aggregation makes
+the classic rule redundant once the rulesets are live).
+
+## Consequences
+
+* Merges to `main` now require both stable aggregate gates to pass and a
+  human approving review (with stale approvals dismissed and resolved
+  conversations); the policy binds repo admins too.
+* **Why two rulesets:** `bypass_actors` exempts an actor from the entire
+  ruleset. The split keeps `dependabot[bot]` and `release-please[bot]`
+  exempt from the human review only; everyone — bots and admins — must still
+  pass the required checks in Ruleset B.
+* **Emergency exception path:** an org admin may temporarily set both
+  rulesets' enforcement to `disabled`, merge the blocking change, and restore
+  both to `active` within 24 hours, recording the incident in a tracking
+  issue. See `docs/runbooks/emergency-branch-protection-bypass.md`.
+* **Audit trail:** `GET /repos/{owner}/{repo}/rulesets/{id}/history` records
+  the actor and timestamp per ruleset version. The org audit-log REST API
+  (`GET /orgs/{owner}/audit-log`) is Enterprise-only and unavailable on this
+  org, so ruleset history is the per-repo audit record.
+* **Known consequence for already-open PRs:** PRs #510, #511, and #420 were
+  branched before the `Code Quality Gate` job existed. Once the ruleset is
+  active they may show "Expected — Waiting for status" for the new required
+  context until they are updated onto new `main`. The enforcement script's
+  pre-apply safety gate verifies both required contexts exist in live check
+  runs on the current `main` head so newly required contexts never dead-end
+  merges.
+
+## Links
+
+* GitHub issue [#499](https://github.com/groktopus/groktocrawl/issues/499)
+* [Emergency Branch Protection Bypass](../../runbooks/emergency-branch-protection-bypass.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,7 +21,7 @@ An Architecture Decision Record captures an important architectural decision mad
 
 **Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, and 0045.
 
-**Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, and 0040–0042.
+**Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, 0040–0042, and 0046.
 
 | ADR | Title | Status |
 |-----|-------|--------|
@@ -70,5 +70,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0043 | [Migration from SearXNG to SlopSearX](0043-migration-to-slopsearx.md) | accepted |
 | 0044 | [Autonomous CAPTCHA Recovery](0044-autonomous-captcha-recovery.md) | accepted |
 | 0045 | [Outbound Webhook Destination Validation](0045-outbound-webhook-destination-validation.md) | accepted |
+| 0046 | [Enforce QA Checks and Review Policy on main](0046-enforce-qa-checks-and-review-policy-on-main.md) | proposed |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -10,6 +10,10 @@ Owner: GroktoCrawl maintainers
 - [QueueDepthSpike](queue-depth-spike.md)
 - [ServiceDown](service-down.md)
 
+## Emergency Procedures
+
+- [Emergency Branch Protection Bypass](emergency-branch-protection-bypass.md)
+
 ---
 
 ## Service Health Check

--- a/docs/runbooks/emergency-branch-protection-bypass.md
+++ b/docs/runbooks/emergency-branch-protection-bypass.md
@@ -1,0 +1,116 @@
+# Emergency Branch Protection Bypass
+
+Owner: GroktoCrawl maintainers
+
+## Severity
+
+High
+
+## Purpose
+
+`main` is protected by two repository rulesets (see ADR-0046): `main review policy` (one approving review for humans) and `main required checks` (`Code Quality Gate` + `Runtime Gate`, strict up to date). The policy is enforced on admins — there is **no routine bypass**. This runbook is the deliberate, audited exception path for a genuine emergency where a merge to `main` must happen and the normal review/CI path cannot complete in time.
+
+Use it **only** when:
+
+- A legitimate fix must land on `main` immediately (e.g., a production incident fix), and
+- The blocking condition (failed required check or missing review) cannot be resolved within the required window.
+
+Never use it for routine merges. Admins are subject to the policy; the audit trail below records every lift.
+
+## Timeline
+
+1. Resolve the two ruleset ids and capture the "before" audit evidence.
+2. Disable **both** rulesets (`main review policy` and `main required checks`).
+3. Verify both are `disabled`.
+4. Merge the blocking change through the normal flow (GitHub UI merge button or `gh pr merge --merge`).
+5. Restore **both** rulesets to `active` **within 24 hours**.
+6. Verify both are `active` again.
+7. Capture the "after" audit evidence and record the incident in a tracking issue.
+
+## Procedure
+
+### 1. Resolve ruleset ids and capture "before" audit evidence
+
+```bash
+RULESET_A_ID="$(gh api repos/groktopus/groktocrawl/rulesets --jq '.[] | select(.name == "main review policy") | .id' | head -n 1)"
+RULESET_B_ID="$(gh api repos/groktopus/groktocrawl/rulesets --jq '.[] | select(.name == "main required checks") | .id' | head -n 1)"
+echo "A=$RULESET_A_ID B=$RULESET_B_ID"
+```
+
+Both ids must be non-empty before continuing. Capture the pre-lift audit trail:
+
+```bash
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_A_ID}/history"
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_B_ID}/history"
+```
+
+### 2. Disable both rulesets
+
+```bash
+echo '{"enforcement": "disabled"}' | gh api -X PUT "repos/groktopus/groktocrawl/rulesets/${RULESET_A_ID}" --input -
+echo '{"enforcement": "disabled"}' | gh api -X PUT "repos/groktopus/groktocrawl/rulesets/${RULESET_B_ID}" --input -
+```
+
+### 3. Verify both are disabled
+
+```bash
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_A_ID}" --jq '.name + ": " + .enforcement'
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_B_ID}" --jq '.name + ": " + .enforcement'
+```
+
+Expected output:
+
+```
+main review policy: disabled
+main required checks: disabled
+```
+
+### 4. Merge the blocking change
+
+Merge through the normal flow: the GitHub UI merge button, or `gh pr merge --merge` (replace `<pr-number>` with the PR being merged):
+
+```bash
+gh pr merge <pr-number> --merge
+```
+
+### 5. Restore both rulesets to active
+
+Restore **immediately after the merge** — the rulesets must be `active` again within 24 hours:
+
+```bash
+echo '{"enforcement": "active"}' | gh api -X PUT "repos/groktopus/groktocrawl/rulesets/${RULESET_A_ID}" --input -
+echo '{"enforcement": "active"}' | gh api -X PUT "repos/groktopus/groktocrawl/rulesets/${RULESET_B_ID}" --input -
+```
+
+### 6. Verify both are active
+
+```bash
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_A_ID}" --jq '.name + ": " + .enforcement'
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_B_ID}" --jq '.name + ": " + .enforcement'
+```
+
+Expected output:
+
+```
+main review policy: active
+main required checks: active
+```
+
+### 7. Capture "after" audit evidence and record the incident
+
+```bash
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_A_ID}/history"
+gh api "repos/groktopus/groktocrawl/rulesets/${RULESET_B_ID}/history"
+```
+
+The history endpoint records the actor and timestamp for each ruleset version (the disable and the restore both appear). Create a tracking issue:
+
+```bash
+gh issue create \
+  --title "Emergency branch protection bypass on main (rulesets disabled on $(date -u +%Y-%m-%d))" \
+  --body "Temporarily disabled 'main review policy' and 'main required checks' on main to merge a blocking change, then restored to active within 24h. Audit evidence: ruleset history for both ruleset ids (RULESET_A_ID / RULESET_B_ID)."
+```
+
+## Audit trail
+
+The per-repo audit record is the ruleset history endpoint: `GET /repos/{owner}/{repo}/rulesets/{id}/history` for each ruleset id, captured **before** the lift (step 1) and **after** the restore (step 7). The org audit-log REST API (`GET /orgs/groktopus/audit-log`) is unavailable on this org — it is Enterprise-only — so ruleset history is the authoritative evidence. Attach both captures to the tracking issue.

--- a/scripts/enforce-branch-protection.py
+++ b/scripts/enforce-branch-protection.py
@@ -1,0 +1,886 @@
+#!/usr/bin/env python3
+"""Declarative, idempotent enforcer for the main-branch QA policy.
+
+Implements the user-approved policy from `docs/adr/0046-*` and
+`library/policy.md` for the repository's default branch as two GitHub
+repository rulesets:
+
+  * Ruleset A "main review policy" - one approving review for humans with
+    stale-review dismissal, last-push re-approval, and required review
+    thread resolution; dependabot[bot] (app 29110) and release-please[bot]
+    (app 40688) are exempt from the review rule only (bypass_mode
+    "pull_request").
+  * Ruleset B "main required checks" - required_status_checks (strict,
+    contexts exactly "Code Quality Gate" + "Runtime Gate"), non_fast_forward
+    and deletion; NO bypass actors, so bots and admins must both pass the
+    required checks.
+
+Why two rulesets: `bypass_actors` exempts an actor from the ENTIRE ruleset,
+so a single combined ruleset would let the bots merge with failing checks.
+
+Behavior:
+
+  * `--dry-run` (the default) never mutates anything: it prints the policy
+    report, verifies the safety gate (both required check contexts exist in
+    live check runs on the target branch head) and computes the change plan.
+    A missing or unreachable safety gate is reported but never aborts.
+  * `--apply` is the ONLY mode that issues mutating API calls. It aborts
+    with zero mutations if the safety gate fails, then applies Ruleset A,
+    Ruleset B, verifies both are active with the exact expected rules, and
+    only then removes the legacy classic branch protection (404 treated as
+    already removed).
+
+The pure policy layer (payloads + whitelist idempotency comparator) is
+separated from the HTTP layer so the module is unit-testable without
+network. Authentication: `GITHUB_TOKEN` preferred, `gh auth token` fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping
+from typing import Any
+
+API_BASE = "https://api.github.com"
+DEFAULT_BRANCH = "main"
+REQUIRED_CHECK_CONTEXTS = ("Code Quality Gate", "Runtime Gate")
+
+# --- Policy payloads (architecture.md section 3.1 / library/policy.md) ---
+
+RULESET_A: dict[str, Any] = {
+    "name": "main review policy",
+    "enforcement": "active",
+    "target": "branch",
+    "conditions": {
+        "ref_name": {
+            "include": ["~DEFAULT_BRANCH"],
+            "exclude": [],
+        }
+    },
+    "bypass_actors": [
+        {
+            "actor_type": "Integration",
+            "actor_id": 29110,
+            "bypass_mode": "pull_request",
+        },
+        {
+            "actor_type": "Integration",
+            "actor_id": 40688,
+            "bypass_mode": "pull_request",
+        },
+    ],
+    "rules": [
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": 1,
+                "dismiss_stale_reviews_on_push": True,
+                "require_last_push_approval": True,
+                "require_code_owner_review": False,
+                "required_review_thread_resolution": True,
+            },
+        }
+    ],
+}
+
+RULESET_B: dict[str, Any] = {
+    "name": "main required checks",
+    "enforcement": "active",
+    "target": "branch",
+    "conditions": {
+        "ref_name": {
+            "include": ["~DEFAULT_BRANCH"],
+            "exclude": [],
+        }
+    },
+    "rules": [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": True,
+                "required_status_checks": [
+                    {"context": "Code Quality Gate", "integration_id": None},
+                    {"context": "Runtime Gate", "integration_id": None},
+                ],
+            },
+        },
+        {"type": "non_fast_forward"},
+        {"type": "deletion"},
+    ],
+}
+
+RULESETS: list[dict[str, Any]] = [RULESET_A, RULESET_B]
+
+# API metadata fields that the whitelist comparator ignores (VAL-TOOL-008).
+METADATA_FIELDS = frozenset(
+    {
+        "created_at",
+        "updated_at",
+        "source_type",
+        "source",
+        "node_id",
+        "url",
+        "links",
+        "_links",
+        "current_user_can_bypass",
+    }
+)
+
+# The pull_request parameters that define the review policy. Parameters whose
+# desired value is False are tolerated when absent from the live payload.
+PULL_REQUEST_POLICY: dict[str, Any] = {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews_on_push": True,
+    "require_last_push_approval": True,
+    "require_code_owner_review": False,
+    "required_review_thread_resolution": True,
+}
+
+
+class EnforceError(Exception):
+    """Base error for the enforcer."""
+
+
+class AuthError(EnforceError):
+    """No GitHub authentication available."""
+
+
+class TransportError(EnforceError):
+    """The HTTP layer could not complete a request."""
+
+
+class ApplyAbortError(EnforceError):
+    """A pre-mutation or verification failure aborted --apply."""
+
+
+# --- Authentication ---------------------------------------------------------
+
+
+def _default_gh_token() -> str | None:
+    """Return the gh auth token only when gh is genuinely authenticated.
+
+    `gh auth token` alone can return a system-keychain token even when no gh
+    host is configured (e.g. when GH_CONFIG_DIR is isolated), so `gh auth
+    status` must confirm an actual gh login before trusting the token.
+    """
+    try:
+        status = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=15,
+        )
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+    if status.returncode != 0:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=15,
+        )
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+    return result.stdout.strip() or None
+
+
+def resolve_auth(
+    env: Mapping[str, str] | None = None,
+    gh_token_runner: Callable[[], str | None] | None = None,
+) -> tuple[str, str]:
+    """Return (token, auth_source). GITHUB_TOKEN is preferred over gh.
+
+    `auth_source` is one of "GITHUB_TOKEN" or "gh". Raises AuthError when
+    neither source provides a token.
+    """
+    env = os.environ if env is None else env
+    token = (env.get("GITHUB_TOKEN") or "").strip()
+    if token:
+        return token, "GITHUB_TOKEN"
+    token = (gh_token_runner or _default_gh_token)()
+    if token:
+        return token, "gh"
+    raise AuthError(
+        "no GitHub authentication available: set GITHUB_TOKEN or run `gh auth login`"
+    )
+
+
+# --- HTTP layer (injectable) ------------------------------------------------
+
+
+class HttpTransport:
+    """Minimal JSON HTTP layer over the Python standard library.
+
+    Injectable so unit tests can substitute a recording fake that simulates
+    200/404/missing-context without network access.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        base_url: str = API_BASE,
+        timeout: float = 30.0,
+    ) -> None:
+        self.token = token
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def _request(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> tuple[int, Any, dict[str, str]]:
+        url = path if path.startswith("http") else f"{self.base_url}{path}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "enforce-branch-protection/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        data = None
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                body = response.read()
+                return response.status, self._parse(body), dict(response.headers)
+        except urllib.error.HTTPError as exc:
+            body = exc.read()
+            return exc.code, self._parse(body), dict(exc.headers)
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise TransportError(f"{method} {url} failed: {exc}") from exc
+
+    @staticmethod
+    def _parse(body: bytes) -> Any:
+        if not body:
+            return {}
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {}
+
+    def get(self, path: str) -> tuple[int, Any, dict[str, str]]:
+        return self._request("GET", path)
+
+    def post(
+        self, path: str, payload: dict[str, Any]
+    ) -> tuple[int, Any, dict[str, str]]:
+        return self._request("POST", path, payload)
+
+    def put(
+        self, path: str, payload: dict[str, Any]
+    ) -> tuple[int, Any, dict[str, str]]:
+        return self._request("PUT", path, payload)
+
+    def delete(self, path: str) -> tuple[int, Any, dict[str, str]]:
+        return self._request("DELETE", path)
+
+
+def _next_link(headers: Mapping[str, str]) -> str | None:
+    link = headers.get("Link", "")
+    for part in link.split(","):
+        match = re.match(r"<([^>]+)>;\s*rel=\"next\"", part.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+class GithubApi:
+    """Read/write operations against the GitHub REST API."""
+
+    def __init__(
+        self,
+        transport: HttpTransport,
+        owner: str,
+        repo: str,
+        branch: str = DEFAULT_BRANCH,
+    ) -> None:
+        self.transport = transport
+        self.owner = owner
+        self.repo = repo
+        self.branch = branch
+
+    def _rulesets_path(self) -> str:
+        return f"/repos/{self.owner}/{self.repo}/rulesets"
+
+    def _ruleset_path(self, ruleset_id: int) -> str:
+        return f"/repos/{self.owner}/{self.repo}/rulesets/{ruleset_id}"
+
+    def _check_runs_path(self) -> str:
+        return f"/repos/{self.owner}/{self.repo}/commits/{self.branch}/check-runs"
+
+    def _protection_path(self) -> str:
+        return f"/repos/{self.owner}/{self.repo}/branches/{self.branch}/protection"
+
+    # --- reads ---
+
+    def fetch_all_check_runs(self) -> list[dict[str, Any]]:
+        runs: list[dict[str, Any]] = []
+        url = f"{self._check_runs_path()}?per_page=100"
+        while url:
+            status, data, headers = self.transport.get(url)
+            if status != 200:
+                raise TransportError(f"GET check-runs returned HTTP {status}: {data}")
+            runs.extend(data.get("check_runs") or [])
+            url = _next_link(headers)
+        return runs
+
+    def safety_gate(self) -> tuple[bool, list[str], str | None]:
+        """Verify both required check contexts exist in live check runs on the
+        target branch head. Returns (verified, missing_contexts, error).
+
+        Never raises: a network failure is reported as unverified so dry-run
+        can proceed (and apply can abort) with a clear message.
+        """
+        try:
+            runs = self.fetch_all_check_runs()
+        except TransportError as exc:
+            return False, [], f"could not fetch check-runs: {exc}"
+        names = {run.get("name") for run in runs if run.get("name")}
+        missing = [ctx for ctx in REQUIRED_CHECK_CONTEXTS if ctx not in names]
+        return (len(missing) == 0), missing, None
+
+    def list_rulesets(self) -> list[dict[str, Any]]:
+        status, data, _ = self.transport.get(self._rulesets_path())
+        if status != 200:
+            raise TransportError(f"GET rulesets returned HTTP {status}: {data}")
+        return data or []
+
+    def get_ruleset(self, ruleset_id: int) -> dict[str, Any]:
+        status, data, _ = self.transport.get(self._ruleset_path(ruleset_id))
+        if status != 200:
+            raise TransportError(
+                f"GET ruleset {ruleset_id} returned HTTP {status}: {data}"
+            )
+        return data
+
+    # --- writes (only reachable from --apply) ---
+
+    def create_ruleset(self, payload: dict[str, Any]) -> dict[str, Any]:
+        status, data, _ = self.transport.post(self._rulesets_path(), payload)
+        if status not in (200, 201):
+            raise TransportError(f"POST rulesets returned HTTP {status}: {data}")
+        return data
+
+    def update_ruleset(
+        self, ruleset_id: int, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        status, data, _ = self.transport.put(self._ruleset_path(ruleset_id), payload)
+        if status != 200:
+            raise TransportError(
+                f"PUT ruleset {ruleset_id} returned HTTP {status}: {data}"
+            )
+        return data
+
+    def delete_branch_protection(self) -> tuple[int, Any]:
+        status, data, _ = self.transport.delete(self._protection_path())
+        return status, data
+
+
+# --- Pure policy layer (whitelist idempotency comparator) -------------------
+
+
+def _normalized_refs(ref_name: dict[str, Any]) -> list[str]:
+    include = ref_name.get("include") or []
+    normalized: list[str] = []
+    for ref in include:
+        if ref in ("~DEFAULT_BRANCH", f"refs/heads/{DEFAULT_BRANCH}"):
+            normalized.append("~DEFAULT_BRANCH")
+        else:
+            normalized.append(str(ref))
+    return sorted(normalized)
+
+
+def _normalized_exclude(ref_name: dict[str, Any]) -> list[str]:
+    return sorted(str(ref) for ref in (ref_name.get("exclude") or []))
+
+
+def _bypass_keys(actors: list[dict[str, Any]] | None) -> set[tuple[str, int, str]]:
+    return {
+        (
+            str(actor.get("actor_type")),
+            int(actor.get("actor_id")),
+            str(actor.get("bypass_mode")),
+        )
+        for actor in (actors or [])
+    }
+
+
+def _pull_request_diff(desired: dict[str, Any], actual: dict[str, Any]) -> list[str]:
+    diffs: list[str] = []
+    actual_params = actual.get("parameters") or {}
+    for key, expected in PULL_REQUEST_POLICY.items():
+        actual_value = actual_params.get(key)
+        if expected is False and actual_value in (None, False):
+            continue  # absent-false parameter is tolerated
+        if actual_value != expected:
+            diffs.append(
+                f"pull_request.{key}: expected {expected!r}, got {actual_value!r}"
+            )
+    return diffs
+
+
+def _status_checks_diff(desired: dict[str, Any], actual: dict[str, Any]) -> list[str]:
+    diffs: list[str] = []
+    desired_params = desired.get("parameters") or {}
+    actual_params = actual.get("parameters") or {}
+    if actual_params.get("strict_required_status_checks_policy") is not True:
+        diffs.append(
+            "required_status_checks.strict_required_status_checks_policy: "
+            f"expected True, got {actual_params.get('strict_required_status_checks_policy')!r}"
+        )
+    desired_contexts = {
+        entry.get("context")
+        for entry in (desired_params.get("required_status_checks") or [])
+    }
+    actual_contexts = {
+        entry.get("context")
+        for entry in (actual_params.get("required_status_checks") or [])
+    }
+    if desired_contexts != actual_contexts:
+        diffs.append(
+            "required_status_checks.contexts: expected "
+            f"{sorted(desired_contexts)!r}, got {sorted(actual_contexts)!r}"
+        )
+    # integration_id absent-vs-null is tolerated per entry (whitelist).
+    return diffs
+
+
+def _rules_diff(
+    desired_rules: list[dict[str, Any]], actual_rules: list[dict[str, Any]]
+) -> list[str]:
+    diffs: list[str] = []
+
+    def by_type(rules: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for rule in rules:
+            grouped.setdefault(rule.get("type", ""), []).append(rule)
+        return grouped
+
+    desired_by_type = by_type(desired_rules)
+    actual_by_type = by_type(actual_rules)
+    for rule_type, desired_list in desired_by_type.items():
+        actual_list = actual_by_type.get(rule_type, [])
+        if not actual_list:
+            diffs.append(f"rule {rule_type}: missing")
+            continue
+        if rule_type == "pull_request":
+            diffs.extend(_pull_request_diff(desired_list[0], actual_list[0]))
+        elif rule_type == "required_status_checks":
+            diffs.extend(_status_checks_diff(desired_list[0], actual_list[0]))
+        # Rules without parameters (non_fast_forward, deletion) only need presence.
+    for rule_type in actual_by_type:
+        if rule_type not in desired_by_type:
+            diffs.append(f"rule {rule_type}: unexpected extra rule")
+    return diffs
+
+
+def ruleset_diff(desired: dict[str, Any], actual: dict[str, Any]) -> list[str]:
+    """Whitelist-based diff between desired and actual ruleset payloads.
+
+    Compares only the policy-relevant fields from library/policy.md and
+    ignores all API metadata (see METADATA_FIELDS). Returns an empty list
+    when the actual payload already matches the desired policy.
+    """
+    diffs: list[str] = []
+    if actual.get("enforcement") != desired.get("enforcement"):
+        diffs.append(
+            f"enforcement: expected {desired.get('enforcement')!r}, "
+            f"got {actual.get('enforcement')!r}"
+        )
+    if actual.get("target") != desired.get("target"):
+        diffs.append(
+            f"target: expected {desired.get('target')!r}, got {actual.get('target')!r}"
+        )
+    desired_conditions = desired.get("conditions") or {}
+    actual_conditions = actual.get("conditions") or {}
+    desired_ref = desired_conditions.get("ref_name") or {}
+    actual_ref = actual_conditions.get("ref_name") or {}
+    if _normalized_refs(actual_ref) != _normalized_refs(desired_ref):
+        diffs.append(
+            f"conditions.ref_name.include: expected {desired_ref.get('include')!r}, "
+            f"got {actual_ref.get('include')!r}"
+        )
+    if _normalized_exclude(actual_ref) != _normalized_exclude(desired_ref):
+        diffs.append(
+            f"conditions.ref_name.exclude: expected {desired_ref.get('exclude')!r}, "
+            f"got {actual_ref.get('exclude')!r}"
+        )
+    if _bypass_keys(actual.get("bypass_actors")) != _bypass_keys(
+        desired.get("bypass_actors")
+    ):
+        diffs.append(
+            f"bypass_actors: expected {desired.get('bypass_actors')!r}, "
+            f"got {actual.get('bypass_actors')!r}"
+        )
+    diffs.extend(_rules_diff(desired.get("rules") or [], actual.get("rules") or []))
+    return diffs
+
+
+def plan_changes(
+    desired: list[dict[str, Any]], actual: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Compute the change plan: create/update/none per desired ruleset."""
+    changes: list[dict[str, Any]] = []
+    for wanted in desired:
+        matches = [a for a in actual if a.get("name") == wanted.get("name")]
+        if not matches:
+            changes.append(
+                {
+                    "name": wanted["name"],
+                    "action": "create",
+                    "differences": [],
+                    "ruleset_id": None,
+                }
+            )
+            continue
+        current = matches[0]
+        diffs = ruleset_diff(wanted, current)
+        changes.append(
+            {
+                "name": wanted["name"],
+                "action": "update" if diffs else "none",
+                "differences": diffs,
+                "ruleset_id": current.get("id"),
+            }
+        )
+    return changes
+
+
+def ruleset_payload_for(name: str) -> dict[str, Any]:
+    for ruleset in RULESETS:
+        if ruleset["name"] == name:
+            return ruleset
+    raise ApplyAbortError(f"unknown ruleset name {name!r}")
+
+
+def verify_returned(returned: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Verify a created/updated ruleset is active with the exact expected policy."""
+    if returned.get("enforcement") != "active":
+        raise ApplyAbortError(
+            f"ruleset {returned.get('name')!r} is not active after apply "
+            f"(enforcement={returned.get('enforcement')!r})"
+        )
+    diffs = ruleset_diff(payload, returned)
+    if diffs:
+        raise ApplyAbortError(
+            f"ruleset {returned.get('name')!r} does not match policy after apply: "
+            f"{', '.join(diffs)}"
+        )
+
+
+# --- Orchestrator -----------------------------------------------------------
+
+
+def compute_plan(api: GithubApi) -> list[dict[str, Any]]:
+    actual = [api.get_ruleset(summary["id"]) for summary in api.list_rulesets()]
+    return plan_changes(RULESETS, actual)
+
+
+def apply_plan(
+    api: GithubApi, changes: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Apply Ruleset A then B (creating or updating), verify both active with
+    the exact expected rules, and only then remove the legacy classic branch
+    protection (404 treated as already removed). Aborts on any failure with
+    no further mutations after the failing point.
+    """
+    applied: list[dict[str, Any]] = []
+    for change in changes:
+        name = change["name"]
+        payload = ruleset_payload_for(name)
+        if change["action"] == "none":
+            applied.append({"name": name, "action": "none"})
+            continue
+        if change["action"] == "create":
+            returned = api.create_ruleset(payload)
+            action = "create"
+        elif change["action"] == "update":
+            returned = api.update_ruleset(change["ruleset_id"], payload)
+            action = "update"
+        else:
+            raise ApplyAbortError(
+                f"unknown change action {change['action']!r} for {name}"
+            )
+        verify_returned(returned, payload)
+        applied.append({"name": name, "action": action})
+
+    status, _ = api.delete_branch_protection()
+    if status == 404:
+        classic: dict[str, Any] = {"deleted": False, "already_removed": True}
+    elif status in (200, 204):
+        classic = {"deleted": True, "already_removed": False}
+    else:
+        raise ApplyAbortError(
+            f"could not remove legacy classic branch protection: HTTP {status}"
+        )
+    return applied, classic
+
+
+def run_orchestrator(
+    api: GithubApi,
+    *,
+    mode: str,
+    auth_source: str,
+    owner: str,
+    repo: str,
+    branch: str,
+) -> dict[str, Any]:
+    """Execute the enforcer. `mode` is "dry-run" (never mutates) or "apply".
+
+    Returns a structured summary suitable for both the human-readable report
+    and the `--json` output. Raises ApplyAbortError on pre-mutation or verification
+    failures in apply mode.
+    """
+    verified, missing, gate_error = api.safety_gate()
+    try:
+        changes = compute_plan(api)
+        plan_error: str | None = None
+    except EnforceError as exc:
+        changes = None
+        plan_error = str(exc)
+
+    summary: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "branch": branch,
+        "mode": mode,
+        "auth_source": auth_source,
+        "rulesets": [RULESET_A["name"], RULESET_B["name"]],
+        "safety_gate": {
+            "verified": verified,
+            "missing_contexts": missing,
+            "error": gate_error,
+        },
+        "changes": changes,
+        "no_changes": bool(
+            changes is not None and all(c["action"] == "none" for c in changes)
+        ),
+        "applied": [],
+        "classic_protection_removed": None,
+    }
+    if mode == "apply":
+        if not verified:
+            raise ApplyAbortError(
+                "aborting apply: required check contexts are missing or "
+                f"unverifiable on {branch} head "
+                f"(missing={missing or 'none'}, error={gate_error or 'none'})"
+            )
+        if changes is None:
+            raise ApplyAbortError(
+                f"aborting apply: could not compute the change plan ({plan_error})"
+            )
+        summary["applied"], classic = apply_plan(api, changes)
+        summary["classic_protection_removed"] = classic
+    return summary
+
+
+# --- Output ----------------------------------------------------------------
+
+
+def policy_report_text() -> str:
+    """Deterministic policy report (no timestamps, shas, or other
+    non-deterministic content) so two consecutive dry-runs are identical."""
+    lines = [
+        "=== POLICY REPORT ===",
+        f"Ruleset A: {RULESET_A['name']} (enforcement: {RULESET_A['enforcement']}, target: {RULESET_A['target']})",
+        "  conditions.ref_name.include: ~DEFAULT_BRANCH",
+        "  bypass_actors:",
+        "    - Integration 29110 (dependabot[bot]) - bypass_mode: pull_request",
+        "    - Integration 40688 (release-please[bot]) - bypass_mode: pull_request",
+        "  rules:",
+        "    - pull_request:",
+        "        required_approving_review_count: 1",
+        "        dismiss_stale_reviews_on_push: true",
+        "        require_last_push_approval: true",
+        "        require_code_owner_review: false",
+        "        required_review_thread_resolution: true",
+        f"Ruleset B: {RULESET_B['name']} (enforcement: {RULESET_B['enforcement']}, target: {RULESET_B['target']}, bypass_actors: none)",
+        "  conditions.ref_name.include: ~DEFAULT_BRANCH",
+        "  rules:",
+        "    - required_status_checks:",
+        "        strict_required_status_checks_policy: true",
+        "        required_status_checks:",
+        "          - Code Quality Gate (integration_id: null)",
+        "          - Runtime Gate (integration_id: null)",
+        "    - non_fast_forward",
+        "    - deletion",
+    ]
+    return "\n".join(lines)
+
+
+def render_text(summary: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("=== SAFETY GATE ===")
+    gate = summary["safety_gate"]
+    if gate["verified"]:
+        lines.append("verified: true")
+        lines.append("required contexts present: " + ", ".join(REQUIRED_CHECK_CONTEXTS))
+    else:
+        lines.append("verified: false")
+        if gate["missing_contexts"]:
+            lines.append("missing contexts: " + ", ".join(gate["missing_contexts"]))
+        if gate["error"]:
+            lines.append("error: " + gate["error"])
+    lines.append("")
+    lines.append("=== CHANGE PLAN ===")
+    changes = summary["changes"]
+    if changes is None:
+        lines.append("could not compute change plan against the live API")
+    elif all(c["action"] == "none" for c in changes):
+        lines.append("no changes")
+    else:
+        for change in changes:
+            if change["action"] == "none":
+                continue
+            lines.append(f"- {change['name']}: {change['action']}")
+            for difference in change["differences"]:
+                lines.append(f"    - {difference}")
+    if summary["applied"]:
+        lines.append("")
+        lines.append("=== APPLY RESULT ===")
+        for item in summary["applied"]:
+            lines.append(f"- {item['name']}: {item['action']}")
+        classic = summary["classic_protection_removed"]
+        if classic is not None:
+            if classic.get("deleted"):
+                lines.append("- classic branch protection: deleted")
+            elif classic.get("already_removed"):
+                lines.append("- classic branch protection: already removed (404)")
+    return "\n".join(lines)
+
+
+# --- CLI --------------------------------------------------------------------
+
+
+def repo_from_git_remote() -> tuple[str, str] | None:
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=10,
+        )
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
+        return None
+    remote = result.stdout.strip()
+    match = re.search(r"github\.com[:/]([^/]+)/([^/.]+?)(?:\.git)?$", remote)
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="enforce-branch-protection",
+        description=(
+            "Declaratively enforce the main-branch QA policy (two repository "
+            "rulesets per ADR-0046). Dry-run by default; --apply is the only "
+            "mode that mutates GitHub state."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="report policy, safety gate, and change plan without mutating (default)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="apply the policy: create/update rulesets, verify, remove classic protection",
+    )
+    parser.add_argument("--owner", help="GitHub owner (default: from git remote)")
+    parser.add_argument("--repo", help="GitHub repository (default: from git remote)")
+    parser.add_argument(
+        "--branch",
+        default=DEFAULT_BRANCH,
+        help=f"target branch (default: {DEFAULT_BRANCH})",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit a single JSON document instead of the human-readable report",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        token, auth_source = resolve_auth()
+    except AuthError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    owner, repo = args.owner, args.repo
+    if owner is None or repo is None:
+        remote = repo_from_git_remote()
+        if remote is None:
+            print(
+                "error: could not determine owner/repo from the git remote; "
+                "pass --owner and --repo",
+                file=sys.stderr,
+            )
+            return 2
+        owner = owner or remote[0]
+        repo = repo or remote[1]
+
+    mode = "apply" if args.apply else "dry-run"
+    api = GithubApi(
+        HttpTransport(token=token), owner=owner, repo=repo, branch=args.branch
+    )
+
+    try:
+        summary = run_orchestrator(
+            api,
+            mode=mode,
+            auth_source=auth_source,
+            owner=owner,
+            repo=repo,
+            branch=args.branch,
+        )
+    except ApplyAbortError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"auth: {auth_source}")
+        print(policy_report_text())
+        print()
+        print(render_text(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/service/test_code_quality_gate.py
+++ b/tests/service/test_code_quality_gate.py
@@ -1,0 +1,125 @@
+"""Contract tests for the Code Quality Gate aggregate job.
+
+The gate job in `.github/workflows/code-quality.yml` mirrors the proven
+Runtime Gate pattern from `docker.yml`: an always-run aggregate over the
+three Code Quality source jobs that concludes `failure` (never `skipped`
+or `neutral`) when any dependency does not succeed. Branch rules require
+the stable `Code Quality Gate` check context, so its structure is pinned
+by these regression tests (same idea as `test_ci_change_classification.py`).
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "code-quality.yml"
+
+GATE_NAME = "Code Quality Gate"
+SOURCE_JOBS = {"python-checks", "duplicate-code", "secret-scan"}
+
+
+class CodeQualityGateContractTests(unittest.TestCase):
+    """Structural contract for the Code Quality Gate aggregate job."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not WORKFLOW.exists():
+            raise unittest.SkipTest(
+                "code-quality.yml is not present in this environment "
+                "(the Docker integration container only receives "
+                "docker.yml and fast-tests.yml)"
+            )
+        cls.workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        # PyYAML parses the `on:` key as the YAML 1.1 boolean True.
+        cls.triggers = cls.workflow.get("on") or cls.workflow.get(True)
+        cls.jobs = cls.workflow["jobs"]
+
+    @classmethod
+    def gate_jobs(cls) -> list[tuple[str, dict]]:
+        return [
+            (job_id, job)
+            for job_id, job in cls.jobs.items()
+            if job.get("name") == GATE_NAME
+        ]
+
+    def test_gate_job_exists_exactly_once_and_is_not_a_matrix(self) -> None:
+        gates = self.gate_jobs()
+        self.assertEqual(len(gates), 1)
+        job_id, job = gates[0]
+        self.assertNotIn("strategy", job)
+        self.assertNotIn("matrix", job)
+        # The gate is an aggregate over the three source jobs, not a source itself.
+        self.assertNotIn(job_id, SOURCE_JOBS)
+
+    def test_gate_depends_on_exactly_the_three_source_jobs(self) -> None:
+        _, job = self.gate_jobs()[0]
+        self.assertEqual(set(job["needs"]), SOURCE_JOBS)
+        # Every needed job id exists as a job in the same workflow file.
+        for source in SOURCE_JOBS:
+            self.assertIn(source, self.jobs)
+
+    def test_gate_runs_unconditionally(self) -> None:
+        _, job = self.gate_jobs()[0]
+        self.assertEqual(job["if"], "always()")
+
+    def test_no_continue_on_error_in_gate_job(self) -> None:
+        _, job = self.gate_jobs()[0]
+        for step in job.get("steps", []):
+            self.assertNotIn("continue-on-error", step)
+
+    def test_every_exit_1_step_is_conditioned_on_a_non_success_dependency(
+        self,
+    ) -> None:
+        _, job = self.gate_jobs()[0]
+        exit_steps = [
+            step
+            for step in job.get("steps", [])
+            if "exit 1" in str(step.get("run", ""))
+        ]
+        self.assertGreaterEqual(len(exit_steps), len(SOURCE_JOBS))
+        conditions = " ".join(step.get("if", "") for step in exit_steps)
+        for step in exit_steps:
+            condition = step.get("if", "")
+            self.assertIn("needs.", condition)
+            self.assertIn("result != 'success'", condition)
+        # Each source job has at least one dedicated failure step.
+        for source in SOURCE_JOBS:
+            self.assertIn(f"needs.{source}.result != 'success'", conditions)
+
+    def test_no_unconditional_failure_step_exists(self) -> None:
+        _, job = self.gate_jobs()[0]
+        for step in job.get("steps", []):
+            run = str(step.get("run", ""))
+            if "exit 1" in run:
+                self.assertIn(
+                    "needs.", step.get("if", ""), f"unconditional exit step: {step}"
+                )
+                self.assertIn("result != 'success'", step.get("if", ""))
+
+    def test_each_failure_step_references_exactly_one_dependency(self) -> None:
+        _, job = self.gate_jobs()[0]
+        for step in job.get("steps", []):
+            if "exit 1" not in str(step.get("run", "")):
+                continue
+            condition = step.get("if", "")
+            referenced = set(re.findall(r"needs\.(\S+?)\.result", condition))
+            self.assertEqual(len(referenced), 1, condition)
+            self.assertIn(next(iter(referenced)), SOURCE_JOBS)
+
+    def test_workflow_triggers_unchanged(self) -> None:
+        self.assertEqual(self.triggers["push"]["branches"], ["main"])
+        self.assertEqual(self.triggers["pull_request"]["branches"], ["main"])
+
+    def test_source_jobs_still_present(self) -> None:
+        for source in SOURCE_JOBS:
+            self.assertIn(source, self.jobs)
+            self.assertNotIn("strategy", self.jobs[source])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/service/test_enforce_branch_protection.py
+++ b/tests/service/test_enforce_branch_protection.py
@@ -1,0 +1,680 @@
+"""Unit tests for scripts/enforce-branch-protection.py (no network).
+
+Covers the pure policy layer (payload construction, whitelist idempotency
+comparator), the safety gate, the apply ordering, auth precedence, and the
+JSON output — all against a recording fake transport so no network access
+is required. Follows the `importlib.util.spec_from_file_location` pattern
+from `test_ci_change_classification.py`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import re
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "enforce-branch-protection.py"
+
+SPEC = (
+    importlib.util.spec_from_file_location("enforce_branch_protection", SCRIPT)
+    if SCRIPT.exists()
+    else None
+)
+if SPEC and SPEC.loader:
+    MODULE = importlib.util.module_from_spec(SPEC)
+    SPEC.loader.exec_module(MODULE)
+else:
+    MODULE = None
+
+META = {
+    "node_id": "RULE_x",
+    "source_type": "Repository",
+    "source": "github",
+    "created_at": "2026-08-03T00:00:00Z",
+    "updated_at": "2026-08-03T00:00:00Z",
+    "url": "https://api.github.com/repos/groktopus/groktocrawl/rulesets/1",
+    "links": {"html": "https://github.com/groktopus/groktocrawl/rules/1"},
+    "_links": {},
+    "current_user_can_bypass": False,
+}
+
+
+class FakeTransport:
+    """Recording fake for the injectable HTTP layer."""
+
+    def __init__(
+        self, handlers: dict[str, Callable[..., tuple[int, Any, dict[str, str]]]]
+    ) -> None:
+        self.handlers = handlers
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def _dispatch(
+        self, method: str, path: str, payload: Any = None
+    ) -> tuple[int, Any, dict[str, str]]:
+        self.calls.append((method, path, payload))
+        handler = self.handlers.get(method)
+        if handler is None:
+            raise AssertionError(f"no handler for {method} {path}")
+        return handler(path, payload)
+
+    def get(self, path: str) -> tuple[int, Any, dict[str, str]]:
+        return self._dispatch("GET", path)
+
+    def post(self, path: str, payload: Any) -> tuple[int, Any, dict[str, str]]:
+        return self._dispatch("POST", path, payload)
+
+    def put(self, path: str, payload: Any) -> tuple[int, Any, dict[str, str]]:
+        return self._dispatch("PUT", path, payload)
+
+    def delete(self, path: str) -> tuple[int, Any, dict[str, str]]:
+        return self._dispatch("DELETE", path)
+
+
+def build_handlers(
+    check_names: tuple[str, ...] = ("Code Quality Gate", "Runtime Gate"),
+    rulesets: list[dict[str, Any]] | None = None,
+    check_error: Exception | None = None,
+    delete_status: int = 204,
+) -> dict[str, Callable[..., tuple[int, Any, dict[str, str]]]]:
+    """Handlers for a healthy scenario: check-runs, rulesets list + detail,
+    echo create/update, and configurable classic-protection DELETE status."""
+
+    def get_handler(path: str, _payload: Any) -> tuple[int, Any, dict[str, str]]:
+        base = path.split("?", maxsplit=1)[0]
+        if base.endswith("/check-runs"):
+            if check_error is not None:
+                raise check_error
+            runs = [
+                {"name": name, "status": "completed", "conclusion": "success"}
+                for name in check_names
+            ]
+            return 200, {"total_count": len(runs), "check_runs": runs}, {}
+        if base.endswith("/rulesets"):
+            return 200, rulesets or [], {}
+        match = re.match(r".*/rulesets/(\d+)$", base)
+        if match:
+            ruleset_id = int(match.group(1))
+            for ruleset in rulesets or []:
+                if ruleset.get("id") == ruleset_id:
+                    return 200, ruleset, {}
+            raise AssertionError(f"unknown ruleset id {ruleset_id}")
+        raise AssertionError(f"unhandled GET {path}")
+
+    def post_handler(path: str, payload: Any) -> tuple[int, Any, dict[str, str]]:
+        return 201, {**payload, "id": 9001}, {}
+
+    def put_handler(path: str, payload: Any) -> tuple[int, Any, dict[str, str]]:
+        return 200, {**payload, "id": 9001}, {}
+
+    def delete_handler(path: str, _payload: Any) -> tuple[int, Any, dict[str, str]]:
+        return delete_status, {}, {}
+
+    return {
+        "GET": get_handler,
+        "POST": post_handler,
+        "PUT": put_handler,
+        "DELETE": delete_handler,
+    }
+
+
+def make_api(transport: FakeTransport) -> Any:
+    return MODULE.GithubApi(
+        transport, owner="groktopus", repo="groktocrawl", branch="main"
+    )
+
+
+def fake_transport_factory(transport: FakeTransport) -> Callable[..., FakeTransport]:
+    """Return an HttpTransport-compatible factory bound to a recording fake.
+
+    The factory accepts HttpTransport's constructor signature (token and
+    optional base_url/timeout) and always hands back the same fake, so
+    `main()` can be exercised without network access.
+    """
+
+    def _factory(
+        token: str, base_url: str = "https://api.github.com", timeout: float = 30.0
+    ) -> FakeTransport:
+        # token/base_url/timeout are accepted for constructor compatibility.
+        return transport
+
+    return _factory
+
+
+def with_github_token(fn: Callable[[], Any]) -> Any:
+    """Run fn with GITHUB_TOKEN set so auth resolution is hermetic."""
+    old = os.environ.get("GITHUB_TOKEN")
+    os.environ["GITHUB_TOKEN"] = "test-token"
+    try:
+        return fn()
+    finally:
+        if old is None:
+            os.environ.pop("GITHUB_TOKEN", None)
+        else:
+            os.environ["GITHUB_TOKEN"] = old
+
+
+class ModuleLoadTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_module_imports_without_side_effects(self) -> None:
+        self.assertEqual(MODULE.__name__, "enforce_branch_protection")
+        # No top-level main() call: import must not parse argv or touch the network.
+        self.assertTrue(callable(MODULE.main))
+        self.assertTrue(callable(MODULE.ruleset_diff))
+        self.assertTrue(callable(MODULE.plan_changes))
+        self.assertTrue(callable(MODULE.resolve_auth))
+
+
+class PolicyPayloadTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_ruleset_a_payload_matches_architecture(self) -> None:
+        ruleset = MODULE.RULESET_A
+        self.assertEqual(ruleset["name"], "main review policy")
+        self.assertEqual(ruleset["enforcement"], "active")
+        self.assertEqual(ruleset["target"], "branch")
+        self.assertEqual(
+            ruleset["conditions"]["ref_name"]["include"], ["~DEFAULT_BRANCH"]
+        )
+        self.assertEqual(ruleset["conditions"]["ref_name"]["exclude"], [])
+        bypasses = sorted(
+            (actor["actor_type"], actor["actor_id"], actor["bypass_mode"])
+            for actor in ruleset["bypass_actors"]
+        )
+        self.assertEqual(
+            bypasses,
+            [
+                ("Integration", 29110, "pull_request"),
+                ("Integration", 40688, "pull_request"),
+            ],
+        )
+        self.assertEqual(len(ruleset["rules"]), 1)
+        pull_request = ruleset["rules"][0]
+        self.assertEqual(pull_request["type"], "pull_request")
+        self.assertEqual(
+            pull_request["parameters"],
+            {
+                "required_approving_review_count": 1,
+                "dismiss_stale_reviews_on_push": True,
+                "require_last_push_approval": True,
+                "require_code_owner_review": False,
+                "required_review_thread_resolution": True,
+            },
+        )
+
+    def test_ruleset_b_payload_matches_architecture(self) -> None:
+        ruleset = MODULE.RULESET_B
+        self.assertEqual(ruleset["name"], "main required checks")
+        self.assertEqual(ruleset["enforcement"], "active")
+        self.assertEqual(ruleset["target"], "branch")
+        self.assertNotIn("bypass_actors", ruleset)
+        self.assertEqual(
+            [rule["type"] for rule in ruleset["rules"]],
+            ["required_status_checks", "non_fast_forward", "deletion"],
+        )
+        status_checks = ruleset["rules"][0]
+        self.assertTrue(
+            status_checks["parameters"]["strict_required_status_checks_policy"]
+        )
+        self.assertEqual(
+            [
+                (entry["context"], entry["integration_id"])
+                for entry in status_checks["parameters"]["required_status_checks"]
+            ],
+            [("Code Quality Gate", None), ("Runtime Gate", None)],
+        )
+
+    def test_required_check_contexts_are_the_two_stable_gates(self) -> None:
+        self.assertEqual(
+            set(MODULE.REQUIRED_CHECK_CONTEXTS), {"Code Quality Gate", "Runtime Gate"}
+        )
+
+
+class IdempotencyComparatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_metadata_rich_actual_yields_no_changes(self) -> None:
+        actual_a = {**MODULE.RULESET_A, **META, "id": 11}
+        actual_b = {**MODULE.RULESET_B, **META, "id": 12}
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_A, actual_a), [])
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_B, actual_b), [])
+        changes = MODULE.plan_changes(MODULE.RULESETS, [actual_a, actual_b])
+        self.assertEqual([change["action"] for change in changes], ["none", "none"])
+        self.assertTrue(all(change["differences"] == [] for change in changes))
+
+    def test_resolved_default_branch_ref_is_normalized(self) -> None:
+        actual = json.loads(json.dumps(MODULE.RULESET_A))
+        actual["id"] = 21
+        actual["conditions"] = {"ref_name": {"include": ["refs/heads/main"]}}
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_A, actual), [])
+
+    def test_absent_exclude_is_normalized(self) -> None:
+        actual = json.loads(json.dumps(MODULE.RULESET_B))
+        actual["id"] = 22
+        actual["conditions"] = {"ref_name": {"include": ["~DEFAULT_BRANCH"]}}
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_B, actual), [])
+
+    def test_absent_integration_id_is_tolerated(self) -> None:
+        actual = json.loads(json.dumps(MODULE.RULESET_B))
+        actual["id"] = 23
+        for entry in actual["rules"][0]["parameters"]["required_status_checks"]:
+            del entry["integration_id"]
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_B, actual), [])
+
+    def test_absent_false_pull_request_parameter_is_tolerated(self) -> None:
+        actual = json.loads(json.dumps(MODULE.RULESET_A))
+        actual["id"] = 24
+        del actual["rules"][0]["parameters"]["require_code_owner_review"]
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_A, actual), [])
+
+    def test_context_order_is_ignored(self) -> None:
+        actual = json.loads(json.dumps(MODULE.RULESET_B))
+        actual["id"] = 25
+        actual["rules"][0]["parameters"]["required_status_checks"].reverse()
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_B, actual), [])
+
+    def test_bypass_actor_order_is_ignored(self) -> None:
+        actual = json.loads(json.dumps(MODULE.RULESET_A))
+        actual["id"] = 26
+        actual["bypass_actors"].reverse()
+        self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_A, actual), [])
+
+    def test_policy_differences_are_detected(self) -> None:
+        actual = json.loads(json.dumps(MODULE.RULESET_B))
+        actual["id"] = 27
+        actual["rules"][0]["parameters"]["required_status_checks"] = [
+            {"context": "Code Quality Gate", "integration_id": None}
+        ]
+        diffs = MODULE.ruleset_diff(MODULE.RULESET_B, actual)
+        self.assertTrue(any("contexts" in diff for diff in diffs))
+
+    def test_missing_ruleset_produces_create_change(self) -> None:
+        changes = MODULE.plan_changes(MODULE.RULESETS, [])
+        self.assertEqual([change["action"] for change in changes], ["create", "create"])
+        self.assertEqual(changes[0]["name"], "main review policy")
+        self.assertEqual(changes[1]["name"], "main required checks")
+
+    def test_partially_missing_ruleset_produces_one_create(self) -> None:
+        actual_a = json.loads(json.dumps(MODULE.RULESET_A))
+        actual_a["id"] = 31
+        changes = MODULE.plan_changes(MODULE.RULESETS, [actual_a])
+        self.assertEqual(changes[0]["action"], "none")
+        self.assertEqual(changes[1]["action"], "create")
+
+
+class SafetyGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_missing_context_aborts_apply_with_zero_mutations(self) -> None:
+        transport = FakeTransport(
+            build_handlers(check_names=("Runtime Gate",), rulesets=[])
+        )
+        api = make_api(transport)
+        with self.assertRaises(MODULE.ApplyAbortError) as ctx:
+            MODULE.run_orchestrator(
+                api,
+                mode="apply",
+                auth_source="gh",
+                owner="groktopus",
+                repo="groktocrawl",
+                branch="main",
+            )
+        self.assertIn("aborting apply", str(ctx.exception))
+        methods = [call[0] for call in transport.calls]
+        self.assertEqual([m for m in methods if m in ("POST", "PUT", "DELETE")], [])
+        self.assertTrue(all(m == "GET" for m in methods))
+
+    def test_dry_run_with_unreachable_safety_gate_does_not_abort(self) -> None:
+        transport = FakeTransport(
+            build_handlers(check_error=MODULE.TransportError("boom"), rulesets=[])
+        )
+        api = make_api(transport)
+        summary = MODULE.run_orchestrator(
+            api,
+            mode="dry-run",
+            auth_source="gh",
+            owner="groktopus",
+            repo="groktocrawl",
+            branch="main",
+        )
+        self.assertFalse(summary["safety_gate"]["verified"])
+        self.assertIn("boom", summary["safety_gate"]["error"])
+        report = f"{MODULE.policy_report_text()}\n\n{MODULE.render_text(summary)}"
+        self.assertIn("=== POLICY REPORT ===", report)
+        self.assertIn("=== SAFETY GATE ===", report)
+        methods = [call[0] for call in transport.calls]
+        self.assertEqual([m for m in methods if m in ("POST", "PUT", "DELETE")], [])
+
+    def test_main_dry_run_unreachable_safety_gate_exits_zero(self) -> None:
+        transport = FakeTransport(
+            build_handlers(check_error=MODULE.TransportError("boom"), rulesets=[])
+        )
+        original = MODULE.HttpTransport
+        MODULE.HttpTransport = fake_transport_factory(transport)
+
+        def run() -> int:
+            return MODULE.main(
+                [
+                    "--dry-run",
+                    "--owner",
+                    "groktopus",
+                    "--repo",
+                    "groktocrawl",
+                    "--branch",
+                    "main",
+                ]
+            )
+
+        try:
+            rc = with_github_token(run)
+        finally:
+            MODULE.HttpTransport = original
+        self.assertEqual(rc, 0)
+
+    def test_main_apply_missing_context_returns_nonzero(self) -> None:
+        transport = FakeTransport(
+            build_handlers(check_names=("Runtime Gate",), rulesets=[])
+        )
+        original = MODULE.HttpTransport
+        MODULE.HttpTransport = fake_transport_factory(transport)
+
+        def run() -> int:
+            return MODULE.main(
+                [
+                    "--apply",
+                    "--owner",
+                    "groktopus",
+                    "--repo",
+                    "groktocrawl",
+                    "--branch",
+                    "main",
+                ]
+            )
+
+        try:
+            rc = with_github_token(run)
+        finally:
+            MODULE.HttpTransport = original
+        self.assertEqual(rc, 1)
+        methods = [call[0] for call in transport.calls]
+        self.assertEqual([m for m in methods if m in ("POST", "PUT", "DELETE")], [])
+
+
+class ApplySequenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_apply_orders_rulesets_then_classic_removal(self) -> None:
+        transport = FakeTransport(
+            build_handlers(
+                check_names=("Code Quality Gate", "Runtime Gate"),
+                rulesets=[],
+                delete_status=204,
+            )
+        )
+        api = make_api(transport)
+        summary = MODULE.run_orchestrator(
+            api,
+            mode="apply",
+            auth_source="gh",
+            owner="groktopus",
+            repo="groktocrawl",
+            branch="main",
+        )
+        calls = transport.calls
+        posts = [
+            (index, call[1], call[2])
+            for index, call in enumerate(calls)
+            if call[0] == "POST"
+        ]
+        deletes = [
+            (index, call[1]) for index, call in enumerate(calls) if call[0] == "DELETE"
+        ]
+        self.assertEqual(len(posts), 2)
+        self.assertEqual(len(deletes), 1)
+        self.assertLess(posts[0][0], posts[1][0])
+        self.assertLess(posts[1][0], deletes[0][0])
+        self.assertIn("/rulesets", posts[0][1])
+        self.assertIn("main review policy", json.dumps(posts[0][2]))
+        self.assertIn("main required checks", json.dumps(posts[1][2]))
+        self.assertIn("/branches/main/protection", deletes[0][1])
+        self.assertEqual(
+            summary["applied"],
+            [
+                {"name": "main review policy", "action": "create"},
+                {"name": "main required checks", "action": "create"},
+            ],
+        )
+        self.assertTrue(summary["classic_protection_removed"]["deleted"])
+
+    def test_apply_stops_on_verification_failure_before_classic_removal(self) -> None:
+        handlers = build_handlers(
+            check_names=("Code Quality Gate", "Runtime Gate"),
+            rulesets=[],
+            delete_status=204,
+        )
+
+        def failing_post(path: str, payload: Any) -> tuple[int, Any, dict[str, str]]:
+            return 201, {**payload, "id": 9001, "enforcement": "disabled"}, {}
+
+        handlers["POST"] = failing_post
+        transport = FakeTransport(handlers)
+        api = make_api(transport)
+        with self.assertRaises(MODULE.ApplyAbortError):
+            MODULE.run_orchestrator(
+                api,
+                mode="apply",
+                auth_source="gh",
+                owner="groktopus",
+                repo="groktocrawl",
+                branch="main",
+            )
+        methods = [call[0] for call in transport.calls]
+        self.assertNotIn("DELETE", methods)
+        # Only Ruleset A was attempted before the abort.
+        self.assertEqual(methods.count("POST"), 1)
+
+    def test_apply_treats_404_on_classic_protection_as_already_removed(self) -> None:
+        transport = FakeTransport(
+            build_handlers(
+                check_names=("Code Quality Gate", "Runtime Gate"),
+                rulesets=[],
+                delete_status=404,
+            )
+        )
+        api = make_api(transport)
+        summary = MODULE.run_orchestrator(
+            api,
+            mode="apply",
+            auth_source="gh",
+            owner="groktopus",
+            repo="groktocrawl",
+            branch="main",
+        )
+        self.assertTrue(summary["classic_protection_removed"]["already_removed"])
+        self.assertFalse(summary["classic_protection_removed"]["deleted"])
+
+
+class NoMutationWithoutApplyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_dry_run_issues_zero_mutating_calls(self) -> None:
+        transport = FakeTransport(
+            build_handlers(
+                check_names=("Code Quality Gate", "Runtime Gate"), rulesets=[]
+            )
+        )
+        api = make_api(transport)
+        summary = MODULE.run_orchestrator(
+            api,
+            mode="dry-run",
+            auth_source="gh",
+            owner="groktopus",
+            repo="groktocrawl",
+            branch="main",
+        )
+        methods = [call[0] for call in transport.calls]
+        self.assertEqual([m for m in methods if m in ("POST", "PUT", "DELETE")], [])
+        self.assertEqual(
+            [change["action"] for change in summary["changes"]], ["create", "create"]
+        )
+
+    def test_apply_is_the_only_mode_that_reaches_mutation_code(self) -> None:
+        self.assertTrue(hasattr(MODULE, "apply_plan"))
+        # The orchestrator only calls apply_plan when mode == "apply".
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('if mode == "apply":', source)
+
+
+class AuthTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_github_token_takes_precedence_over_gh(self) -> None:
+        def boom() -> str:
+            raise AssertionError(
+                "gh runner must not be called when GITHUB_TOKEN is set"
+            )
+
+        token, source = MODULE.resolve_auth(
+            env={"GITHUB_TOKEN": "env-token"}, gh_token_runner=boom
+        )
+        self.assertEqual((token, source), ("env-token", "GITHUB_TOKEN"))
+
+    def test_gh_fallback_used_without_github_token(self) -> None:
+        token, source = MODULE.resolve_auth(env={}, gh_token_runner=lambda: "gh-token")
+        self.assertEqual((token, source), ("gh-token", "gh"))
+
+    def test_neither_auth_source_raises_clear_error(self) -> None:
+        with self.assertRaises(MODULE.AuthError) as ctx:
+            MODULE.resolve_auth(env={}, gh_token_runner=lambda: None)
+        self.assertIn("GITHUB_TOKEN", str(ctx.exception))
+
+    def test_main_neither_auth_returns_error_without_mutations(self) -> None:
+        transport = FakeTransport({})
+        original_transport = MODULE.HttpTransport
+        original_runner = MODULE._default_gh_token
+        MODULE.HttpTransport = fake_transport_factory(transport)
+        MODULE._default_gh_token = lambda: None
+        old = os.environ.pop("GITHUB_TOKEN", None)
+
+        def run() -> int:
+            return MODULE.main(
+                ["--dry-run", "--owner", "groktopus", "--repo", "groktocrawl"]
+            )
+
+        try:
+            rc = run()
+        finally:
+            MODULE.HttpTransport = original_transport
+            MODULE._default_gh_token = original_runner
+            if old is not None:
+                os.environ["GITHUB_TOKEN"] = old
+        self.assertEqual(rc, 2)
+        self.assertEqual(transport.calls, [])
+
+
+class JsonOutputTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def test_summary_json_parses_with_required_keys(self) -> None:
+        transport = FakeTransport(
+            build_handlers(
+                check_names=("Code Quality Gate", "Runtime Gate"), rulesets=[]
+            )
+        )
+        api = make_api(transport)
+        summary = MODULE.run_orchestrator(
+            api,
+            mode="dry-run",
+            auth_source="GITHUB_TOKEN",
+            owner="groktopus",
+            repo="groktocrawl",
+            branch="main",
+        )
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        parsed = json.loads(text)
+        self.assertIn("main review policy", parsed["rulesets"])
+        self.assertIn("main required checks", parsed["rulesets"])
+        self.assertIn("no_changes", parsed)
+        self.assertIn("safety_gate", parsed)
+        self.assertEqual(parsed["auth_source"], "GITHUB_TOKEN")
+        self.assertEqual(parsed["mode"], "dry-run")
+
+    def test_main_dry_run_json_emits_single_valid_document(self) -> None:
+        transport = FakeTransport(
+            build_handlers(
+                check_names=("Code Quality Gate", "Runtime Gate"), rulesets=[]
+            )
+        )
+        original = MODULE.HttpTransport
+        MODULE.HttpTransport = fake_transport_factory(transport)
+        buf = io.StringIO()
+
+        def run() -> int:
+            with contextlib.redirect_stdout(buf):
+                return MODULE.main(
+                    [
+                        "--dry-run",
+                        "--json",
+                        "--owner",
+                        "groktopus",
+                        "--repo",
+                        "groktocrawl",
+                        "--branch",
+                        "main",
+                    ]
+                )
+
+        try:
+            rc = with_github_token(run)
+        finally:
+            MODULE.HttpTransport = original
+        self.assertEqual(rc, 0)
+        parsed = json.loads(buf.getvalue())
+        self.assertIn("main review policy", parsed["rulesets"])
+        self.assertIn("main required checks", parsed["rulesets"])
+        self.assertIn("no_changes", parsed)
+        self.assertIn("safety_gate", parsed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR makes the QA signals enforceable release conditions on `main` (issue #499). Today the classic branch-protection rule requires 0 approving reviews and no required status checks, so the Code Quality and Runtime Gate results are advisory at the merge boundary.

What this PR adds:

- **Code Quality Gate** — an always-run aggregate job in `.github/workflows/code-quality.yml` (`needs: [python-checks, duplicate-code, secret-scan]`, `if: always()`, per-dependency explicit `exit 1`, no `continue-on-error`), giving one stable check context that branch rules can require.
- **Enforcement script** — `scripts/enforce-branch-protection.py`: declarative, idempotent, `--dry-run` default / `--apply` sole mutation path, pre-mutation safety gate, the two-ruleset policy per ADR-0046, JSON output, `GITHUB_TOKEN` / `gh` auth.
- **Tests** — `tests/service/test_code_quality_gate.py` (gate workflow structure) and `tests/service/test_enforce_branch_protection.py` (payload construction, idempotency, safety gate, apply ordering, auth precedence, JSON output).
- **Docs** — ADR-0046 (policy, two-ruleset split rationale, bot exemption, emergency path, audit trail, open-PR consequence), emergency branch-protection runbook, and policy notes in CONTRIBUTING.md / README.md.

## Related Issue

Closes #499

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/` (the full Docker Runtime Gate lane runs on this PR — workflows/scripts/tests changed; pending CI)
- [x] New tests added for the change
- [x] Manual verification done (describe): fast-tests lane green locally (1186 passed); enforcement script `--dry-run` verified against the live API (read-only) with deterministic policy report and JSON output

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] N/A — New API endpoints have a corresponding CLI subcommand (see ADR-0039); no API change
- [ ] N/A — If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure; no API change

## Notes for Reviewers

- The enforcement script defaults to `--dry-run` and creates nothing; the policy is applied in a follow-up step (M2) after this PR merges and is reviewed.
- ADR-0046 is marked `proposed` per repo convention (accepted after the PR is reviewed and merged).
- This PR changes workflows/scripts/tests, so the classifier requires the full Docker Runtime Gate lane on the self-hosted runner (can take 10–30 min).
