### PR TITLE
fix: omit integration_id from Ruleset B required status checks payload

### DIFF
--- a/scripts/enforce-branch-protection.py
+++ b/scripts/enforce-branch-protection.py
@@ -103,9 +103,13 @@ RULESET_B: dict[str, Any] = {
             "type": "required_status_checks",
             "parameters": {
                 "strict_required_status_checks_policy": True,
+                # integration_id is intentionally omitted: GitHub's REST schema
+                # types it as integer (not nullable) and rejects `null`, while
+                # an absent value means "any source" — identical policy (the
+                # idempotency comparator treats absent and null as equal).
                 "required_status_checks": [
-                    {"context": "Code Quality Gate", "integration_id": None},
-                    {"context": "Runtime Gate", "integration_id": None},
+                    {"context": "Code Quality Gate"},
+                    {"context": "Runtime Gate"},
                 ],
             },
         },
@@ -718,8 +722,8 @@ def policy_report_text() -> str:
         "    - required_status_checks:",
         "        strict_required_status_checks_policy: true",
         "        required_status_checks:",
-        "          - Code Quality Gate (integration_id: null)",
-        "          - Runtime Gate (integration_id: null)",
+        "          - Code Quality Gate",
+        "          - Runtime Gate",
         "    - non_fast_forward",
         "    - deletion",
     ]

--- a/tests/service/test_enforce_branch_protection.py
+++ b/tests/service/test_enforce_branch_protection.py
@@ -235,11 +235,16 @@ class PolicyPayloadTests(unittest.TestCase):
         )
         self.assertEqual(
             [
-                (entry["context"], entry["integration_id"])
+                entry["context"]
                 for entry in status_checks["parameters"]["required_status_checks"]
             ],
-            [("Code Quality Gate", None), ("Runtime Gate", None)],
+            ["Code Quality Gate", "Runtime Gate"],
         )
+        # integration_id is omitted from the payload: the REST schema types it
+        # as integer (not nullable) and rejects null; absent means "any
+        # source", which is the policy (VAL-ENF-003 tolerates absent-or-null).
+        for entry in status_checks["parameters"]["required_status_checks"]:
+            self.assertNotIn("integration_id", entry)
 
     def test_required_check_contexts_are_the_two_stable_gates(self) -> None:
         self.assertEqual(
@@ -279,7 +284,7 @@ class IdempotencyComparatorTests(unittest.TestCase):
         actual = json.loads(json.dumps(MODULE.RULESET_B))
         actual["id"] = 23
         for entry in actual["rules"][0]["parameters"]["required_status_checks"]:
-            del entry["integration_id"]
+            entry["integration_id"] = None
         self.assertEqual(MODULE.ruleset_diff(MODULE.RULESET_B, actual), [])
 
     def test_absent_false_pull_request_parameter_is_tolerated(self) -> None:


### PR DESCRIPTION
## Summary

While applying the enforcement policy (issue #499, M2 `apply-enforcement`), GitHub rejected the Ruleset B "main required checks" payload with `422 Invalid property /rules/0: data matches no possible input` when `required_status_checks[].integration_id` was sent as `null`. The REST schema types `integration_id` as `integer` (not nullable), so `null` matches no schema variant. Omitting the field means "any source" — identical policy (the enforcement script's whitelist comparator already normalizes absent-vs-null, per validation contract VAL-ENF-003 / VAL-TOOL-008).

This change omits `integration_id` from the payload built by `scripts/enforce-branch-protection.py` and updates the payload/report unit tests. With this payload the live `--apply` succeeded end-to-end (Ruleset A + B active, classic protection removed) and the follow-up `--dry-run` reports zero changes.

## Related Issue

Refs #499

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test (adding or updating tests)

## Test Plan

- [x] `PYTHONPATH=... uv run --no-sync pytest tests/unit/ tests/service/ --no-cov` → 1186 passed
- [x] New/updated tests for the payload (`tests/service/test_enforce_branch_protection.py`)
- [x] Manual verification: `python3 scripts/enforce-branch-protection.py --apply --json` exit 0; live rulesets verified via API (A: pull_request params + dependabot-only bypass; B: strict checks Code Quality Gate + Runtime Gate, no bypass); classic protection 404; second `--dry-run --json` reports `no_changes: true`

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [ ] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG) — none needed; policy meaning unchanged
- [x] I have added tests that prove my fix is effective or my feature works
- [ ] New API endpoints have a corresponding CLI subcommand (see ADR-0039) — N/A
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure — N/A

## Notes for Reviewers

The enforcement itself is already applied and verified live (Ruleset A id 20314008, Ruleset B id 20314768, classic protection removed). This PR only keeps `main`'s script schema-valid so future idempotent re-runs (or ruleset recreation) work. Do NOT re-introduce `integration_id: null`.
