### PR TITLE
docs: promote ADR-0046 status to accepted

### DIFF
--- a/docs/adr/0046-enforce-qa-checks-and-review-policy-on-main.md
+++ b/docs/adr/0046-enforce-qa-checks-and-review-policy-on-main.md
@@ -1,6 +1,6 @@
 # Enforce QA Checks and Review Policy on main
 
-* Status: proposed
+* Status: accepted
 * Deciders: GroktoCrawl maintainers
 * Date: 2026-08-03
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,9 +19,9 @@ An Architecture Decision Record captures an important architectural decision mad
 
 **Status legend:** accepted ADRs describe decisions used by the current implementation. Proposed ADRs are design work, not promises of current behavior. Superseded ADRs are historical context only; use their successor when documenting current behavior.
 
-**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, and 0045.
+**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, and 0046.
 
-**Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, 0040–0042, and 0046.
+**Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, and 0040–0042.
 
 | ADR | Title | Status |
 |-----|-------|--------|
@@ -70,6 +70,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0043 | [Migration from SearXNG to SlopSearX](0043-migration-to-slopsearx.md) | accepted |
 | 0044 | [Autonomous CAPTCHA Recovery](0044-autonomous-captcha-recovery.md) | accepted |
 | 0045 | [Outbound Webhook Destination Validation](0045-outbound-webhook-destination-validation.md) | accepted |
-| 0046 | [Enforce QA Checks and Review Policy on main](0046-enforce-qa-checks-and-review-policy-on-main.md) | proposed |
+| 0046 | [Enforce QA Checks and Review Policy on main](0046-enforce-qa-checks-and-review-policy-on-main.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.


### PR DESCRIPTION
## Summary

Post-merge promotion of ADR-0046 ("Enforce QA Checks and Review Policy on main") to **accepted**, per repo convention (see precedent commits `887be9d` "docs: promote ADR-0039 status to accepted" and `6a83d5d` "docs: promote ADR-0035 from proposed to accepted").

The policy documented by ADR-0046 shipped and landed on `main` in #512 (merge `9277c293`) and is now in effect: the Code Quality Gate and Runtime Gate are required checks, and the review policy (1 approving review, stale dismissal, resolved threads, bot exemption, enforced on admins) is active. This tiny docs-only PR flips the ADR status to accepted and updates the ADR index accordingly.

## Related Issue

Refs #499 (QA Enforcement and Signal Integrity). The parent work was resolved via #512; this PR is the conventional post-merge status promotion of the ADR that documents the shipped policy.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [ ] New tests added for the change
- [x] Manual verification done (describe)

Docs-only change (two files under `docs/adr/`): status line flipped to accepted; index row updated; ADR-0046 moved from the "Proposed work" prose list to "Current accepted decisions". No production code, workflow, or test changes, so the CI classifier runs no Docker lane; Runtime Gate still reports success.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

- No test additions: a documentation status promotion with zero code change.
- The `CHANGELOG` was not updated; ADR promotions have not historically been changelog entries (see `887be9d`).
- Do not merge until CI is green (Fast Tests, Code Quality incl. the gate, Docs Surface inventory, Droid review; Runtime Gate succeeds on docs-only PRs without a Docker lane).
