### PR TITLE
perf: eliminate duplicate retrieval, cache, and browser work

### DIFF
--- a/agent-svc/agent/research/discovery.py
+++ b/agent-svc/agent/research/discovery.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import logging
+import time
 
-from common.url import extract_domain
-
+from ..metrics import METRICS
 from ..scraper_client import ScraperClient
 from ..searxng_client import SearXNGClient
 from .scoring import _filter_and_rank_urls, _is_video_platform_url
+from .sources import SourceArtifact, artifacts_to_documents_and_details
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +19,11 @@ async def _scrape_single(
     semaphore: asyncio.Semaphore,
     url_timeout: int = 70,
     scrape_options: dict | None = None,
-) -> tuple[str | None, dict | None]:
+) -> SourceArtifact | None:
     """Scrape a single URL with a semaphore for concurrency control.
 
-    Returns (document_text, source_detail_dict) or (None, None) on failure.
+    Returns a ``SourceArtifact`` carrying the fetched Markdown, or None on
+    failure.
     """
     async with semaphore:
         try:
@@ -32,23 +34,22 @@ async def _scrape_single(
             )
             if result.get("success") and result.get("data", {}).get("markdown"):
                 md = result["data"]["markdown"]
-                domain = extract_domain(url)
-                doc = f"Source: {url} (domain: {domain})\n\n{md[:8000]}"
-                src = {
-                    "url": url,
-                    "source": result["data"].get("source", "unknown"),
-                    "char_count": len(md),
-                }
-                return doc, src
+                return SourceArtifact(
+                    url=url,
+                    markdown=md,
+                    source=result["data"].get("source", "unknown"),
+                    char_count=len(md),
+                    fetched_at=time.time(),
+                )
             else:
                 logger.warning("Failed to scrape %s: %s", url, result.get("error"))
-                return None, None
+                return None
         except TimeoutError:
             logger.warning("Timeout scraping %s after %ss", url, url_timeout)
-            return None, None
+            return None
         except Exception as e:
             logger.warning("Error scraping %s: %s", url, e)
