### PR TITLE
docs: note maintainer self-merge in emergency runbook

### DIFF
--- a/docs/runbooks/emergency-branch-protection-bypass.md
+++ b/docs/runbooks/emergency-branch-protection-bypass.md
@@ -13,7 +13,7 @@ High
 Use it **only** when:
 
 - A legitimate fix must land on `main` immediately (e.g., a production incident fix), and
-- The blocking condition (failed required check or missing review) cannot be resolved within the required window.
+- The blocking condition (failed required check) cannot be resolved within the required window.
 
 Never use it for routine merges. Admins are subject to the policy; the audit trail below records every lift.
 

--- a/docs/runbooks/emergency-branch-protection-bypass.md
+++ b/docs/runbooks/emergency-branch-protection-bypass.md
@@ -17,6 +17,18 @@ Use it **only** when:
 
 Never use it for routine merges. Admins are subject to the policy; the audit trail below records every lift.
 
+> **Update (2026-08-03): maintainer self-merge amendment.** Per ADR-0046 (2026-08-03
+> amendment, "allow maintainer to merge own PRs (review bypass only)"), the sole
+> maintainer `magnus919` is a User bypass actor (`bypass_mode: pull_request`) on
+> Ruleset A `main review policy`, so they can merge their **own** green PRs without
+> an approving review (GitHub disallows self-approval). After this amendment, this
+> emergency path is needed **only when required checks fail** — a `Code Quality Gate`
+> or `Runtime Gate` failure that cannot be resolved in time. A missing review on the
+> maintainer's own PR is no longer an emergency: the normal merge flow (with green
+> required checks) handles it. The amendment does **not** relax required checks:
+> Ruleset B `main required checks` has no bypass actors, so merging a PR whose
+> required checks fail still requires this emergency path.
+
 ## Timeline
 
 1. Resolve the two ruleset ids and capture the "before" audit evidence.


### PR DESCRIPTION
## Summary

Adds a dated **2026-08-03 maintainer self-merge note** to the emergency branch-protection bypass runbook (`docs/runbooks/emergency-branch-protection-bypass.md`). Per ADR-0046's 2026-08-03 amendment, the sole maintainer `magnus919` is now a User bypass actor (`bypass_mode: pull_request`) on Ruleset A `main review policy`, so they can merge their **own** green PRs without an approving review (GitHub disallows self-approval). The runbook now records that the emergency path is needed **only when required checks fail** — required checks still bind everyone via Ruleset B `main required checks` (no bypass actors).

This is a docs-only change (classifier: `false`, no Docker lane).

## Related Issue

Refs #499

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 🧪 Test (adding or updating tests)
- [ ] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [ ] New tests added for the change
- [x] Manual verification done (describe): docs-only change; `scripts/classify_ci_changes.py` prints `false` (no Docker runtime lane — Runtime Gate reports success). No production code touched.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [ ] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

Docs-only runbook update; no behavior change to enforcement. This PR is part of the VAL-SELF-001 maintainer self-merge verification: once CI is green it is expected to be merged without an approving review (the maintainer is a bypass actor on Ruleset A) and without the emergency path — required checks must pass (Ruleset B).