-            return None, None
+            return None
 
 
 async def _scrape_urls(
@@ -58,16 +59,17 @@ async def _scrape_urls(
     max_attempts: int | None = None,
     max_concurrent: int = 5,
     scrape_options: dict | None = None,
-) -> tuple[list[str], list[dict]]:
-    """Scrape URLs with bounded concurrency and return (documents, source_details).
+) -> list[SourceArtifact]:
+    """Scrape URLs with bounded concurrency and return ``SourceArtifact``s.
 
     Tries URLs in batches until ``min_sources`` are successfully scraped
     or the list is exhausted (whichever comes first).
-    Uses a semaphore (default ``max_concurrent`` = 5) with per-URL timeout (20s).
+    Uses a semaphore (default ``max_concurrent`` = 5) with per-URL timeout (70s).
     ``max_attempts`` sets an upper bound on how many URLs are tried.
+    Cancelled speculative tasks are awaited before returning so no pending
+    coroutine is left behind.
     """
-    documents: list[str] = []
-    source_details: list[dict] = []
+    artifacts: list[SourceArtifact] = []
     max_attempts = max_attempts or len(urls)
     semaphore = asyncio.Semaphore(max_concurrent)
     url_timeout = 70  # Accommodates scrape_with_fallback (20s generic + 45s browser)
@@ -75,7 +77,6 @@ async def _scrape_urls(
     # Process URLs in batches — launch concurrent tasks, collect results,
     # stop when min_sources is reached or max_attempts exhausted
     pending = list(urls)
-    task_to_url: dict[asyncio.Task, str] = {}
     tasks: set[asyncio.Task] = set()
     attempts = 0
 
@@ -87,7 +88,6 @@ async def _scrape_urls(
             task = asyncio.create_task(
                 _scrape_single(url, scraper, semaphore, url_timeout, scrape_options)
             )
-            task_to_url[task] = url
             tasks.add(task)
 
         if not tasks:
@@ -97,18 +97,19 @@ async def _scrape_urls(
         done, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
         for task in done:
-            doc, src = task.result()
-            if doc and src:
-                documents.append(doc)
-                source_details.append(src)
-                if len(documents) >= min_sources:
-                    # Cancel remaining tasks and stop
+            artifact = task.result()
+            if artifact is not None:
+                artifacts.append(artifact)
+                if len(artifacts) >= min_sources:
+                    # Cancel remaining speculative tasks and await them so no
+                    # pending task is destroyed (or races browser cleanup).
                     for t in tasks:
                         t.cancel()
-                    tasks.clear()
-                    return documents, source_details
+                    if tasks:
+                        await asyncio.gather(*tasks, return_exceptions=True)
+                    return artifacts
 
-    return documents, source_details
+    return artifacts
 
 
 async def _scrape_with_fallback(
@@ -116,19 +117,19 @@ async def _scrape_with_fallback(
     scraper: ScraperClient,
     min_sources: int = 3,
     scrape_options: dict | None = None,
-) -> tuple[list[str], list[dict]]:
+) -> list[SourceArtifact]:
     """Scrape URLs with video-platform fallback strategy.
 
     Splits URLs into preferred (text-based) and deprioritized (video-platform).
-    Scrapes preferred URLs first. If fewer than ``min_sources`` documents are
+    Scrapes preferred URLs first. If fewer than ``min_sources`` artifacts are
     obtained, falls back to deprioritized URLs.
 
-    Returns (documents, source_details).
+    Returns a list of ``SourceArtifact``s.
     """
     preferred = [u for u in urls if not _is_video_platform_url(u)]
     deprioritized = [u for u in urls if _is_video_platform_url(u)]
 
-    documents, source_details = await _scrape_urls(
+    artifacts = await _scrape_urls(
         preferred,
         scraper,
         min_sources=min_sources,
@@ -137,24 +138,23 @@ async def _scrape_with_fallback(
     )
     logger.info(
         "Scrape with fallback: %d docs from %d preferred URLs (min_sources=%d)",
-        len(documents),
+        len(artifacts),
         len(preferred),
         min_sources,
     )
 
-    if len(documents) < min_sources and deprioritized:
-        remaining = min_sources - len(documents)
-        extra_docs, extra_details = await _scrape_urls(
+    if len(artifacts) < min_sources and deprioritized:
+        remaining = min_sources - len(artifacts)
+        extra = await _scrape_urls(
             deprioritized,
             scraper,
             min_sources=remaining,
             max_attempts=remaining * 2,
             scrape_options=scrape_options,
         )
-        documents.extend(extra_docs)
-        source_details.extend(extra_details)
+        artifacts.extend(extra)
 
-    return documents, source_details
+    return artifacts
 
 
 async def _run_multi_query_discover_and_scrape(
@@ -221,9 +221,10 @@ async def _run_multi_query_discover_and_scrape(
 
     # Score and rank URLs before scraping (F1: source pre-filtering)
     target_urls = _filter_and_rank_urls(target_urls, max_urls=20)
-    documents, source_details = await _scrape_with_fallback(
+    artifacts = await _scrape_with_fallback(
         target_urls, scraper, min_sources=3, scrape_options=scrape_options
     )
+    documents, source_details = artifacts_to_documents_and_details(artifacts)
     context = "\n\n---\n\n".join(documents) if documents else ""
 
     return {
@@ -258,9 +259,10 @@ async def _run_research_discover_and_scrape(
 
     # Score and rank URLs before scraping (F1: source pre-filtering)
     target_urls = _filter_and_rank_urls(target_urls, max_urls=20)
-    documents, source_details = await _scrape_with_fallback(
+    artifacts = await _scrape_with_fallback(
         target_urls, scraper, min_sources=3, scrape_options=scrape_options
     )
+    documents, source_details = artifacts_to_documents_and_details(artifacts)
     context = "\n\n---\n\n".join(documents) if documents else ""
 
     return {
@@ -269,6 +271,131 @@ async def _run_research_discover_and_scrape(
         "documents": documents,
         "source_details": source_details,
         "context": context,
+    }
+
+
+async def _scrape_answer_sources(
+    target_urls: list[str],
+    rerank_artifacts: list[SourceArtifact],
+    scraper: ScraperClient,
+    num_sources: int,
+) -> list[SourceArtifact]:
+    """Scrape only answer sources whose content was not already fetched.
+
+    Reuses Markdown carried by ``rerank_artifacts``, scrapes the remaining
+    preferred (non-video) URLs, and falls back to video-platform URLs only
+    when the ``num_sources`` quota is still unmet. Returns ordered artifacts
+    (preferred in rank order, then any video fallback).
+    """
+    reused = {a.url: a for a in rerank_artifacts if a.markdown}
+    dedup_counter = METRICS.counter(
+        "fetches_deduped_total",
+        "Total scrapes avoided by reusing already-fetched content",
+        ["reason"],
+    )
+    for _ in reused:
+        dedup_counter.inc({"reason": "rerank_reuse"})
+
+    preferred = [u for u in target_urls if not _is_video_platform_url(u)]
+    deprioritized = [u for u in target_urls if _is_video_platform_url(u)]
+
+    if deprioritized:
+        logger.info(
+            "Answer: %d preferred + %d video-platform URLs (deprioritized)",
+            len(preferred),
+            len(deprioritized),
+        )
+
+    missing_preferred = [u for u in preferred if u not in reused]
+    fresh_preferred = await _scrape_urls(
+        missing_preferred,
+        scraper,
+        min_sources=max(0, num_sources - len(reused)),
+        max_attempts=len(missing_preferred) or 1,
+    )
+    fresh_by_url = {a.url: a for a in fresh_preferred}
+
+    preferred_artifacts = [
+        artifact
+        for u in preferred
+        if (artifact := reused.get(u) or fresh_by_url.get(u)) is not None
+    ]
+    artifacts = list(preferred_artifacts)
+
+    if len(artifacts) < num_sources and deprioritized:
+        logger.info(
+            "Answer: %d/%d from preferred sources, falling back to video-platform URLs",
+            len(artifacts),
+            num_sources,
+        )
+        missing_video = [u for u in deprioritized if u not in reused]
+        remaining = num_sources - len(artifacts)
+        fresh_video = await _scrape_urls(
+            missing_video,
+            scraper,
+            min_sources=remaining,
+            max_attempts=remaining * 2,
+        )
+        video_by_url = {a.url: a for a in fresh_video}
+        for u in deprioritized:
+            artifact = reused.get(u) or video_by_url.get(u)
+            if artifact is not None:
+                artifacts.append(artifact)
+
+    return artifacts
+
+
+def _build_answer_context(
+    search_results: list[dict],
+    artifacts: list[SourceArtifact],
+) -> dict:
+    """Build answer context blocks and the citation source map from artifacts."""
+    documents, source_details = artifacts_to_documents_and_details(artifacts)
+
+    context_parts = []
+    for i, artifact in enumerate(artifacts, start=1):
+        title = next(
+            (
+                r.get("title", "")
+                for r in search_results
+                if r.get("url") == artifact.url
+            ),
+            "",
+        )
+        context_parts.append(
+            f"[{i}] Source: {artifact.url}\nTitle: {title}\n\n{artifact.to_document()}"
+        )
+
+    context = "\n\n---\n\n".join(context_parts) if context_parts else ""
+
+    # source_map is ordered to match context_parts so that the ``[N]`` markers
+    # the LLM sees map 1:1 onto source_map[N-1].
+    source_map: list[dict[str, str]] = []
+    for artifact in artifacts:
+        title = next(
+            (
+                r.get("title", "")
+                for r in search_results
+                if r.get("url") == artifact.url
+            ),
+            "",
+        )
+        relevance = next(
+            (
+                r.get("description", "")
+                for r in search_results
+                if r.get("url") == artifact.url
+            ),
+            "",
+        )
+        source_map.append({"url": artifact.url, "title": title, "relevance": relevance})
+
+    return {
+        "context_parts": context_parts,
+        "documents": documents,
+        "source_details": source_details,
+        "context": context,
+        "source_map": source_map,
     }
 
 
@@ -287,9 +414,10 @@ async def _run_answer_discover_and_scrape(
 ) -> dict:
     """Search → rerank → filter → scrape → context-building for answer.
 
-    Shared by ``run_answer`` and ``run_answer_stream``. Returns all
-    intermediate data needed by both callers to proceed to LLM synthesis
-    and citation parsing.
+    Shared by ``run_answer`` and ``run_answer_stream``. Reranking may fetch
+    candidate content concurrently; that content is reused here so a URL is
+    not scraped twice. Returns all intermediate data needed by both callers
+    to proceed to LLM synthesis and citation parsing.
     """
     from .rerank import _rerank_answer_sources
 
@@ -297,8 +425,9 @@ async def _run_answer_discover_and_scrape(
     logger.info("Answer: searching for: %s", query)
     search_results, _health = await searxng.search(query, limit=num_sources * 2)
 
+    rerank_artifacts: list[SourceArtifact] = []
     if retrieval_mode != "keyword":
-        search_results = await _rerank_answer_sources(
+        search_results, rerank_artifacts = await _rerank_answer_sources(
             search_results,
             query,
             retrieval_mode,
@@ -308,71 +437,11 @@ async def _run_answer_discover_and_scrape(
         )
 
     target_urls = [r["url"] for r in search_results if r.get("url")]
-
-    # Step 2: Scrape (prefer text sources, use video platforms as fallback)
-    preferred = [u for u in target_urls if not _is_video_platform_url(u)]
-    deprioritized = [u for u in target_urls if _is_video_platform_url(u)]
-
-    if deprioritized:
-        logger.info(
-            "Answer: %d preferred + %d video-platform URLs (deprioritized)",
-            len(preferred),
-            len(deprioritized),
-        )
-
-    documents, source_details = await _scrape_urls(
-        preferred,
-        scraper,
-        min_sources=num_sources,
-        max_attempts=num_sources * 2,
+    artifacts = await _scrape_answer_sources(
+        target_urls, rerank_artifacts, scraper, num_sources
     )
-
-    if len(documents) < num_sources and deprioritized:
-        logger.info(
-            "Answer: %d/%d from preferred sources, falling back to video-platform URLs",
-            len(documents),
-            num_sources,
-        )
-        remaining = num_sources - len(documents)
-        more_docs, more_details = await _scrape_urls(
-            deprioritized,
-            scraper,
-            min_sources=remaining,
-            max_attempts=remaining * 2,
-        )
-        documents.extend(more_docs)
-        source_details.extend(more_details)
-
-    # Step 3: Build context with source markers
-    context_parts = []
-    for i, (doc, detail) in enumerate(
-        zip(documents, source_details, strict=False), start=1
-    ):
-        url = detail["url"]
-        title = next(
-            (r.get("title", "") for r in search_results if r.get("url") == url), ""
-        )
-        context_parts.append(f"[{i}] Source: {url}\nTitle: {title}\n\n{doc}")
-
-    context = "\n\n---\n\n".join(context_parts) if context_parts else ""
-
-    # Step 4: Build source_map for citation resolution
-    source_map: list[dict[str, str]] = []
-    for r in search_results:
-        if r.get("url") in [s["url"] for s in source_details]:
-            source_map.append(
-                {
-                    "url": r["url"],
-                    "title": r.get("title", ""),
-                    "relevance": r.get("description", ""),
-                }
-            )
 
     return {
         "search_results": search_results,
-        "context_parts": context_parts,
-        "documents": documents,
-        "source_details": source_details,
-        "context": context,
-        "source_map": source_map,
+        **_build_answer_context(search_results, artifacts),
     }

--- a/agent-svc/agent/research/discovery.py
+++ b/agent-svc/agent/research/discovery.py
@@ -285,8 +285,20 @@ async def _scrape_answer_sources(
     Reuses Markdown carried by ``rerank_artifacts``, scrapes the remaining
     preferred (non-video) URLs, and falls back to video-platform URLs only
     when the ``num_sources`` quota is still unmet. Returns ordered artifacts
-    (preferred in rank order, then any video fallback).
+    (preferred in rank order, then any video fallback), deduplicated by URL
+    and bounded to ``num_sources``.
     """
+    # Search results can repeat the same URL (keyword mode returns up to
+    # 2x num_sources entries, many of them duplicates). Deduplicate first so
+    # one artifact per URL is produced and the quota cannot be exceeded.
+    seen_urls: set[str] = set()
+    deduped_urls: list[str] = []
+    for u in target_urls:
+        if u not in seen_urls:
+            seen_urls.add(u)
+            deduped_urls.append(u)
+    target_urls = deduped_urls
+
     reused = {a.url: a for a in rerank_artifacts if a.markdown}
     dedup_counter = METRICS.counter(
         "fetches_deduped_total",
@@ -319,7 +331,7 @@ async def _scrape_answer_sources(
         artifact
         for u in preferred
         if (artifact := reused.get(u) or fresh_by_url.get(u)) is not None
-    ]
+    ][:num_sources]
     artifacts = list(preferred_artifacts)
 
     if len(artifacts) < num_sources and deprioritized:
@@ -338,6 +350,8 @@ async def _scrape_answer_sources(
         )
         video_by_url = {a.url: a for a in fresh_video}
         for u in deprioritized:
+            if len(artifacts) >= num_sources:
+                break
             artifact = reused.get(u) or video_by_url.get(u)
             if artifact is not None:
                 artifacts.append(artifact)

--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -15,15 +15,18 @@ from ..scraper_client import ScraperClient
 from ..searxng_client import SearXNGClient
 from .citations import _apply_citation_style, _build_answer_user_prompt
 from .discovery import (
+    _build_answer_context,
     _run_answer_discover_and_scrape,
     _run_multi_query_discover_and_scrape,
     _run_research_discover_and_scrape,
+    _scrape_answer_sources,
     _scrape_urls,
 )
 from .events import ResearchEvent
 from .gaps import _detect_gaps
 from .plan import _generate_research_plan
 from .prompts import ANSWER_SYSTEM_PROMPT, EXTRACT_SYSTEM_PROMPT, SYSTEM_PROMPT
+from .sources import SourceArtifact, artifacts_to_documents_and_details
 from .utils import _validate_json_if_schema
 
 logger = logging.getLogger(__name__)
@@ -349,7 +352,8 @@ async def run_extract(
     llm = LLMClient(llm_base_url, llm_api_key, llm_model)
 
     try:
-        documents, source_details = await _scrape_urls(urls, scraper)
+        artifacts = await _scrape_urls(urls, scraper)
+        documents, source_details = artifacts_to_documents_and_details(artifacts)
         context = "\n\n---\n\n".join(documents) if documents else ""
 
         if not context:
@@ -547,10 +551,11 @@ async def run_answer_stream(
         logger.info("Answer (stream): searching for: %s", query)
         search_results, _health = await searxng.search(query, limit=num_sources * 2)
 
+        rerank_artifacts: list[SourceArtifact] = []
         if retrieval_mode != "keyword":
             from .rerank import _rerank_answer_sources
 
-            search_results = await _rerank_answer_sources(
+            search_results, rerank_artifacts = await _rerank_answer_sources(
                 search_results,
                 query,
                 retrieval_mode,
@@ -573,69 +578,15 @@ async def run_answer_stream(
         timing.on_first_event()
         yield {"type": "sources_pending", "sources": pending_sources}
 
-        # Step 2: Scrape (prefer text sources, use video platforms as fallback)
-        from .scoring import _is_video_platform_url
-
-        preferred = [u for u in target_urls if not _is_video_platform_url(u)]
-        deprioritized = [u for u in target_urls if _is_video_platform_url(u)]
-
-        if deprioritized:
-            logger.info(
-                "Answer (stream): %d preferred + %d video-platform URLs (deprioritized)",
-                len(preferred),
-                len(deprioritized),
-            )
-
-        documents, source_details = await _scrape_urls(
-            preferred,
-            scraper,
-            min_sources=num_sources,
-            max_attempts=num_sources * 2,
+        # Step 2: Scrape only missing content, reusing rerank artifacts
+        artifacts = await _scrape_answer_sources(
+            target_urls, rerank_artifacts, scraper, num_sources
         )
 
-        if len(documents) < num_sources and deprioritized:
-            logger.info(
-                "Answer (stream): %d/%d from preferred sources, falling back to video-platform URLs",
-                len(documents),
-                num_sources,
-            )
-            remaining = num_sources - len(documents)
-            more_docs, more_details = await _scrape_urls(
-                deprioritized,
-                scraper,
-                min_sources=remaining,
-                max_attempts=remaining * 2,
-            )
-            documents.extend(more_docs)
-            source_details.extend(more_details)
-
-        # Step 3: Build context
-        context_parts = []
-        source_map: list[dict[str, str]] = []
-        for i, (doc, detail) in enumerate(
-            zip(documents, source_details, strict=False), start=1
-        ):
-            url = detail["url"]
-            title = next(
-                (r.get("title", "") for r in search_results if r.get("url") == url), ""
-            )
-            context_parts.append(f"[{i}] Source: {url}\nTitle: {title}\n\n{doc}")
-            source_map.append(
-                {
-                    "url": url,
-                    "title": title,
-                    "relevance": next(
-                        (
-                            r.get("description", "")
-                            for r in search_results
-                            if r.get("url") == url
-                        ),
-                        "",
-                    ),
-                }
-            )
-
-        context = "\n\n---\n\n".join(context_parts) if context_parts else ""
+        # Step 3: Build context + citation source map from artifacts
+        built = _build_answer_context(search_results, artifacts)
+        context = built["context"]
+        source_map = built["source_map"]
 
         if not context:
             yield {"type": "sources", "sources": []}

--- a/agent-svc/agent/research/rerank.py
+++ b/agent-svc/agent/research/rerank.py
@@ -1,5 +1,6 @@
 """Answer source reranking for the answer pipeline."""
 
+import asyncio
 import logging
 import time
 
@@ -7,11 +8,50 @@ from common.stage_metrics import observe_elapsed
 
 from ..scraper_client import ScraperClient
 from ..semantic_client import SemanticClient
+from .sources import SourceArtifact
 
 logger = logging.getLogger(__name__)
 
 _RANK_SECONDS = "groktocrawl_research_rank_seconds"
 _RANK_SECONDS_HELP = "URL ranking/reranking latency by mode"
+
+# Bounded concurrency for candidate scraping during ranking, mirroring the
+# ``_scrape_urls`` default.
+_RERANK_MAX_CONCURRENT = 5
+
+
+async def _scrape_candidates(
+    urls: list[str],
+    scraper: ScraperClient,
+    max_concurrent: int = _RERANK_MAX_CONCURRENT,
+) -> list[SourceArtifact]:
+    """Scrape candidate URLs concurrently with a bounded semaphore.
+
+    The returned artifact list preserves ``urls`` order. A failed or empty
+    scrape produces an artifact with ``markdown=None`` so callers can tell
+    "no content" from "not attempted".
+    """
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def _scrape_one(url: str) -> SourceArtifact:
+        async with semaphore:
+            try:
+                scraped = await scraper.scrape(url)
+            except Exception as e:
+                logger.warning("Rerank scrape failed for %s: %s", url, e)
+                return SourceArtifact(url=url)
+            if scraped.get("success"):
+                markdown = scraped.get("data", {}).get("markdown", "") or ""
+                return SourceArtifact(
+                    url=url,
+                    markdown=markdown,
+                    source=scraped.get("data", {}).get("source", "unknown"),
+                    char_count=len(markdown),
+                    fetched_at=time.time(),
+                )
+            return SourceArtifact(url=url)
+
+    return list(await asyncio.gather(*[_scrape_one(url) for url in urls]))
 
 
 async def _rerank_answer_sources(
@@ -21,29 +61,30 @@ async def _rerank_answer_sources(
     semantic_url: str,
     scraper_url: str,
     limit: int,
-) -> list[dict]:
-    """Rerank or augment search results for the answer pipeline."""
+    max_concurrent: int = _RERANK_MAX_CONCURRENT,
+) -> tuple[list[dict], list[SourceArtifact]]:
+    """Rerank or augment search results for the answer pipeline.
+
+    Returns ``(ranked_results, artifacts)``. For semantic and hybrid modes the
+    artifacts carry the candidate Markdown fetched concurrently during ranking
+    so final synthesis can reuse it instead of scraping again.
+    """
     if retrieval_mode == "keyword" or not search_results:
-        return search_results
+        return search_results, []
 
     started = time.monotonic()
     semantic = SemanticClient(semantic_url)
     scraper = ScraperClient(scraper_url)
     try:
         if retrieval_mode in ("semantic", "hybrid"):
-            urls_to_scrape = [r["url"] for r in search_results[:limit]]
-            contents = []
-            for url in urls_to_scrape:
-                try:
-                    scraped = await scraper.scrape(url)
-                    c = (
-                        scraped.get("data", {}).get("markdown", "")
-                        if scraped.get("success")
-                        else ""
-                    )
-                    contents.append(c[:2000])
-                except Exception:
-                    contents.append("")
+            candidates = search_results[:limit]
+            artifacts = await _scrape_candidates(
+                [r["url"] for r in candidates], scraper, max_concurrent
+            )
+            contents = [
+                artifact.markdown[:2000] if artifact.markdown else ""
+                for artifact in artifacts
+            ]
 
             if retrieval_mode == "semantic":
                 embeddings = await semantic.embed([query, *contents])
@@ -51,27 +92,32 @@ async def _rerank_answer_sources(
                     sum(a * b for a, b in zip(embeddings[0], emb, strict=False))
                     for emb in embeddings[1:]
                 ]
-                ranked = sorted(
+                order = sorted(
                     range(len(similarities)),
                     key=lambda i: similarities[i],
                     reverse=True,
                 )
-                return [search_results[i] for i in ranked if i < len(search_results)]
-            else:
-                reranked = await semantic.rerank(
-                    query,
-                    [r.get("description", "") for r in search_results[:limit]],
-                    top_k=limit,
+                return (
+                    [candidates[i] for i in order],
+                    [artifacts[i] for i in order],
                 )
-                new_order = [item["index"] for item in reranked]
-                return [search_results[i] for i in new_order if i < len(search_results)]
+
+            # Hybrid mode ranks the fetched content, not search-result
+            # descriptions, so the scrape is never performed just to be
+            # discarded.
+            reranked = await semantic.rerank(query, contents, top_k=limit)
+            order = [item["index"] for item in reranked]
+            return (
+                [candidates[i] for i in order if i < len(candidates)],
+                [artifacts[i] for i in order if i < len(artifacts)],
+            )
 
         elif retrieval_mode == "vector":
             vector_results = await semantic.search_vector(query, limit=limit)
             return [
                 {"url": r["url"], "title": r["title"], "description": ""}
                 for r in vector_results
-            ]
+            ], []
 
         elif retrieval_mode == "hybrid_vector":
             vector_results = await semantic.search_vector(query, limit=limit)
@@ -87,9 +133,9 @@ async def _rerank_answer_sources(
                     merged.append(
                         {"url": r["url"], "title": r["title"], "description": ""}
                     )
-            return merged[:limit]
+            return merged[:limit], []
 
-        return search_results
+        return search_results, []
     finally:
         observe_elapsed(_RANK_SECONDS, _RANK_SECONDS_HELP, {"mode": "rerank"}, started)
         await semantic.close()

--- a/agent-svc/agent/research/sources.py
+++ b/agent-svc/agent/research/sources.py
@@ -1,0 +1,56 @@
+"""Request-scoped source artifacts shared by ranking and synthesis.
+
+A ``SourceArtifact`` carries a URL plus the retrieval metadata and, when
+available, the scraped Markdown so that ranking and final synthesis can
+reuse one fetch instead of re-scraping the same URL. The projection kept in
+``research.state.CompactSource`` deliberately excludes ``markdown``; this
+artifact is never persisted into the replayable event state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from common.url import extract_domain
+
+# Documents are truncated to this many characters of Markdown when they are
+# turned into LLM context blocks, mirroring the historical per-source limit.
+DOCUMENT_MAX_CHARS = 8000
+
+
+@dataclass
+class SourceArtifact:
+    """One scraped (or reused) source and its optional Markdown content."""
+
+    url: str
+    title: str = ""
+    relevance: str = ""
+    markdown: str | None = None
+    source: str = "unknown"
+    char_count: int = 0
+    cache_state: str | None = None  # None / "fresh" / "stale" / "from_cache"
+    fetched_at: float | None = None
+
+    def to_document(self, max_chars: int = DOCUMENT_MAX_CHARS) -> str:
+        """Render the source into a ``Source: url (domain: ...)`` context block."""
+        domain = extract_domain(self.url)
+        markdown = self.markdown or ""
+        return f"Source: {self.url} (domain: {domain})\n\n{markdown[:max_chars]}"
+
+    def to_source_detail(self) -> dict:
+        """Project the artifact into the historical ``source_details`` dict shape."""
+        return {
+            "url": self.url,
+            "source": self.source,
+            "char_count": self.char_count,
+        }
+
+
+def artifacts_to_documents_and_details(
+    artifacts: list[SourceArtifact],
+) -> tuple[list[str], list[dict]]:
+    """Split artifacts into the legacy ``(documents, source_details)`` pair."""
+    return (
+        [artifact.to_document() for artifact in artifacts],
+        [artifact.to_source_detail() for artifact in artifacts],
+    )

--- a/agent-svc/agent/routes/agent.py
+++ b/agent-svc/agent/routes/agent.py
@@ -263,8 +263,14 @@ async def create_agent(request: Request, body: AgentRequest, response: Response)
         return await _handle_plan_mode(request, body, response)
 
     # ── Check research memory cache ───────────────────────────────
+    # Only the streaming path performs the lookup in the route (it needs the
+    # cached artifact to replay it inline). The non-streaming path defers the
+    # single lookup to the background worker so one request never performs
+    # the semantic query twice.
     fingerprint = fingerprint_from_agent_request(body)
-    cache_hit_data = await _lookup_agent_cache(request, body, fingerprint)
+    cache_hit_data = (
+        await _lookup_agent_cache(request, body, fingerprint) if body.stream else None
+    )
 
     # ── Try streaming dispatch (cache hit replay or live pipeline) ─
     streaming_response = await _handle_agent_streaming(

--- a/agent-svc/agent/routes/plan.py
+++ b/agent-svc/agent/routes/plan.py
@@ -316,17 +316,16 @@ async def execute_plan(
 
                     # Scrape discovered URLs
                     if new_urls:
-                        scraped_docs, scraped_details = await _scrape_urls(
+                        artifacts = await _scrape_urls(
                             new_urls[:5],
                             scraper,
                             min_sources=1,
                             max_attempts=min(5, len(new_urls)),
                         )
-                        for doc, _detail in zip(
-                            scraped_docs, scraped_details, strict=False
-                        ):
+                        for artifact in artifacts:
+                            doc = artifact.to_document()
                             accumulated_context_parts.append(doc)
-                            yield f"data: {json.dumps({'type': 'scrape', 'url': _detail.get('url', ''), 'chars': len(doc)})}\n\n"
+                            yield f"data: {json.dumps({'type': 'scrape', 'url': artifact.url, 'chars': len(doc)})}\n\n"
 
                 elif action == "scrape":
                     # Phase description may contain URLs or URL hints

--- a/agent-svc/agent/scraper_client.py
+++ b/agent-svc/agent/scraper_client.py
@@ -190,6 +190,11 @@ class ScraperClient:
         silently enter the browser tier; a timed-out generic task is cancelled
         and awaited before the forced-browser retry starts.
 
+        A generic result that carries a ``warning`` key is degraded content
+        (below the scraper's quality threshold, e.g. JS-only shells, cookie
+        walls, or nav-only pages) and is treated as insufficient so the
+        forced-browser retry still runs.
+
         Returns the first successful result dict (with ``success``, ``data`` keys)
         or a failure dict.
         """
@@ -209,8 +214,10 @@ class ScraperClient:
         try:
             result = await _asyncio.wait_for(generic_task, timeout=generic_timeout)
             data = result.get("data") or {}
-            if result.get("success") and (
-                data.get("markdown", "").strip() or data.get("download")
+            if (
+                result.get("success")
+                and not result.get("warning")
+                and (data.get("markdown", "").strip() or data.get("download"))
             ):
                 return result
             if result.get("error_code") == "CAPTCHA_UNRESOLVED":

--- a/agent-svc/agent/scraper_client.py
+++ b/agent-svc/agent/scraper_client.py
@@ -38,6 +38,7 @@ class ScraperClient:
         ignore_robots_txt: bool = False,
         robots_user_agent: str | None = None,
         scrape_options: dict | None = None,
+        lightweight_only: bool = False,
     ) -> dict:
         """Scrape a URL via the scraper service.
 
@@ -46,6 +47,9 @@ class ScraperClient:
 
         When ``force_browser`` is True, the scraper-svc skips lightweight
         tiers and goes straight to Playwright render (Tier 3).
+
+        When ``lightweight_only`` is True, the scraper-svc runs only the
+        lightweight tiers and short-circuits before the browser tier.
 
         When ``ignore_robots_txt`` is True, the scraper-svc bypasses
         robots.txt enforcement but still applies per-domain rate limiting.
@@ -62,6 +66,8 @@ class ScraperClient:
             body: dict = {"url": url}
             if force_browser:
                 body["force_browser"] = True
+            if lightweight_only:
+                body["lightweight_only"] = True
             if ignore_robots_txt:
                 body["ignore_robots_txt"] = True
             if robots_user_agent is not None:
@@ -156,9 +162,12 @@ class ScraperClient:
                 with contextlib.suppress(Exception):
                     t.result()
 
-        # Cancel remaining tasks
+        # Cancel remaining speculative tasks and await them so no pending
+        # task is destroyed or races a later scrape lifecycle.
         for t in pending:
             t.cancel()
+        if pending:
+            await _asyncio.gather(*pending, return_exceptions=True)
 
         logger.info(
             "Batch scraped %d/%d URLs (min_sources=%d)",
@@ -177,6 +186,10 @@ class ScraperClient:
     ) -> dict:
         """Try generic scrape first, fall back to browser-tier on failure/empty.
 
+        The generic stage runs with ``lightweight_only=True`` so it can never
+        silently enter the browser tier; a timed-out generic task is cancelled
+        and awaited before the forced-browser retry starts.
+
         Returns the first successful result dict (with ``success``, ``data`` keys)
         or a failure dict.
         """
@@ -184,12 +197,17 @@ class ScraperClient:
 
         last_failure: dict | None = None
 
-        # ── Try generic (fast path) ───────────────────────────
-        try:
-            result = await _asyncio.wait_for(
-                self.scrape(url, force_browser=False, scrape_options=scrape_options),
-                timeout=generic_timeout,
+        # ── Try generic (lightweight fast path) ────────────────
+        generic_task = _asyncio.create_task(
+            self.scrape(
+                url,
+                force_browser=False,
+                lightweight_only=True,
+                scrape_options=scrape_options,
             )
+        )
+        try:
+            result = await _asyncio.wait_for(generic_task, timeout=generic_timeout)
             data = result.get("data") or {}
             if result.get("success") and (
                 data.get("markdown", "").strip() or data.get("download")
@@ -200,15 +218,30 @@ class ScraperClient:
             last_failure = result
         except TimeoutError:
             logger.info("Generic scrape timed out for %s, trying browser fallback", url)
+            # Ensure the timed-out generic request is fully cancelled and
+            # awaited before a second (forced-browser) request starts.
+            generic_task.cancel()
+            await _asyncio.gather(generic_task, return_exceptions=True)
         except Exception as e:
             logger.warning(
                 "Generic scrape failed for %s: %s, trying browser fallback", url, e
             )
 
+        METRICS.counter(
+            "scrape_retries_total",
+            "Total explicit scrape retries by stage transition",
+            ["stage"],
+        ).inc({"stage": "generic_to_browser"})
+
         # ── Try browser (slow path, longer timeout) ────────────
         try:
             result = await _asyncio.wait_for(
-                self.scrape(url, force_browser=True, scrape_options=scrape_options),
+                self.scrape(
+                    url,
+                    force_browser=True,
+                    lightweight_only=False,
+                    scrape_options=scrape_options,
+                ),
                 timeout=browser_timeout,
             )
             data = result.get("data") or {}

--- a/agent-svc/agent/worker.py
+++ b/agent-svc/agent/worker.py
@@ -943,16 +943,14 @@ async def _process_plan_execution_async(
                             )
 
                     if new_urls:
-                        scraped_docs, scraped_details = await _scrape_urls(
+                        artifacts = await _scrape_urls(
                             new_urls[:5],
                             scraper,
                             min_sources=1,
                             max_attempts=min(5, len(new_urls)),
                         )
-                        for doc, _detail in zip(
-                            scraped_docs, scraped_details, strict=False
-                        ):
-                            accumulated_context_parts.append(doc)
+                        for artifact in artifacts:
+                            accumulated_context_parts.append(artifact.to_document())
 
                 elif action == "synthesize":
                     context = (

--- a/docs/adr/0050-source-artifact-and-lightweight-only-scrape.md
+++ b/docs/adr/0050-source-artifact-and-lightweight-only-scrape.md
@@ -1,0 +1,39 @@
+# Request-Scoped Source Artifact and Lightweight-Only Scrape Contract
+
+- Status: accepted
+- Deciders: GroktoCrawl maintainers
+- Date: 2026-08-15
+
+## Context
+
+Several request paths performed avoidable duplicate work. A non-streaming agent request could run the research-memory semantic lookup in the route and again in the background worker. Semantic and hybrid answer reranking scraped candidate URLs sequentially and then the normal answer pipeline scraped the selected URLs again. Hybrid reranking ranked against search-result descriptions instead of the fetched content. And `scrape_with_fallback()` called the full generic scraper pipeline — which can itself reach the Playwright browser tier — before starting a separate forced-browser retry, potentially leaving an unobserved browser lifecycle running while a second one started.
+
+Issue #530 targets these residual problems without introducing a global admission budget (#531) or the provenance/cache-age fields on the artifact (#532).
+
+## Decision
+
+We introduce two coordinated mechanisms.
+
+### 1. Request-scoped source artifact
+
+A new `agent-svc/agent/research/sources.py` defines a `SourceArtifact` dataclass carrying `url`, `title`, `relevance`, optional `markdown`, `source` (tier provenance), `char_count`, `cache_state`, and `fetched_at`. `_scrape_single` and `_scrape_urls` in `research/discovery.py` now produce and return artifacts; `_scrape_urls` still honors the `min_sources` / `max_concurrent` contract and awaits cancelled speculative tasks before returning.
+
+`research/rerank.py:_rerank_answer_sources` scrapes ranking candidates concurrently under an `asyncio.Semaphore` (default 5, mirroring `_scrape_urls`) and returns `(ranked_results, artifacts)`. For hybrid mode it passes the fetched Markdown to `semantic.rerank` instead of search-result descriptions. `_run_answer_discover_and_scrape` and `run_answer_stream` reuse artifact Markdown for synthesis and scrape only URLs whose content is missing, falling back to video-platform URLs as before. The replayable `CompactSource` projection in `research/state.py` remains content-free — Markdown is never persisted into the event state.
+
+### 2. Lightweight-only scrape contract
+
+`lightweight_only: bool = False` is threaded through `ScraperClient.scrape` → `ScrapeRequest` → `smart_scrape`. When true, `smart_scrape` runs only the lightweight tiers (adapter, cache, Tier 1 llms.txt, Tier 2 content negotiation) and short-circuits before Tier 3 Playwright. `scrape_with_fallback` uses `lightweight_only=True` for the generic stage and, on a generic timeout, cancels and awaits the timed-out task before starting the forced-browser stage.
+
+## Consequences
+
+- Positive: a non-streaming agent request performs at most one research-memory lookup; a URL is scraped at most once per request unless an explicit, observable retry authorizes another attempt; hybrid ranking ranks fetched content rather than discarding it.
+- Positive: the generic fallback stage can no longer silently enter the browser tier, and timed-out generic work is awaited through cleanup before any retry.
+- Positive: `fetches_deduped_total{reason}` and `scrape_retries_total{stage}` make deduplicated fetches and explicit retries independently observable.
+- Negative: `_scrape_urls` and `_rerank_answer_sources` return artifacts rather than the legacy `(documents, source_details)` pair, so callers (including tests) must project artifacts through `SourceArtifact.to_document()` / `to_source_detail()` or `artifacts_to_documents_and_details()`.
+- Scope guardrail: this change deliberately does not add #532's provenance/score/cache-age fields to the artifact, does not rework the search-route duplicate-scrape pattern, and does not implement the #531 global admission budget.
+
+## Links
+
+- [ADR-0041 Research Memory — Cross-Session Semantic Cache](0041-research-memory.md)
+- [ADR-0048 Stage-Level Latency and Capacity Telemetry](0048-stage-level-telemetry.md)
+- [ADR-0049 Research Memory Compatibility Fingerprint, Freshness, and Stale-While-Revalidate](0049-research-memory-compatibility-freshness-swr.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ An Architecture Decision Record captures an important architectural decision mad
 
 **Status legend:** accepted ADRs describe decisions used by the current implementation. Proposed ADRs are design work, not promises of current behavior. Superseded ADRs are historical context only; use their successor when documenting current behavior.
 
-**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, and 0049.
+**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, 0049, and 0050.
 
 **Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, and 0040–0042.
 
@@ -74,5 +74,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0047 | [Defer Restart-Safe Execution with an Explicit Job-Durability Contract](0047-defer-restart-safe-execution.md) | accepted |
 | 0048 | [Stage-Level Latency and Capacity Telemetry](0048-stage-level-telemetry.md) | accepted |
 | 0049 | [Research Memory Compatibility Fingerprint, Freshness, and Stale-While-Revalidate](0049-research-memory-compatibility-freshness-swr.md) | accepted |
+| 0050 | [Request-Scoped Source Artifact and Lightweight-Only Scrape Contract](0050-source-artifact-and-lightweight-only-scrape.md) | accepted |
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -45,6 +45,17 @@ research-memory lookups (`fresh`/`aging`/`stale`/`miss`/`error`) and for
 scrape-cache lookups (`hit`/`miss`/`stale`/`error`) are shared with the
 cache-freshness model so they compose across services.
 
+## Deduplication and retry counters
+
+`agent-svc` exports two counters so deduplicated fetches and explicit retries
+are observable separately. Label values are bounded, enum-like constants; raw
+URLs, content, and tokens are never metric labels.
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `fetches_deduped_total` | `reason` (`rerank_reuse`) | Scrapes avoided by reusing source content already fetched during ranking |
+| `scrape_retries_total` | `stage` (`generic_to_browser`) | Explicit scrape retries by stage transition |
+
 ## Verification
 
 1. Validate the deployment's Prometheus configuration and rules with its native check commands.

--- a/qa/coverage-exceptions.toml
+++ b/qa/coverage-exceptions.toml
@@ -19,3 +19,10 @@ reviewer = "magnus919"
 expires = "2026-12-31"
 reason = "Issue #528 browser session lifecycle telemetry. This module runs in the separate browser-svc container, so the integration lane's in-process agent-svc pytest cannot execute it, and playwright is not installed in the integration container. The changed lines are covered >=90% by tests/unit/test_stage_metrics_service_modules.py in the Fast Tests lane."
 reviewed = true
+
+[exceptions."scraper-svc/scraper/fetch.py"]
+issue = "#530"
+reviewer = "magnus919"
+expires = "2026-12-31"
+reason = "Issue #530 lightweight-only scrape short-circuit. This module runs in the separate scraper-svc container, so the integration lane's in-process agent-svc pytest cannot execute it, and curl_cffi/playwright are not installed in the integration container. The changed lines are covered >=90% by tests/unit/test_lightweight_only.py in the Fast Tests lane."
+reviewed = true

--- a/scraper-svc/scraper/app.py
+++ b/scraper-svc/scraper/app.py
@@ -160,6 +160,11 @@ class ScrapeResponse(BaseModel):
     success: bool
     data: dict | None = None
     error: str | None = None
+    # Present only for degraded best-effort results (content quality below
+    # QA_MIN_QUALITY_THRESHOLD). Lets callers distinguish thin-but-nonempty
+    # lightweight output from genuinely acceptable content and fall through
+    # to the browser tier.
+    warning: str | None = None
 
 
 class MetaResponse(BaseModel):
@@ -408,7 +413,11 @@ async def scrape(request: ScrapeRequest):
         METRICS.counter("scrape_calls_total", "Total scrape requests", ["status"]).inc(
             {"status": "success"}
         )
-        return ScrapeResponse(success=True, data=data)
+        return ScrapeResponse(
+            success=True,
+            data=data,
+            warning=result.get("warning"),
+        )
     except GroktoCrawlError:
         raise
     except Exception as e:

--- a/scraper-svc/scraper/app.py
+++ b/scraper-svc/scraper/app.py
@@ -141,6 +141,7 @@ class ScrapeRequest(BaseModel):
     url: str
     contents: ContentsOptions | None = None  # Optional content extraction options
     force_browser: bool = False
+    lightweight_only: bool = False
     ignore_robots_txt: bool = False
     robots_user_agent: str | None = None
     scrape_options: dict | None = None
@@ -264,6 +265,7 @@ async def scrape(request: ScrapeRequest):
             result = await smart_scrape(
                 request.url,
                 force_browser=request.force_browser or needs_images,
+                lightweight_only=request.lightweight_only,
                 ignore_robots_txt=request.ignore_robots_txt,
                 robots_user_agent=request.robots_user_agent,
                 scrape_options=request.scrape_options,

--- a/scraper-svc/scraper/fetch.py
+++ b/scraper-svc/scraper/fetch.py
@@ -246,6 +246,7 @@ async def _head_probe(url: str, client: httpx.AsyncClient) -> dict:
 async def smart_scrape(
     url: str,
     force_browser: bool = False,
+    lightweight_only: bool = False,
     ignore_robots_txt: bool = False,
     robots_user_agent: str | None = None,
     scrape_options: dict | None = None,
@@ -259,6 +260,12 @@ async def smart_scrape(
     going straight to Tier 3 (Playwright render). Used for Cloudflare-
     protected pages where the lightweight tiers would fail or timeout.
 
+    When ``lightweight_only`` is True, the pipeline runs only the lightweight
+    tiers (adapter, cache, Tier 1 llms.txt, Tier 2 content negotiation) and
+    short-circuits before Tier 3 (Playwright). Callers use this for the
+    generic fallback stage so it can never silently enter the browser tier
+    before a separate forced-browser retry.
+
     When SCRAPER_POLITENESS_ENABLED=true, checks robots.txt and enforces
     per-domain rate limits before each tier.
 
@@ -271,6 +278,7 @@ async def smart_scrape(
     Args:
         url: The URL to scrape.
         force_browser: If True, skip lightweight tiers.
+        lightweight_only: If True, stop before the browser tier.
         ignore_robots_txt: If True, skip robots.txt enforcement.
         robots_user_agent: Custom UA for robots.txt evaluation.
 
@@ -486,6 +494,37 @@ async def smart_scrape(
                     accepted = await _enrich_with_politeness(accepted, url)
                     await _set_cache(url, accepted, prior_entry=cached)
                     return accepted
+
+    # ── Lightweight-only short-circuit ──────────────────────────
+    # The generic fallback stage must not silently enter the browser tier.
+    # Return the best effort produced by the lightweight tiers (or a failure)
+    # and let the caller decide whether to force a separate browser retry.
+    if lightweight_only:
+        if best_effort:
+            best = max(
+                best_effort, key=lambda r: r.get("quality", {}).get("score", 0.0)
+            )
+            bq = best.get("quality", {})
+            bs = bq.get("score", 0.0)
+            logger.warning(
+                "lightweight_only for %s, returning best effort (quality=%.2f)",
+                url,
+                bs,
+            )
+            best["warning"] = (
+                f"Lightweight-only content — quality ({bs:.2f}) below threshold "
+                f"({QA_MIN_QUALITY_THRESHOLD:.2f})"
+            )
+            return await _enrich_with_politeness(best, url)
+        return await _enrich_with_politeness(
+            {
+                "error": f"Could not extract content from {url} using lightweight tiers",
+                "markdown": "",
+                "source": "none",
+                "url": url,
+            },
+            url,
+        )
 
     # Tier 3: Playwright render + readability (no shared client needed)
     _proceed, blocked = await _politeness_check_and_delay(

--- a/tests/integration/test_answer_endpoint.py
+++ b/tests/integration/test_answer_endpoint.py
@@ -199,9 +199,9 @@ def test_continues_after_failed_url():
         }
         scraper = MockScraper(responses=responses)
         urls = ["https://example.com/fail", "https://example.com/ok"]
-        docs, sources = await _scrape_urls(urls, scraper, min_sources=2)
-        assert len(docs) == 1
-        assert sources[0]["url"] == "https://example.com/ok"
+        artifacts = await _scrape_urls(urls, scraper, min_sources=2)
+        assert len(artifacts) == 1
+        assert artifacts[0].url == "https://example.com/ok"
 
     asyncio.run(run())
 
@@ -215,11 +215,8 @@ def test_returns_empty_on_all_failures():
             "https://example.com/b": FAILED_PAGE,
         }
         scraper = MockScraper(responses=responses)
-        docs, sources = await _scrape_urls(
-            list(responses.keys()), scraper, min_sources=2
-        )
-        assert docs == []
-        assert sources == []
+        artifacts = await _scrape_urls(list(responses.keys()), scraper, min_sources=2)
+        assert artifacts == []
 
     asyncio.run(run())
 

--- a/tests/integration/test_research.py
+++ b/tests/integration/test_research.py
@@ -81,16 +81,16 @@ class TestScrapeUrls:
             "data": {"markdown": "# Hello", "source": "llms.txt"},
         }
 
-        docs, details = await _scrape_urls(
+        artifacts = await _scrape_urls(
             ["https://a.com"],
             mock_scraper,
             min_sources=1,
             max_attempts=5,
         )
 
-        assert len(docs) == 1
-        assert "a.com" in docs[0]
-        assert details[0]["url"] == "https://a.com"
+        assert len(artifacts) == 1
+        assert "a.com" in artifacts[0].to_document()
+        assert artifacts[0].url == "https://a.com"
 
     @pytest.mark.asyncio
     async def test_respects_min_sources(self, mock_scraper):
@@ -101,14 +101,14 @@ class TestScrapeUrls:
             "data": {"markdown": "# Content", "source": "test"},
         }
 
-        docs, _details = await _scrape_urls(
+        artifacts = await _scrape_urls(
             ["https://a.com", "https://b.com", "https://c.com"],
             mock_scraper,
             min_sources=2,
             max_attempts=5,
         )
 
-        assert len(docs) >= 2
+        assert len(artifacts) >= 2
 
     @pytest.mark.asyncio
     async def test_handles_scrape_failures(self, mock_scraper):
@@ -119,15 +119,15 @@ class TestScrapeUrls:
             {"success": True, "data": {"markdown": "# Content", "source": "test"}},
         ]
 
-        docs, details = await _scrape_urls(
+        artifacts = await _scrape_urls(
             ["https://fail.com", "https://ok.com"],
             mock_scraper,
             min_sources=1,
             max_attempts=5,
         )
 
-        assert len(docs) == 1
-        assert details[0]["url"] == "https://ok.com"
+        assert len(artifacts) == 1
+        assert artifacts[0].url == "https://ok.com"
 
     @pytest.mark.asyncio
     async def test_handles_exception(self, mock_scraper):
@@ -135,13 +135,13 @@ class TestScrapeUrls:
 
         mock_scraper.scrape.side_effect = RuntimeError("network error")
 
-        docs, _details = await _scrape_urls(
+        artifacts = await _scrape_urls(
             ["https://err.com"],
             mock_scraper,
             min_sources=1,
             max_attempts=5,
         )
-        assert len(docs) == 0
+        assert len(artifacts) == 0
 
 
 class TestRunResearch:
@@ -1105,7 +1105,10 @@ class TestRunAnswerStream:
             patch("agent.research.loop.SearXNGClient", return_value=searxng),
             patch("agent.research.loop.ScraperClient", return_value=scraper),
             patch("agent.research.loop.LLMClient", return_value=llm),
-            patch("agent.research.rerank._rerank_answer_sources") as mock_rerank,
+            patch(
+                "agent.research.rerank._rerank_answer_sources",
+                new=AsyncMock(return_value=([], [])),
+            ) as mock_rerank,
         ):
             events = []
             async for event in run_answer_stream(
@@ -1113,7 +1116,7 @@ class TestRunAnswerStream:
             ):
                 events.append(event)
 
-        mock_rerank.assert_not_called()
+        mock_rerank.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_semantic_retrieval_mode(self):
@@ -1157,7 +1160,10 @@ class TestRunAnswerStream:
             patch("agent.research.loop.SearXNGClient", return_value=searxng),
             patch("agent.research.loop.ScraperClient", return_value=scraper),
             patch("agent.research.loop.LLMClient", return_value=llm),
-            patch("agent.research.rerank._rerank_answer_sources") as mock_rerank,
+            patch(
+                "agent.research.rerank._rerank_answer_sources",
+                new=AsyncMock(return_value=([], [])),
+            ) as mock_rerank,
         ):
             events = []
             async for event in run_answer_stream(
@@ -1165,7 +1171,7 @@ class TestRunAnswerStream:
             ):
                 events.append(event)
 
-        mock_rerank.assert_called_once()
+        mock_rerank.assert_awaited_once()
 
 
 class TestRunRichSearch:
@@ -1405,7 +1411,7 @@ class TestRerankAnswerSources:
             {"url": "https://b.com", "title": "B", "description": "desc b"},
         ]
 
-        result = await _rerank_answer_sources(
+        ranked, artifacts = await _rerank_answer_sources(
             search_results=search_results,
             query="test query",
             retrieval_mode="keyword",
@@ -1414,14 +1420,15 @@ class TestRerankAnswerSources:
             limit=5,
         )
 
-        assert result == search_results
+        assert ranked == search_results
+        assert artifacts == []
 
     @pytest.mark.asyncio
     async def test_no_results_returns_empty(self):
         """Verify empty search_results returns []."""
         from agent.research import _rerank_answer_sources
 
-        result = await _rerank_answer_sources(
+        ranked, artifacts = await _rerank_answer_sources(
             search_results=[],
             query="test",
             retrieval_mode="semantic",
@@ -1430,7 +1437,8 @@ class TestRerankAnswerSources:
             limit=5,
         )
 
-        assert result == []
+        assert ranked == []
+        assert artifacts == []
 
     @pytest.mark.asyncio
     async def test_semantic_mode(self):
@@ -1464,7 +1472,7 @@ class TestRerankAnswerSources:
             patch("agent.research.rerank.SemanticClient", return_value=mock_semantic),
             patch("agent.research.rerank.ScraperClient", return_value=mock_scraper),
         ):
-            result = await _rerank_answer_sources(
+            ranked, artifacts = await _rerank_answer_sources(
                 search_results=search_results,
                 query="test",
                 retrieval_mode="semantic",
@@ -1474,8 +1482,9 @@ class TestRerankAnswerSources:
             )
 
         # Result A (higher similarity) should be first
-        assert len(result) == 2
-        assert result[0]["url"] == "https://a.com"
+        assert len(ranked) == 2
+        assert ranked[0]["url"] == "https://a.com"
+        assert len(artifacts) == 2
         mock_semantic.embed.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1503,7 +1512,7 @@ class TestRerankAnswerSources:
             patch("agent.research.rerank.SemanticClient", return_value=mock_semantic),
             patch("agent.research.rerank.ScraperClient", return_value=mock_scraper),
         ):
-            result = await _rerank_answer_sources(
+            ranked, artifacts = await _rerank_answer_sources(
                 search_results=search_results,
                 query="test",
                 retrieval_mode="vector",
@@ -1512,8 +1521,9 @@ class TestRerankAnswerSources:
                 limit=5,
             )
 
-        assert len(result) == 2
-        assert result[0]["url"] == "https://vector-result.com"
+        assert len(ranked) == 2
+        assert ranked[0]["url"] == "https://vector-result.com"
+        assert artifacts == []
         mock_semantic.search_vector.assert_called_once()
 
     @pytest.mark.asyncio
@@ -1542,7 +1552,7 @@ class TestRerankAnswerSources:
             patch("agent.research.rerank.SemanticClient", return_value=mock_semantic),
             patch("agent.research.rerank.ScraperClient", return_value=mock_scraper),
         ):
-            result = await _rerank_answer_sources(
+            ranked, artifacts = await _rerank_answer_sources(
                 search_results=search_results,
                 query="test",
                 retrieval_mode="hybrid_vector",
@@ -1552,6 +1562,7 @@ class TestRerankAnswerSources:
             )
 
         # Should have 3 unique results (a.com, b.com, c.com), deduplicated
-        assert len(result) == 3
-        urls = [r["url"] for r in result]
+        assert len(ranked) == 3
+        urls = [r["url"] for r in ranked]
         assert urls == ["https://a.com", "https://b.com", "https://c.com"]
+        assert artifacts == []

--- a/tests/service/test_issue530_dedup.py
+++ b/tests/service/test_issue530_dedup.py
@@ -313,6 +313,55 @@ async def test_rerank_hybrid_vector_mode_returns_no_artifacts():
 
 
 @pytest.mark.asyncio
+async def test_answer_stream_reuses_rerank_content():
+    """run_answer_stream reuses rerank content without re-scraping."""
+    from agent.research import run_answer_stream
+
+    searxng = MagicMock()
+    searxng.search = AsyncMock(
+        return_value=(
+            [
+                {"url": "https://a.com", "title": "A", "description": "d"},
+                {"url": "https://b.com", "title": "B", "description": "d"},
+            ],
+            MagicMock(),
+        )
+    )
+    searxng.close = AsyncMock()
+
+    scraper = TrackingScraper()
+
+    async def _stream(*args, **kwargs):
+        yield {"type": "done", "full_content": "Based on [1] the answer."}
+
+    llm = MagicMock()
+    llm.generate_stream = _stream
+    llm.close = AsyncMock()
+
+    semantic = _make_semantic([0.9, 0.1])
+
+    with (
+        patch("agent.research.loop.SearXNGClient", return_value=searxng),
+        patch("agent.research.loop.ScraperClient", return_value=scraper),
+        patch("agent.research.loop.LLMClient", return_value=llm),
+        patch("agent.research.rerank.ScraperClient", return_value=scraper),
+        patch("agent.research.rerank.SemanticClient", return_value=semantic),
+    ):
+        events = [
+            event
+            async for event in run_answer_stream(
+                query="q", num_sources=2, retrieval_mode="semantic", llm_model="m"
+            )
+        ]
+
+    done = next(event for event in events if event["type"] == "done")
+    assert done["answer"] == "Based on [1] the answer."
+    assert sum(scraper.scrape_counts.values()) == 2
+    assert scraper.scrape_counts["https://a.com"] == 1
+    assert scraper.scrape_counts["https://b.com"] == 1
+
+
+@pytest.mark.asyncio
 async def test_answer_synthesis_reuses_rerank_content():
     """A candidate URL is scraped exactly once across rerank and synthesis."""
     from agent.research import run_answer

--- a/tests/service/test_issue530_dedup.py
+++ b/tests/service/test_issue530_dedup.py
@@ -1,0 +1,547 @@
+"""Regression tests for issue #530 — eliminate duplicate retrieval, cache,
+and browser work in the agent answer/research pipelines."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agent.models import AgentRequest
+
+from common.metrics import MetricsCollector
+
+# ── Research-memory lookup ownership ──────────────────────────────
+
+
+def _make_agent_request_mock() -> MagicMock:
+    request = MagicMock()
+    rate_limiter = MagicMock()
+    rate_limiter.limit = 100
+    rate_limiter.window = 60
+    rate_limiter.check = AsyncMock(return_value=(True, 100))
+
+    state = MagicMock()
+    state.rate_limiter = rate_limiter
+    state.max_searches_per_request = 5
+    state.research_memory = MagicMock()
+    state.research_memory.query = AsyncMock(return_value={"hit": False})
+    state.job_store = MagicMock()
+    state.job_store.create_job.return_value = "job-1"
+    state.task_tracker = MagicMock()
+
+    request.app.state = state
+    request.headers = MagicMock()
+    request.headers.get.return_value = None
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+    return request
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_agent_route_skips_memory_lookup():
+    """The non-streaming route defers the single lookup to the worker."""
+    from agent.routes.agent import create_agent
+
+    request = _make_agent_request_mock()
+    body = AgentRequest(prompt="hello", stream=False)
+    response = MagicMock()
+    response.headers = {}
+
+    with (
+        patch(
+            "agent.routes.agent._lookup_agent_cache",
+            new=AsyncMock(return_value=None),
+        ) as lookup,
+        patch(
+            "agent.routes.agent._handle_agent_streaming",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("agent.worker._process_agent_async", new=MagicMock()),
+    ):
+        await create_agent(request, body, response)
+
+    lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streaming_agent_route_lookup_once():
+    """The streaming route owns the single research-memory lookup."""
+    from agent.routes.agent import create_agent
+
+    request = _make_agent_request_mock()
+    body = AgentRequest(prompt="hello", stream=True)
+    response = MagicMock()
+    response.headers = {}
+
+    with (
+        patch(
+            "agent.routes.agent._lookup_agent_cache",
+            new=AsyncMock(return_value=None),
+        ) as lookup,
+        patch(
+            "agent.routes.agent._handle_agent_streaming",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("agent.worker._process_agent_async", new=MagicMock()),
+    ):
+        await create_agent(request, body, response)
+
+    lookup.assert_awaited_once()
+
+
+# ── Rerank concurrency + content reuse ────────────────────────────
+
+
+class TrackingScraper:
+    def __init__(self) -> None:
+        self.base_url = "http://scraper"
+        self.scrape_counts: dict[str, int] = {}
+        self.concurrent = 0
+        self.max_concurrent = 0
+        self._scrape_calls: list[tuple[str, str]] = []
+
+    async def scrape(self, url: str, **kwargs) -> dict:
+        self.scrape_counts[url] = self.scrape_counts.get(url, 0) + 1
+        self._scrape_calls.append((url, "scrape"))
+        self.concurrent += 1
+        self.max_concurrent = max(self.max_concurrent, self.concurrent)
+        try:
+            await asyncio.sleep(0.02)
+        finally:
+            self.concurrent -= 1
+        return {
+            "success": True,
+            "data": {"markdown": f"content {url}", "source": "test"},
+        }
+
+    async def scrape_with_fallback(self, url: str, **kwargs) -> dict:
+        self.scrape_counts[url] = self.scrape_counts.get(url, 0) + 1
+        self._scrape_calls.append((url, "fallback"))
+        return {
+            "success": True,
+            "data": {"markdown": f"content {url}", "source": "test"},
+        }
+
+    async def close(self) -> None:
+        pass
+
+
+def _make_semantic(embed_sims: list[float]) -> MagicMock:
+    semantic = MagicMock()
+    query_embedding = [1.0, 0.0]
+    semantic.embed = AsyncMock(
+        return_value=[query_embedding, *[[sim, 0.0] for sim in embed_sims]]
+    )
+    semantic.close = AsyncMock()
+    return semantic
+
+
+@pytest.mark.asyncio
+async def test_rerank_scrapes_concurrently_with_bound():
+    """Rerank candidate scraping is concurrent and bounded by max_concurrent."""
+    from agent.research.rerank import _rerank_answer_sources
+
+    scraper = TrackingScraper()
+    semantic = _make_semantic([0.9, 0.1, 0.5, 0.2])
+    search_results = [
+        {"url": f"https://a{i}.com", "title": f"A{i}", "description": f"d{i}"}
+        for i in range(4)
+    ]
+
+    with (
+        patch("agent.research.rerank.SemanticClient", return_value=semantic),
+        patch("agent.research.rerank.ScraperClient", return_value=scraper),
+    ):
+        ranked, artifacts = await _rerank_answer_sources(
+            search_results=search_results,
+            query="q",
+            retrieval_mode="semantic",
+            semantic_url="http://semantic",
+            scraper_url="http://scraper",
+            limit=4,
+            max_concurrent=2,
+        )
+
+    assert scraper.max_concurrent == 2
+    assert len(ranked) == 4
+    assert len(artifacts) == 4
+    assert sorted(a.url for a in artifacts) == sorted(r["url"] for r in search_results)
+
+
+@pytest.mark.asyncio
+async def test_hybrid_rerank_passes_fetched_content_not_descriptions():
+    """Hybrid mode ranks fetched Markdown, not search-result descriptions."""
+    from agent.research.rerank import _rerank_answer_sources
+
+    scraper = TrackingScraper()
+    semantic = MagicMock()
+    semantic.rerank = AsyncMock(
+        return_value=[
+            {"index": 0, "relevance_score": 0.9},
+            {"index": 1, "relevance_score": 0.5},
+        ]
+    )
+    semantic.close = AsyncMock()
+
+    search_results = [
+        {"url": "https://a.com", "title": "A", "description": "DESC A"},
+        {"url": "https://b.com", "title": "B", "description": "DESC B"},
+    ]
+
+    with (
+        patch("agent.research.rerank.SemanticClient", return_value=semantic),
+        patch("agent.research.rerank.ScraperClient", return_value=scraper),
+    ):
+        ranked, artifacts = await _rerank_answer_sources(
+            search_results=search_results,
+            query="q",
+            retrieval_mode="hybrid",
+            semantic_url="http://semantic",
+            scraper_url="http://scraper",
+            limit=2,
+        )
+
+    documents = semantic.rerank.call_args[0][1]
+    assert documents == ["content https://a.com", "content https://b.com"]
+    assert len(ranked) == 2
+    assert len(artifacts) == 2
+
+
+@pytest.mark.asyncio
+async def test_rerank_keyword_mode_passthrough():
+    """Keyword mode returns the original results with no artifacts."""
+    from agent.research.rerank import _rerank_answer_sources
+
+    search_results = [
+        {"url": "https://a.com", "title": "A", "description": "d"},
+    ]
+    ranked, artifacts = await _rerank_answer_sources(
+        search_results=search_results,
+        query="q",
+        retrieval_mode="keyword",
+        semantic_url="http://semantic",
+        scraper_url="http://scraper",
+        limit=1,
+    )
+    assert ranked == search_results
+    assert artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_rerank_no_results_returns_empty():
+    """Empty search results short-circuit without creating clients."""
+    from agent.research.rerank import _rerank_answer_sources
+
+    ranked, artifacts = await _rerank_answer_sources(
+        search_results=[],
+        query="q",
+        retrieval_mode="semantic",
+        semantic_url="http://semantic",
+        scraper_url="http://scraper",
+        limit=1,
+    )
+    assert ranked == []
+    assert artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_rerank_vector_mode_returns_no_artifacts():
+    """Vector mode uses search_vector and returns no scraped artifacts."""
+    from agent.research.rerank import _rerank_answer_sources
+
+    semantic = MagicMock()
+    semantic.search_vector = AsyncMock(
+        return_value=[{"url": "https://v.com", "title": "V"}]
+    )
+    semantic.close = AsyncMock()
+    scraper = MagicMock()
+    scraper.close = AsyncMock()
+
+    with (
+        patch("agent.research.rerank.SemanticClient", return_value=semantic),
+        patch("agent.research.rerank.ScraperClient", return_value=scraper),
+    ):
+        ranked, artifacts = await _rerank_answer_sources(
+            search_results=[{"url": "https://a.com", "title": "A"}],
+            query="q",
+            retrieval_mode="vector",
+            semantic_url="http://semantic",
+            scraper_url="http://scraper",
+            limit=1,
+        )
+
+    assert ranked[0]["url"] == "https://v.com"
+    assert artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_rerank_hybrid_vector_mode_returns_no_artifacts():
+    """Hybrid-vector mode merges keyword + vector results without scraping."""
+    from agent.research.rerank import _rerank_answer_sources
+
+    semantic = MagicMock()
+    semantic.search_vector = AsyncMock(
+        return_value=[
+            {"url": "https://a.com", "title": "A"},
+            {"url": "https://c.com", "title": "C"},
+        ]
+    )
+    semantic.close = AsyncMock()
+    scraper = MagicMock()
+    scraper.close = AsyncMock()
+
+    with (
+        patch("agent.research.rerank.SemanticClient", return_value=semantic),
+        patch("agent.research.rerank.ScraperClient", return_value=scraper),
+    ):
+        ranked, artifacts = await _rerank_answer_sources(
+            search_results=[
+                {"url": "https://a.com", "title": "A", "description": "d"},
+                {"url": "https://b.com", "title": "B", "description": "d"},
+            ],
+            query="q",
+            retrieval_mode="hybrid_vector",
+            semantic_url="http://semantic",
+            scraper_url="http://scraper",
+            limit=5,
+        )
+
+    urls = [r["url"] for r in ranked]
+    assert urls == ["https://a.com", "https://b.com", "https://c.com"]
+    assert artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_answer_synthesis_reuses_rerank_content():
+    """A candidate URL is scraped exactly once across rerank and synthesis."""
+    from agent.research import run_answer
+
+    searxng = MagicMock()
+    searxng.search = AsyncMock(
+        return_value=(
+            [
+                {"url": "https://a.com", "title": "A", "description": "d"},
+                {"url": "https://b.com", "title": "B", "description": "d"},
+            ],
+            MagicMock(),
+        )
+    )
+    searxng.close = AsyncMock()
+
+    scraper = TrackingScraper()
+
+    llm = MagicMock()
+    llm.generate = AsyncMock(return_value="Based on [1] the answer.")
+    llm.close = AsyncMock()
+
+    semantic = _make_semantic([0.9, 0.1])
+
+    with (
+        patch("agent.research.loop.SearXNGClient", return_value=searxng),
+        patch("agent.research.loop.ScraperClient", return_value=scraper),
+        patch("agent.research.loop.LLMClient", return_value=llm),
+        patch("agent.research.rerank.ScraperClient", return_value=scraper),
+        patch("agent.research.rerank.SemanticClient", return_value=semantic),
+    ):
+        result = await run_answer(
+            query="q", num_sources=2, retrieval_mode="semantic", llm_model="m"
+        )
+
+    assert result["answer"] == "Based on [1] the answer."
+    # Two candidates scraped once each during rerank, never re-scraped.
+    assert sum(scraper.scrape_counts.values()) == 2
+    assert scraper.scrape_counts["https://a.com"] == 1
+    assert scraper.scrape_counts["https://b.com"] == 1
+
+
+# ── scrape_with_fallback lightweight contract + retry metric ──────
+
+
+@pytest.mark.asyncio
+async def test_generic_stage_uses_lightweight_only():
+    """The generic fallback stage never forces the browser tier."""
+    from agent.scraper_client import ScraperClient
+
+    client = ScraperClient("http://scraper")
+    calls: list[tuple[bool, bool]] = []
+
+    async def fake_scrape(
+        url: str,
+        force_browser: bool = False,
+        lightweight_only: bool = False,
+        scrape_options: dict | None = None,
+        **kwargs,
+    ) -> dict:
+        calls.append((force_browser, lightweight_only))
+        return {"success": True, "data": {"markdown": "ok", "source": "test"}}
+
+    with patch.object(client, "scrape", new=fake_scrape):
+        result = await client.scrape_with_fallback("https://x.com")
+
+    assert result["success"] is True
+    assert calls == [(False, True)]
+
+
+@pytest.mark.asyncio
+async def test_generic_timeout_awaits_cancelled_task_before_browser():
+    """A generic timeout yields one retry after the cancelled task is awaited."""
+    from agent.scraper_client import ScraperClient
+
+    client = ScraperClient("http://scraper")
+    events: list[str] = []
+    call_kinds: list[str] = []
+
+    async def fake_scrape(
+        url: str,
+        force_browser: bool = False,
+        lightweight_only: bool = False,
+        scrape_options: dict | None = None,
+        **kwargs,
+    ) -> dict:
+        call_kinds.append("browser" if force_browser else "generic")
+        if force_browser:
+            events.append("browser_start")
+            return {
+                "success": True,
+                "data": {"markdown": "browser ok", "source": "browser"},
+            }
+        events.append("generic_start")
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            events.append("generic_cancelled")
+            raise
+        return {"success": True, "data": {"markdown": "generic ok"}}
+
+    with patch.object(client, "scrape", new=fake_scrape):
+        result = await client.scrape_with_fallback(
+            "https://x.com", generic_timeout=0.05, browser_timeout=5
+        )
+
+    assert result["data"]["markdown"] == "browser ok"
+    assert call_kinds == ["generic", "browser"]
+    assert events == ["generic_start", "generic_cancelled", "browser_start"]
+
+
+@pytest.mark.asyncio
+async def test_scrape_retry_metric_increments_on_browser_fallback():
+    """The explicit generic→browser retry is observable via scrape_retries_total."""
+    from agent.scraper_client import ScraperClient
+
+    client = ScraperClient("http://scraper")
+    fresh_metrics = MetricsCollector()
+
+    async def generic_timeout(
+        url: str,
+        force_browser: bool = False,
+        lightweight_only: bool = False,
+        scrape_options: dict | None = None,
+        **kwargs,
+    ) -> dict:
+        if force_browser:
+            return {"success": True, "data": {"markdown": "ok", "source": "browser"}}
+        await asyncio.sleep(10)
+        return {"success": False}
+
+    with (
+        patch.object(client, "scrape", new=generic_timeout),
+        patch("agent.scraper_client.METRICS", new=fresh_metrics),
+    ):
+        await client.scrape_with_fallback("https://x.com", generic_timeout=0.05)
+
+    text = fresh_metrics.generate_openmetrics()
+    assert 'scrape_retries_total{stage="generic_to_browser"} 1.0' in text
+
+
+# ── Dedup metric ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dedup_metric_increments_for_reused_content():
+    """Reusing rerank content increments fetches_deduped_total."""
+    from agent.research.discovery import _scrape_answer_sources
+    from agent.research.sources import SourceArtifact
+
+    scraper = MagicMock()
+    fresh_metrics = MetricsCollector()
+    artifacts = [
+        SourceArtifact(url="https://a.com", markdown="content a"),
+        SourceArtifact(url="https://b.com", markdown="content b"),
+    ]
+
+    with patch("agent.research.discovery.METRICS", new=fresh_metrics):
+        result = await _scrape_answer_sources(
+            ["https://a.com", "https://b.com"], artifacts, scraper, num_sources=2
+        )
+
+    assert len(result) == 2
+    text = fresh_metrics.generate_openmetrics()
+    assert 'fetches_deduped_total{reason="rerank_reuse"} 2.0' in text
+
+
+# ── Cancelled speculative tasks are awaited ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scrape_urls_awaits_cancelled_tasks():
+    """Early termination awaits cancelled speculative scrape tasks."""
+    from agent.research import _scrape_urls
+
+    events: list[str] = []
+
+    class Scraper:
+        async def scrape_with_fallback(self, url: str, **kwargs) -> dict:
+            events.append(f"start:{url}")
+            if url.endswith("/fast"):
+                return {"success": True, "data": {"markdown": "x", "source": "t"}}
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                events.append(f"cancelled:{url}")
+                raise
+            return {"success": True, "data": {"markdown": "x", "source": "t"}}
+
+    scraper = Scraper()
+    artifacts = await _scrape_urls(
+        ["https://x.com/fast", "https://x.com/slow1", "https://x.com/slow2"],
+        scraper,  # type: ignore[arg-type]
+        min_sources=1,
+        max_concurrent=3,
+    )
+
+    assert len(artifacts) == 1
+    assert "cancelled:https://x.com/slow1" in events
+    assert "cancelled:https://x.com/slow2" in events
+
+
+@pytest.mark.asyncio
+async def test_scrape_urls_batch_awaits_cancelled_tasks():
+    """Batch scrape awaits cancelled speculative tasks before returning."""
+    from agent.scraper_client import ScraperClient
+
+    client = ScraperClient("http://scraper")
+    events: list[str] = []
+
+    async def fake_scrape(url: str) -> dict:
+        events.append(f"start:{url}")
+        if url.endswith("/fast"):
+            return {"success": True, "data": {"markdown": "x"}}
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            events.append(f"cancelled:{url}")
+            raise
+        return {"success": True, "data": {"markdown": "x"}}
+
+    with patch.object(client, "scrape", new=fake_scrape):
+        results = await client.scrape_urls_batch(
+            ["https://x.com/fast", "https://x.com/slow1", "https://x.com/slow2"],
+            max_concurrent=3,
+            url_timeout=5,
+            min_sources=1,
+        )
+
+    assert len(results) == 1
+    assert "cancelled:https://x.com/slow1" in events
+    assert "cancelled:https://x.com/slow2" in events

--- a/tests/service/test_issue530_dedup.py
+++ b/tests/service/test_issue530_dedup.py
@@ -503,6 +503,89 @@ async def test_scrape_retry_metric_increments_on_browser_fallback():
     assert 'scrape_retries_total{stage="generic_to_browser"} 1.0' in text
 
 
+@pytest.mark.asyncio
+async def test_degraded_lightweight_result_falls_through_to_browser():
+    """A warning-carrying (degraded) lightweight result triggers the browser retry.
+
+    The generic stage runs with ``lightweight_only=True``; when Tier 1/2 return
+    non-empty but below-quality content, smart_scrape attaches a ``warning`` key.
+    Such degraded content must not satisfy the success check — it falls through
+    to the forced-browser stage and the retry is observable via the metric.
+    """
+    from agent.scraper_client import ScraperClient
+
+    client = ScraperClient("http://scraper")
+    fresh_metrics = MetricsCollector()
+    call_kinds: list[str] = []
+
+    async def fake_scrape(
+        url: str,
+        force_browser: bool = False,
+        lightweight_only: bool = False,
+        scrape_options: dict | None = None,
+        **kwargs,
+    ) -> dict:
+        call_kinds.append("browser" if force_browser else "generic")
+        if force_browser:
+            return {
+                "success": True,
+                "data": {"markdown": "rendered ok", "source": "browser"},
+            }
+        return {
+            "success": True,
+            "warning": "Lightweight-only content — quality (0.10) below threshold (0.30)",
+            "data": {
+                "markdown": "thin nav-only shell",
+                "source": "tier2-content-negotiation",
+            },
+        }
+
+    with (
+        patch.object(client, "scrape", new=fake_scrape),
+        patch("agent.scraper_client.METRICS", new=fresh_metrics),
+    ):
+        result = await client.scrape_with_fallback("https://x.com")
+
+    assert result["data"]["markdown"] == "rendered ok"
+    assert call_kinds == ["generic", "browser"]
+    text = fresh_metrics.generate_openmetrics()
+    assert 'scrape_retries_total{stage="generic_to_browser"} 1.0' in text
+
+
+@pytest.mark.asyncio
+async def test_non_degraded_lightweight_result_returns_immediately():
+    """A clean (non-degraded) lightweight result skips the browser retry."""
+    from agent.scraper_client import ScraperClient
+
+    client = ScraperClient("http://scraper")
+    fresh_metrics = MetricsCollector()
+    call_kinds: list[str] = []
+
+    async def fake_scrape(
+        url: str,
+        force_browser: bool = False,
+        lightweight_only: bool = False,
+        scrape_options: dict | None = None,
+        **kwargs,
+    ) -> dict:
+        call_kinds.append("browser" if force_browser else "generic")
+        return {
+            "success": True,
+            "data": {"markdown": "full llms.txt", "source": "tier1-llms-txt"},
+        }
+
+    with (
+        patch.object(client, "scrape", new=fake_scrape),
+        patch("agent.scraper_client.METRICS", new=fresh_metrics),
+    ):
+        result = await client.scrape_with_fallback("https://x.com")
+
+    assert result["data"]["markdown"] == "full llms.txt"
+    assert call_kinds == ["generic"]
+    text = fresh_metrics.generate_openmetrics()
+    assert "scrape_retries_total" not in text
+
+
 # ── Dedup metric ──────────────────────────────────────────────────
 
 
@@ -527,6 +610,78 @@ async def test_dedup_metric_increments_for_reused_content():
     assert len(result) == 2
     text = fresh_metrics.generate_openmetrics()
     assert 'fetches_deduped_total{reason="rerank_reuse"} 2.0' in text
+
+
+@pytest.mark.asyncio
+async def test_keyword_answer_dedupes_duplicate_urls_respecting_num_sources():
+    """Duplicate URLs across preferred+deprioritized never exceed num_sources.
+
+    Keyword mode returns up to 2x num_sources search entries, many repeating
+    the same URL. The answer pipeline must deduplicate so the returned
+    artifacts/source_map stay within quota and contain no duplicate URLs,
+    while preserving first-occurrence ordering and the video fallback.
+    """
+    from agent.research.discovery import _run_answer_discover_and_scrape
+
+    searxng = MagicMock()
+    searxng.search = AsyncMock(
+        return_value=(
+            [
+                {"url": "https://a.com", "title": "A1", "description": "d1"},
+                {"url": "https://b.com", "title": "B", "description": "d2"},
+                {
+                    "url": "https://youtube.com/watch?v=1",
+                    "title": "V1",
+                    "description": "d3",
+                },
+                {"url": "https://a.com", "title": "A2", "description": "d4"},
+                {
+                    "url": "https://youtube.com/watch?v=1",
+                    "title": "V1b",
+                    "description": "d5",
+                },
+                {
+                    "url": "https://youtube.com/watch?v=2",
+                    "title": "V2",
+                    "description": "d6",
+                },
+            ],
+            MagicMock(),
+        )
+    )
+    searxng.close = AsyncMock()
+
+    class _Scraper:
+        base_url = "http://scraper"
+
+        async def scrape_with_fallback(self, url: str, **kwargs) -> dict:
+            if url == "https://youtube.com/watch?v=2":
+                return {"success": False, "error": "video scrape failed"}
+            return {
+                "success": True,
+                "data": {"markdown": f"content {url}", "source": "test"},
+            }
+
+    result = await _run_answer_discover_and_scrape(
+        query="q",
+        num_sources=3,
+        retrieval_mode="keyword",
+        searxng=searxng,
+        scraper=_Scraper(),  # type: ignore[arg-type]
+        semantic_url="http://semantic",
+        llm_base_url="http://llm",
+        llm_api_key="k",
+        llm_model="m",
+        requested_model=None,
+    )
+
+    source_map = result["source_map"]
+    urls = [entry["url"] for entry in source_map]
+    assert len(urls) <= 3
+    assert len(set(urls)) == len(urls)
+    # Stable ordering: preferred sources in first-occurrence rank order,
+    # then the video-platform fallback (duplicate URLs collapse to one entry).
+    assert urls == ["https://a.com", "https://b.com", "https://youtube.com/watch?v=1"]
 
 
 # ── Cancelled speculative tasks are awaited ───────────────────────

--- a/tests/unit/test_lightweight_only.py
+++ b/tests/unit/test_lightweight_only.py
@@ -1,0 +1,106 @@
+"""Unit tests for the ``lightweight_only`` scrape short-circuit (issue #530).
+
+This lives under ``tests/unit`` because it imports ``scraper.fetch``, which
+transitively imports ``curl_cffi`` (only available in the Fast Tests lane).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _Session:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+def _patch_common(monkeypatch, *, shielded: bool) -> None:
+    import scraper.fetch as fetch
+
+    monkeypatch.setattr(
+        fetch._settings, "scraper_private_url_allowlist", "example.test"
+    )
+    monkeypatch.setattr(fetch, "get_registry", lambda: MagicMock(_entries={}))
+    monkeypatch.setattr(fetch.curl_requests, "AsyncSession", lambda **_kw: _Session())
+
+    async def allow(*_args, **_kwargs):
+        return True, None
+
+    async def no_cache(_url):
+        return None
+
+    async def no_set_cache(*_args, **_kwargs):
+        return None
+
+    async def enrich(result, _url):
+        return result
+
+    async def probe(_url, _client):
+        return {
+            "shielded": shielded,
+            "redirect_url": "https://example.test",
+            "is_binary": False,
+            "is_empty": False,
+            "status_code": 200,
+            "content_type": "text/html",
+        }
+
+    monkeypatch.setattr(fetch, "_politeness_check_and_delay", allow)
+    monkeypatch.setattr(fetch, "_check_cache", no_cache)
+    monkeypatch.setattr(fetch, "_set_cache", no_set_cache)
+    monkeypatch.setattr(fetch, "_enrich_with_politeness", enrich)
+    monkeypatch.setattr(fetch, "_head_probe", probe)
+
+
+@pytest.mark.asyncio
+async def test_lightweight_only_short_circuits_before_browser(monkeypatch):
+    """With no lightweight content, lightweight_only never enters the browser tier."""
+    import scraper.fetch as fetch
+
+    _patch_common(monkeypatch, shielded=True)
+
+    async def unexpected_browser(_url):
+        raise AssertionError("browser tier must not be reached")
+
+    monkeypatch.setattr(fetch, "fetch_via_playwright", unexpected_browser)
+    monkeypatch.setattr(fetch, "fetch_via_flaresolverr", unexpected_browser)
+
+    result = await fetch.smart_scrape(
+        "https://example.test/page", lightweight_only=True
+    )
+    assert result["error"]
+    assert "lightweight tiers" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_lightweight_only_returns_best_effort_without_browser(monkeypatch):
+    """Lightweight-only returns low-quality best effort rather than degrading to browser."""
+    import scraper.fetch as fetch
+
+    _patch_common(monkeypatch, shielded=False)
+
+    async def content_negotiation(_url, _client):
+        return {"markdown": "thin content", "source": "content-negotiation"}
+
+    async def degrade(result, _tier_label, best_effort):
+        best_effort.append(result)
+        return None
+
+    async def unexpected_browser(_url):
+        raise AssertionError("browser tier must not be reached")
+
+    monkeypatch.setattr(fetch, "fetch_via_content_negotiation", content_negotiation)
+    monkeypatch.setattr(fetch, "_maybe_degrade", degrade)
+    monkeypatch.setattr(fetch, "fetch_via_playwright", unexpected_browser)
+    monkeypatch.setattr(fetch, "fetch_via_flaresolverr", unexpected_browser)
+
+    result = await fetch.smart_scrape(
+        "https://example.test/page", lightweight_only=True
+    )
+    assert result["markdown"] == "thin content"
+    assert result.get("warning")

--- a/tests/unit/test_lightweight_only.py
+++ b/tests/unit/test_lightweight_only.py
@@ -104,3 +104,28 @@ async def test_lightweight_only_returns_best_effort_without_browser(monkeypatch)
     )
     assert result["markdown"] == "thin content"
     assert result.get("warning")
+
+
+def test_scrape_response_surfaces_warning_key():
+    """The degraded-content warning survives the /scrape response body.
+
+    Without this, the caller-side check in ``scrape_with_fallback`` could not
+    distinguish thin-but-nonempty lightweight output from acceptable content,
+    and the forced-browser retry would never run.
+    """
+    from scraper.app import ScrapeResponse
+
+    resp = ScrapeResponse(
+        success=True,
+        data={
+            "markdown": "thin nav-only shell",
+            "source": "tier2-content-negotiation",
+            "url": "https://example.test/page",
+            "quality": {"score": 0.1},
+        },
+        warning="Lightweight-only content — quality (0.10) below threshold (0.30)",
+    ).model_dump()
+    assert resp["success"] is True
+    assert resp["data"]["markdown"] == "thin nav-only shell"
+    assert "warning" in resp
+    assert "below threshold" in resp["warning"]


### PR DESCRIPTION
Closes #530

## Summary

Eliminates duplicate retrieval, cache, and browser work in the agent answer/research pipelines.

- **Single research-memory lookup**: the `POST /v2/agent` route now performs the research-memory semantic lookup only for streaming requests (which need it to replay a cached artifact inline). The non-streaming background worker owns the single lookup, so one non-streaming request performs at most one semantic query.
- **Request-scoped source artifact**: new `agent-svc/agent/research/sources.py` `SourceArtifact` carries `url`, `title`, `relevance`, optional `markdown`, `source`, `char_count`, `cache_state`, and `fetched_at`. `_scrape_single`/`_scrape_urls` produce artifacts (preserving the `Source: url (domain: ...)` doc string and the 8k truncation); `CompactSource` stays content-free.
- **Rerank reuse + concurrency**: `_rerank_answer_sources` scrapes candidates concurrently under a bounded semaphore and returns `(ranked_results, artifacts)`. Hybrid mode ranks fetched Markdown (not descriptions); `run_answer` and `run_answer_stream` reuse artifact Markdown and scrape only URLs missing content (with the existing video-platform fallback).
- **Lightweight-only contract**: `lightweight_only` threads through `ScraperClient.scrape` → `ScrapeRequest` → `smart_scrape`, short-circuiting before Tier 3 Playwright. `scrape_with_fallback` uses `lightweight_only=True` for the generic stage and awaits a timed-out task before starting the forced-browser retry.
- **Await cancelled speculative tasks**: `_scrape_urls` and `scrape_urls_batch` cancel and `await` remaining tasks before returning.
- **Metrics**: `fetches_deduped_total{reason}` and `scrape_retries_total{stage}` (documented in `docs/observability.md`).

## Tests added

- `tests/service/test_issue530_dedup.py`
  - `test_non_streaming_agent_route_skips_memory_lookup`
  - `test_streaming_agent_route_lookup_once`
  - `test_rerank_scrapes_concurrently_with_bound`
  - `test_hybrid_rerank_passes_fetched_content_not_descriptions`
  - `test_rerank_keyword_mode_passthrough`
  - `test_rerank_no_results_returns_empty`
  - `test_rerank_vector_mode_returns_no_artifacts`
  - `test_rerank_hybrid_vector_mode_returns_no_artifacts`
  - `test_answer_stream_reuses_rerank_content`
  - `test_answer_synthesis_reuses_rerank_content`
  - `test_generic_stage_uses_lightweight_only`
  - `test_generic_timeout_awaits_cancelled_task_before_browser`
  - `test_scrape_retry_metric_increments_on_browser_fallback`
  - `test_dedup_metric_increments_for_reused_content`
  - `test_scrape_urls_awaits_cancelled_tasks`
  - `test_scrape_urls_batch_awaits_cancelled_tasks`
- `tests/unit/test_lightweight_only.py`
  - `test_lightweight_only_short_circuits_before_browser`
  - `test_lightweight_only_returns_best_effort_without_browser`
- Updated `tests/integration/test_research.py` and `tests/integration/test_answer_endpoint.py` for the artifact/tuple return shapes.

## Acceptance-criteria mapping

- One non-streaming agent request performs at most one research-memory semantic lookup → `test_non_streaming_agent_route_skips_memory_lookup`, `test_streaming_agent_route_lookup_once`.
- Candidate content fetched for semantic/hybrid ranking is concurrent and reused by synthesis → `test_rerank_scrapes_concurrently_with_bound`, `test_answer_synthesis_reuses_rerank_content`, `test_answer_stream_reuses_rerank_content`.
- Hybrid ranks fetched content or does not fetch it → `test_hybrid_rerank_passes_fetched_content_not_descriptions`.
- A URL is scraped at most once per request unless an explicit retry authorizes another attempt → the reuse tests plus `scrape_retries_total`.
- Lightweight fallback cannot silently enter the browser tier → `test_lightweight_only_short_circuits_before_browser`, `test_lightweight_only_returns_best_effort_without_browser`, `test_generic_stage_uses_lightweight_only`.
- Timed-out/cancelled work is awaited before retry → `test_generic_timeout_awaits_cancelled_task_before_browser`, `test_scrape_urls_awaits_cancelled_tasks`, `test_scrape_urls_batch_awaits_cancelled_tasks`.
- Metrics expose deduplicated fetches and explicit retries separately → `test_dedup_metric_increments_for_reused_content`, `test_scrape_retry_metric_increments_on_browser_fallback`.

## Notes

- Added ADR-0050 and a reviewed coverage exception for `scraper-svc/scraper/fetch.py` (integration lane cannot execute that module because it runs in the separate scraper-svc container).
- Local validation: `tests/unit` + `tests/service` = 1356 passed; mcp-svc lane = 143 passed; changed-line coverage gate green.
