### PR TITLE
perf: add concurrent cache-assisted hybrid retrieval

### DIFF
--- a/agent-svc/agent/research/discovery.py
+++ b/agent-svc/agent/research/discovery.py
@@ -437,7 +437,12 @@ async def _run_answer_discover_and_scrape(
 
     search_results: list[dict] = []
     logger.info("Answer: searching for: %s", query)
-    search_results, _health = await searxng.search(query, limit=num_sources * 2)
+    if retrieval_mode == "hybrid_vector":
+        # Defer web search to the hybrid planner, which runs SearXNG and
+        # Qdrant discovery concurrently (web is not searched twice).
+        search_results = []
+    else:
+        search_results, _health = await searxng.search(query, limit=num_sources * 2)
 
     rerank_artifacts: list[SourceArtifact] = []
     if retrieval_mode != "keyword":
@@ -448,6 +453,7 @@ async def _run_answer_discover_and_scrape(
             semantic_url,
             scraper.base_url,
             num_sources,
+            searxng=searxng,
         )
 
     target_urls = [r["url"] for r in search_results if r.get("url")]

--- a/agent-svc/agent/research/hybrid.py
+++ b/agent-svc/agent/research/hybrid.py
@@ -1,0 +1,476 @@
+"""Concurrent, cache-assisted hybrid retrieval planner (ADR-0052).
+
+``plan_hybrid_retrieval`` is the single implementation of ``hybrid_vector``
+retrieval. It runs independent SlopSearX (web) and Qdrant (vector) discovery
+concurrently under the global admission budget, blends the two ranked result
+sets deterministically (rather than concatenating web-first), and — when a
+scraper is supplied — acquires candidate Markdown from the Valkey scrape cache
+or via live scrape.
+
+Blend policy (deterministic, no web-first starvation)
+-----------------------------------------------------
+
+1. Every URL is normalised (lowercased scheme/host, default ports dropped,
+   fragment stripped, trailing slash stripped) and deduplicated by that
+   normalised form. Provenance per URL is ``web``, ``vector``, or ``both``.
+2. A floor guarantee prevents either source from being starved by a full
+   budget from the other::
+
+       floor_web    = max(0, limit - len(vector_unique))
+       floor_vector = max(0, limit - len(web_unique))
+
+   The web floor and vector floor are emitted first (each in its source's
+   rank order), then the remaining slots are filled by round-robin
+   interleaving of the two rank orders (web first). Rank order within a
+   source is preserved, so each source's own relevance signal is retained;
+   the round-robin interleave is the deterministic cross-source tie-break.
+   Overlapping URLs (provenance ``both``) are emitted once, keeping web's
+   richer metadata (title/description) and the vector score when present.
+3. A Qdrant-only candidate therefore always has a chance to enter the final
+   candidate set even when web returns a full result budget.
+
+Acquisition
+-----------
+
+For each surviving candidate the planner consults ``CrawlCache.check_cache``
+with ``cache_max_age_ms``. A fresh, compatible cached entry (non-empty
+Markdown) is reused and marked ``cache_state="from_cache"`` with
+``cache_age_ms``; everything else is live-scraped via ``_scrape_urls`` and
+marked ``cache_state="live"``. Cache lookups are best-effort: a cache failure
+degrades to a live scrape and never raises.
+
+Graceful degradation
+--------------------
+
+- Semantic service disabled/unavailable → web-only (equivalent to keyword
+  retrieval: the web results are returned in their original rank order).
+- Web (SearXNG) failure/empty/timeout → vector-only.
+
+Transport failures never propagate to callers; each discovery branch is
+independently timeout-bounded and exceptions are logged and treated as an
+empty result set for that branch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from ..admission import get_admission
+from ..crawl_cache import CrawlCache
+from ..scraper_client import ScraperClient
+from ..searxng_client import SearchHealth, SearXNGClient
+from ..semantic_client import SemanticClient
+from ..settings import load_settings
+from .discovery import _scrape_urls
+from .sources import SourceArtifact
+
+logger = logging.getLogger(__name__)
+
+WEB_TIMEOUT_SECONDS = 15.0
+VECTOR_TIMEOUT_SECONDS = 8.0
+
+# Default freshness window for reusing the Valkey scrape cache during hybrid
+# acquisition. Entries older than this are treated as stale and live-scraped.
+# Stale-serving behaviour is governed by the cache-contract issue (#529), not
+# this module — only fresh, compatible entries are ever reused here.
+DEFAULT_CACHE_MAX_AGE_MS = 3_600_000  # 1 hour
+
+_crawl_cache: CrawlCache | None = None
+
+
+def get_crawl_cache() -> CrawlCache:
+    """Return a process-wide :class:`CrawlCache` singleton, created on demand.
+
+    Mirrors :func:`agent.admission.get_admission`: the Valkey connection is
+    lazy (no socket until the first command), so creating the singleton has no
+    startup cost even when Valkey is down.
+    """
+    global _crawl_cache
+    if _crawl_cache is None:
+        settings = load_settings()
+        _crawl_cache = CrawlCache(
+            f"redis://{settings.valkey_host}:{settings.valkey_port}/{settings.valkey_db}"
+        )
+    return _crawl_cache
+
+
+@dataclass
+class HybridRetrievalResult:
+    """Output of a hybrid retrieval plan."""
+
+    results: list[dict[str, Any]]
+    artifacts: list[SourceArtifact]
+    web_health: SearchHealth | None = None
+    web_count: int = 0
+
+
+def _is_default_port(scheme: str, port: int) -> bool:
+    """Return True when *port* is the scheme's default port."""
+    return (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+
+
+def _normalize_url_for_blend(url: str) -> str:
+    """Normalize a URL for deduplication during hybrid blending.
+
+    Lowercases the scheme and hostname, drops the default port, strips the
+    fragment, and strips a trailing slash from the path. The query string and
+    path case are preserved (both are significant to URL identity).
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    if not host:
+        # Relative or otherwise unparseable URL — normalize what we can.
+        return url
+    display_host = f"[{host}]" if ":" in host else host
+    port = parsed.port
+    if port is not None and not _is_default_port(scheme, port):
+        display_host = f"{display_host}:{port}"
+    path = parsed.path.rstrip("/")
+    if not path:
+        path = "/"
+    normalized = f"{scheme}://{display_host}{path}"
+    if parsed.query:
+        normalized += f"?{parsed.query}"
+    return normalized
+
+
+def _collect_candidates(
+    web_results: list[dict[str, Any]],
+    vector_results: list[dict[str, Any]],
+) -> tuple[list[str], list[str], dict[str, dict[str, Any]]]:
+    """Normalize, deduplicate, and record provenance for both result sets.
+
+    Returns ``(web_order, vector_order, by_norm)`` where the two order lists
+    contain normalised URLs in rank order and ``by_norm`` maps a normalised
+    URL to its candidate dict (``url``, ``title``, ``description``, ``score``,
+    ``retrieval``). Web metadata (title/description) is preferred for URLs
+    present in both sources; the vector score is retained when available.
+    """
+    by_norm: dict[str, dict[str, Any]] = {}
+    web_order: list[str] = []
+    vector_order: list[str] = []
+    seen_web: set[str] = set()
+    seen_vector: set[str] = set()
+
+    for rank, result in enumerate(web_results):
+        url = str(result.get("url") or "").strip()
+        if not url:
+            continue
+        norm = _normalize_url_for_blend(url)
+        if norm in seen_web:
+            continue
+        seen_web.add(norm)
+        by_norm[norm] = {
+            "url": url,
+            "title": result.get("title", ""),
+            "description": result.get("description", ""),
+            "score": None,
+            "retrieval": "web",
+            "web_rank": rank,
+            "vector_rank": None,
+        }
+        web_order.append(norm)
+
+    for rank, result in enumerate(vector_results):
+        url = str(result.get("url") or "").strip()
+        if not url:
+            continue
+        norm = _normalize_url_for_blend(url)
+        if norm in seen_vector:
+            continue
+        seen_vector.add(norm)
+        score = result.get("score")
+        candidate = by_norm.get(norm)
+        if candidate is None:
+            by_norm[norm] = {
+                "url": url,
+                "title": result.get("title", ""),
+                "description": "",
+                "score": score,
+                "retrieval": "vector",
+                "web_rank": None,
+                "vector_rank": rank,
+            }
+        else:
+            candidate["retrieval"] = "both"
+            candidate["vector_rank"] = rank
+            if candidate["score"] is None:
+                candidate["score"] = score
+        # Overlapping URLs remain in ``vector_order`` so that the floor
+        # formula sees the vector source's true unique count.
+        vector_order.append(norm)
+
+    return web_order, vector_order, by_norm
+
+
+def _blend(
+    web_order: list[str],
+    vector_order: list[str],
+    by_norm: dict[str, dict[str, Any]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Blend two rank-ordered candidate lists into at most ``limit`` results.
+
+    See the module docstring for the full policy. The floor guarantee ensures
+    neither source can be fully starved by a full budget from the other; the
+    remaining slots are filled by round-robin interleaving (web first), which
+    is deterministic.
+    """
+    floor_web = max(0, limit - len(vector_order))
+    floor_vector = max(0, limit - len(web_order))
+
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _take_from(order: list[str], count: int) -> None:
+        taken = 0
+        for norm in order:
+            if taken >= count or len(result) >= limit:
+                return
+            if norm in seen:
+                continue
+            result.append(by_norm[norm])
+            seen.add(norm)
+            taken += 1
+
+    _take_from(web_order, floor_web)
+    _take_from(vector_order, floor_vector)
+
+    # Round-robin interleave of the remaining rank slots (web first).
+    web_idx = 0
+    vector_idx = 0
+    while len(result) < limit and (
+        web_idx < len(web_order) or vector_idx < len(vector_order)
+    ):
+        while web_idx < len(web_order) and web_order[web_idx] in seen:
+            web_idx += 1
+        while vector_idx < len(vector_order) and vector_order[vector_idx] in seen:
+            vector_idx += 1
+
+        advanced = False
+        if web_idx < len(web_order):
+            result.append(by_norm[web_order[web_idx]])
+            seen.add(web_order[web_idx])
+            web_idx += 1
+            advanced = True
+        if len(result) < limit and vector_idx < len(vector_order):
+            result.append(by_norm[vector_order[vector_idx]])
+            seen.add(vector_order[vector_idx])
+            vector_idx += 1
+            advanced = True
+        if not advanced:
+            break
+
+    return result
+
+
+def _make_artifact(
+    candidate: dict[str, Any],
+    markdown: str,
+    source: str,
+    cache_state: str,
+    cache_age_ms: int | None,
+) -> SourceArtifact:
+    """Build a :class:`SourceArtifact` carrying full hybrid provenance."""
+    return SourceArtifact(
+        url=candidate["url"],
+        title=candidate.get("title", ""),
+        relevance=candidate.get("description", ""),
+        markdown=markdown,
+        source=source,
+        char_count=len(markdown),
+        cache_state=cache_state,
+        cache_age_ms=cache_age_ms,
+        retrieval=candidate.get("retrieval", "web"),
+        score=candidate.get("score"),
+        fetched_at=time.time(),
+    )
+
+
+async def _acquire_candidates(
+    candidates: list[dict[str, Any]],
+    scraper: ScraperClient,
+    cache: CrawlCache,
+    cache_max_age_ms: int | None,
+    limit: int,
+) -> list[SourceArtifact]:
+    """Acquire Markdown for surviving candidates via cache then live scrape.
+
+    Cache hits that pass the freshness policy are reused immediately
+    (``cache_state="from_cache"``); misses and stale entries are live-scraped
+    in one batch via ``_scrape_urls`` (``cache_state="live"``). Artifacts are
+    returned in candidate order. Cache lookup failures degrade to a live
+    scrape and never raise.
+    """
+    cached: dict[str, SourceArtifact] = {}
+    missing: list[dict[str, Any]] = []
+
+    for candidate in candidates:
+        artifact: SourceArtifact | None = None
+        if cache_max_age_ms:
+            try:
+                use_cached, cached_data, _err = cache.check_cache(
+                    candidate["url"], max_age_ms=cache_max_age_ms
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Hybrid cache check failed for %s: %s", candidate["url"], exc
+                )
+                use_cached, cached_data = False, None
+            if use_cached and isinstance(cached_data, dict):
+                data = cached_data.get("data") or {}
+                markdown = data.get("markdown")
+                if isinstance(markdown, str) and markdown.strip():
+                    age_ms: int | None = None
+                    with contextlib.suppress(Exception):
+                        age_ms = cache.get_age_ms(candidate["url"])
+                    artifact = _make_artifact(
+                        candidate,
+                        markdown,
+                        data.get("source") or "cache",
+                        "from_cache",
+                        age_ms,
+                    )
+        if artifact is not None:
+            cached[candidate["url"]] = artifact
+        else:
+            missing.append(candidate)
+
+    live_by_url: dict[str, SourceArtifact] = {}
+    if missing:
+        live = await _scrape_urls(
+            [candidate["url"] for candidate in missing],
+            scraper,
+            min_sources=max(0, limit - len(cached)),
+            max_attempts=len(missing),
+        )
+        for artifact in live:
+            if artifact.markdown:
+                live_by_url[artifact.url] = artifact
+
+    artifacts: list[SourceArtifact] = []
+    for candidate in candidates:
+        if candidate["url"] in cached:
+            artifacts.append(cached[candidate["url"]])
+        elif candidate["url"] in live_by_url:
+            live_artifact = live_by_url[candidate["url"]]
+            artifacts.append(
+                _make_artifact(
+                    candidate,
+                    live_artifact.markdown or "",
+                    live_artifact.source,
+                    "live",
+                    None,
+                )
+            )
+    return artifacts
+
+
+async def plan_hybrid_retrieval(
+    query: str,
+    limit: int,
+    *,
+    searxng: SearXNGClient | None = None,
+    semantic: SemanticClient | None = None,
+    web_results: list[dict[str, Any]] | None = None,
+    categories: list[str] | None = None,
+    sources: list[str] | None = None,
+    admission: Any = None,
+    scraper: ScraperClient | None = None,
+    cache: CrawlCache | None = None,
+    cache_max_age_ms: int | None = DEFAULT_CACHE_MAX_AGE_MS,
+    web_timeout: float = WEB_TIMEOUT_SECONDS,
+    vector_timeout: float = VECTOR_TIMEOUT_SECONDS,
+) -> HybridRetrievalResult:
+    """Plan a ``hybrid_vector`` retrieval: discover, blend, and acquire.
+
+    Args:
+        query: The search query.
+        limit: The maximum number of candidates to return.
+        searxng: Web-search client. When omitted and ``web_results`` is not
+            supplied, web discovery is skipped.
+        semantic: Vector-search client. When omitted, vector discovery is
+            skipped (semantic disabled).
+        web_results: Pre-fetched web results. When supplied, web discovery is
+            not performed (the caller has already searched).
+        categories: SearXNG categories for web discovery.
+        sources: SearXNG sources for web discovery.
+        admission: Admission controller; defaults to the process singleton.
+        scraper: When supplied, enables cache-assisted content acquisition and
+            populates ``artifacts``. Otherwise only discovery + blend run.
+        cache: Scrape cache; defaults to the process-wide singleton.
+        cache_max_age_ms: Freshness window for cache reuse (``None`` disables
+            the cache lookup).
+        web_timeout: Per-branch timeout for web discovery (seconds).
+        vector_timeout: Per-branch timeout for vector discovery (seconds).
+
+    Returns:
+        A :class:`HybridRetrievalResult` with blended ``results``, acquired
+        ``artifacts`` (empty unless ``scraper`` is set), and ``web_health`` /
+        ``web_count`` for callers that need the raw web-search outcome.
+    """
+    admission = admission if admission is not None else get_admission()
+
+    web_list: list[dict[str, Any]] = (
+        list(web_results) if web_results is not None else []
+    )
+    vector_list: list[dict[str, Any]] = []
+    web_health: SearchHealth | None = None
+
+    web_needed = web_results is None and searxng is not None
+    vector_needed = semantic is not None
+
+    async def _discover_web() -> None:
+        nonlocal web_health
+        assert searxng is not None  # nosec — guarded by web_needed
+        async with admission.resource("lightweight_fetch", weight=1):
+            results, health = await searxng.search(
+                query, limit=limit, categories=categories, sources=sources
+            )
+        web_list.extend(results)
+        web_health = health
+
+    async def _discover_vector() -> None:
+        assert semantic is not None  # nosec — guarded by vector_needed
+        async with admission.resource("lightweight_fetch", weight=1):
+            results = await semantic.search_vector(query, limit=limit)
+        vector_list.extend(results)
+
+    coros: list[Any] = []
+    labels: list[str] = []
+    if web_needed:
+        coros.append(asyncio.wait_for(_discover_web(), timeout=web_timeout))
+        labels.append("web")
+    if vector_needed:
+        coros.append(asyncio.wait_for(_discover_vector(), timeout=vector_timeout))
+        labels.append("vector")
+
+    if coros:
+        outcomes = await asyncio.gather(*coros, return_exceptions=True)
+        for label, outcome in zip(labels, outcomes, strict=True):
+            if isinstance(outcome, BaseException):
+                logger.warning("Hybrid %s discovery failed: %s", label, outcome)
+
+    web_order, vector_order, by_norm = _collect_candidates(web_list, vector_list)
+    results = _blend(web_order, vector_order, by_norm, limit)
+
+    artifacts: list[SourceArtifact] = []
+    if scraper is not None and results:
+        effective_cache = cache if cache is not None else get_crawl_cache()
+        artifacts = await _acquire_candidates(
+            results, scraper, effective_cache, cache_max_age_ms, limit
+        )
+
+    return HybridRetrievalResult(
+        results=results,
+        artifacts=artifacts,
+        web_health=web_health,
+        web_count=len(web_list),
+    )

--- a/agent-svc/agent/research/hybrid.py
+++ b/agent-svc/agent/research/hybrid.py
@@ -19,6 +19,13 @@ Blend policy (deterministic, no web-first starvation)
        floor_web    = max(0, limit - len(vector_unique))
        floor_vector = max(0, limit - len(web_unique))
 
+   In addition, a diversity floor reserves one slot for each source that has
+   at least one exclusive candidate (provenance ``web`` / ``vector``) while
+   the other source also contributes candidates::
+
+       if has_web_only and vector_unique:    floor_web    = max(floor_web, 1)
+       if has_vector_only and web_unique:    floor_vector = max(floor_vector, 1)
+
    The web floor and vector floor are emitted first (each in its source's
    rank order), then the remaining slots are filled by round-robin
    interleaving of the two rank orders (web first). Rank order within a
@@ -26,8 +33,9 @@ Blend policy (deterministic, no web-first starvation)
    the round-robin interleave is the deterministic cross-source tie-break.
    Overlapping URLs (provenance ``both``) are emitted once, keeping web's
    richer metadata (title/description) and the vector score when present.
-3. A Qdrant-only candidate therefore always has a chance to enter the final
-   candidate set even when web returns a full result budget.
+3. An exclusive (``web``-only or ``vector``-only) candidate therefore always
+   has a chance to enter the final candidate set even when the other source
+   returns a full result budget.
 
 Acquisition
 -----------
@@ -121,15 +129,23 @@ def _normalize_url_for_blend(url: str) -> str:
     Lowercases the scheme and hostname, drops the default port, strips the
     fragment, and strips a trailing slash from the path. The query string and
     path case are preserved (both are significant to URL identity).
+
+    Malformed URLs (an invalid IPv6 literal, a non-numeric port) raise
+    ``ValueError`` during parsing; those fall back to the raw URL so a single
+    bad result cannot abort the whole blend. The raw text is still
+    deduplicated exactly by :func:`_collect_candidates`.
     """
-    parsed = urlparse(url)
-    scheme = parsed.scheme.lower()
-    host = (parsed.hostname or "").lower()
+    try:
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+    except ValueError:
+        return url
     if not host:
         # Relative or otherwise unparseable URL — normalize what we can.
         return url
     display_host = f"[{host}]" if ":" in host else host
-    port = parsed.port
     if port is not None and not _is_default_port(scheme, port):
         display_host = f"{display_host}:{port}"
     path = parsed.path.rstrip("/")
@@ -220,11 +236,24 @@ def _blend(
 
     See the module docstring for the full policy. The floor guarantee ensures
     neither source can be fully starved by a full budget from the other; the
-    remaining slots are filled by round-robin interleaving (web first), which
-    is deterministic.
+    diversity floor reserves a slot for each source that has an exclusive
+    candidate while the other source also contributes. The remaining slots are
+    filled by round-robin interleaving (web first), which is deterministic.
     """
+    has_web_only = any(by_norm[norm]["retrieval"] == "web" for norm in web_order)
+    has_vector_only = any(
+        by_norm[norm]["retrieval"] == "vector" for norm in vector_order
+    )
+
     floor_web = max(0, limit - len(vector_order))
     floor_vector = max(0, limit - len(web_order))
+
+    # Diversity floor: an exclusive candidate from a source that also faces
+    # candidates from the other source must always have a chance to enter.
+    if has_web_only and vector_order:
+        floor_web = max(floor_web, 1)
+    if has_vector_only and web_order:
+        floor_vector = max(floor_vector, 1)
 
     result: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -251,8 +280,6 @@ def _blend(
     ):
         while web_idx < len(web_order) and web_order[web_idx] in seen:
             web_idx += 1
-        while vector_idx < len(vector_order) and vector_order[vector_idx] in seen:
-            vector_idx += 1
 
         advanced = False
         if web_idx < len(web_order):
@@ -260,11 +287,17 @@ def _blend(
             seen.add(web_order[web_idx])
             web_idx += 1
             advanced = True
+
+        # Re-check ``seen`` after the web append so an overlapping URL at the
+        # current vector pointer is not emitted twice in the same iteration.
+        while vector_idx < len(vector_order) and vector_order[vector_idx] in seen:
+            vector_idx += 1
         if len(result) < limit and vector_idx < len(vector_order):
             result.append(by_norm[vector_order[vector_idx]])
             seen.add(vector_order[vector_idx])
             vector_idx += 1
             advanced = True
+
         if not advanced:
             break
 

--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -549,7 +549,11 @@ async def run_answer_stream(
     try:
         # Step 1: Search (fetch extra results to allow for scrape failures)
         logger.info("Answer (stream): searching for: %s", query)
-        search_results, _health = await searxng.search(query, limit=num_sources * 2)
+        if retrieval_mode == "hybrid_vector":
+            # Defer web search to the hybrid planner (concurrent web+vector).
+            search_results: list[dict] = []
+        else:
+            search_results, _health = await searxng.search(query, limit=num_sources * 2)
 
         rerank_artifacts: list[SourceArtifact] = []
         if retrieval_mode != "keyword":
@@ -562,6 +566,7 @@ async def run_answer_stream(
                 semantic_url,
                 scraper_url,
                 num_sources,
+                searxng=searxng,
             )
         target_urls = [r["url"] for r in search_results if r.get("url")]
 

--- a/agent-svc/agent/research/rerank.py
+++ b/agent-svc/agent/research/rerank.py
@@ -7,6 +7,7 @@ import time
 from common.stage_metrics import observe_elapsed
 
 from ..scraper_client import ScraperClient
+from ..searxng_client import SearXNGClient
 from ..semantic_client import SemanticClient
 from .sources import SourceArtifact
 
@@ -62,6 +63,7 @@ async def _rerank_answer_sources(
     scraper_url: str,
     limit: int,
     max_concurrent: int = _RERANK_MAX_CONCURRENT,
+    searxng: SearXNGClient | None = None,
 ) -> tuple[list[dict], list[SourceArtifact]]:
     """Rerank or augment search results for the answer pipeline.
 
@@ -69,7 +71,9 @@ async def _rerank_answer_sources(
     artifacts carry the candidate Markdown fetched concurrently during ranking
     so final synthesis can reuse it instead of scraping again.
     """
-    if retrieval_mode == "keyword" or not search_results:
+    if retrieval_mode == "keyword" or (
+        not search_results and retrieval_mode != "hybrid_vector"
+    ):
         return search_results, []
 
     started = time.monotonic()
@@ -120,20 +124,17 @@ async def _rerank_answer_sources(
             ], []
 
         elif retrieval_mode == "hybrid_vector":
-            vector_results = await semantic.search_vector(query, limit=limit)
-            seen: set[str] = set()
-            merged: list[dict] = []
-            for r in search_results[:limit]:
-                if r["url"] not in seen:
-                    seen.add(r["url"])
-                    merged.append(r)
-            for r in vector_results:
-                if r["url"] not in seen:
-                    seen.add(r["url"])
-                    merged.append(
-                        {"url": r["url"], "title": r["title"], "description": ""}
-                    )
-            return merged[:limit], []
+            from .hybrid import plan_hybrid_retrieval
+
+            plan = await plan_hybrid_retrieval(
+                query=query,
+                limit=limit,
+                searxng=searxng,
+                semantic=semantic,
+                web_results=search_results or None,
+                scraper=scraper,
+            )
+            return plan.results, plan.artifacts
 
         return search_results, []
     finally:

--- a/agent-svc/agent/research/search.py
+++ b/agent-svc/agent/research/search.py
@@ -332,27 +332,19 @@ async def run_search_stream(
 
         elif retrieval_mode == "hybrid_vector":
             from ..semantic_client import SemanticClient
+            from .hybrid import plan_hybrid_retrieval
 
             semantic = SemanticClient(semantic_url)
             try:
-                searxng_results, _health = await searxng.search(
-                    query, limit=limit, categories=categories, sources=sources
+                plan = await plan_hybrid_retrieval(
+                    query=query,
+                    limit=limit,
+                    searxng=searxng,
+                    semantic=semantic,
+                    categories=categories,
+                    sources=sources,
                 )
-                vector_results = await semantic.search_vector(query, limit=limit)
-
-                seen: set[str] = set()
-                merged: list[dict] = []
-                for r in searxng_results:
-                    if r["url"] not in seen:
-                        seen.add(r["url"])
-                        merged.append(r)
-                for r in vector_results:
-                    if r["url"] not in seen:
-                        seen.add(r["url"])
-                        merged.append(
-                            {"url": r["url"], "title": r["title"], "description": ""}
-                        )
-                search_results = merged[:limit]
+                search_results = plan.results
             finally:
                 await semantic.close()
 

--- a/agent-svc/agent/research/sources.py
+++ b/agent-svc/agent/research/sources.py
@@ -28,8 +28,15 @@ class SourceArtifact:
     markdown: str | None = None
     source: str = "unknown"
     char_count: int = 0
-    cache_state: str | None = None  # None / "fresh" / "stale" / "from_cache"
+    cache_state: str | None = None  # None / "live" / "from_cache"
     fetched_at: float | None = None
+    # Hybrid-retrieval provenance (ADR-0052). ``retrieval`` records which
+    # discovery source(s) produced the URL; ``score`` carries the vector
+    # similarity score when one exists; ``cache_age_ms`` is set only when
+    # content was reused from the Valkey scrape cache.
+    retrieval: str = "web"  # "web" / "vector" / "both"
+    score: float | None = None
+    cache_age_ms: int | None = None
 
     def to_document(self, max_chars: int = DOCUMENT_MAX_CHARS) -> str:
         """Render the source into a ``Source: url (domain: ...)`` context block."""

--- a/agent-svc/agent/routes/search.py
+++ b/agent-svc/agent/routes/search.py
@@ -179,52 +179,40 @@ async def search(request: Request, body: SearchRequest) -> SearchResponse:
             finally:
                 await semantic.close()
 
-        # Hybrid vector mode: SearXNG + Qdrant in parallel, merge, dedup
+        # Hybrid vector mode: concurrent SearXNG + Qdrant discovery, blended
+        # deterministically by the shared hybrid planner.
         elif body.retrieval_mode == "hybrid_vector":
+            from ..research.hybrid import plan_hybrid_retrieval
             from ..semantic_client import SemanticClient
 
             semantic = SemanticClient(request.app.state.semantic_url)
             try:
-                # Fetch SearXNG results first
-                searxng_results, _health = await searxng.search(
-                    body.query,
+                plan = await plan_hybrid_retrieval(
+                    query=body.query,
                     limit=body.limit,
+                    searxng=searxng,
+                    semantic=semantic,
                     categories=body.categories,
                     sources=effective_sources,
+                    admission=request.app.state.admission,
                 )
-                if not searxng_results and _health.engines_responding == 0:
+                if (
+                    plan.web_count == 0
+                    and plan.web_health is not None
+                    and plan.web_health.engines_responding == 0
+                ):
                     warning_msg = (
                         "All search engines returned no results. "
                         "Check your BRAVE_API_KEY configuration."
                     )
-                # Query vector index in parallel (async would be better, but sequential for now)
-                vector_results = await semantic.search_vector(
-                    body.query, limit=body.limit
-                )
-
-                # Convert both to SearchResult lists
-                kw_results = [
+                search_results = [
                     SearchResult(
                         url=r["url"],
                         title=r["title"],
                         description=r.get("description", ""),
                     )
-                    for r in searxng_results
+                    for r in plan.results
                 ]
-                vec_results = [
-                    SearchResult(url=r["url"], title=r["title"], description="")
-                    for r in vector_results
-                ]
-
-                # Merge and dedup by URL (keep first occurrence — SearXNG has richer metadata)
-                seen: set[str] = set()
-                merged: list[SearchResult] = []
-                for r in kw_results + vec_results:
-                    if r.url not in seen:
-                        seen.add(r.url)
-                        merged.append(r)
-
-                search_results = merged[: body.limit]
             finally:
                 await semantic.close()
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -70,3 +70,24 @@ Each artifact in `benchmarks/baselines/` is JSON with:
 the raw samples. Artifacts must never contain deployment identifiers (hostname,
 IP, machine, node, or pod values); the harness strips these via
 `sanitise_baseline`.
+
+## Hybrid retrieval old-vs-new comparison
+
+`scripts/benchmark_hybrid_retrieval.py` compares the pre-#532 sequential
+web-first `hybrid_vector` merge against the #532 concurrent, floor-guaranteed
+blend across four dimensions — latency, source diversity (Qdrant-only
+candidates that survive), citation validity, and answer quality (recall@k proxy).
+It is a deterministic, stdlib-only, in-process simulation (no Docker), so it is
+runnable anywhere:
+
+```bash
+python scripts/benchmark_hybrid_retrieval.py --runs 5
+python scripts/benchmark_hybrid_retrieval.py --runs 5 --json
+```
+
+The results demonstrate the structural change (concurrent latency is the max of
+the two branches rather than their sum, and a Qdrant-only candidate can enter a
+full web budget) but are **not** a live-stack benchmark and make **no universal
+quality claim from a single run** — the metrics are structural proxies, and real
+latency/diversity/citation/answer-quality numbers require the live Docker stack
+plus an LLM-judge harness (documented follow-up, consistent with #528).

--- a/docs/adr/0052-hybrid-retrieval-planner.md
+++ b/docs/adr/0052-hybrid-retrieval-planner.md
@@ -1,0 +1,106 @@
+# Concurrent Cache-Assisted Hybrid Retrieval Planner
+
+- Status: accepted
+- Deciders: GroktoCrawl maintainers
+- Date: 2026-01-15
+
+## Context
+
+`hybrid_vector` retrieval combined SlopSearX (web) and Qdrant (vector) results by
+running the two lookups sequentially and then concatenating web results before
+vector results, truncating to the requested limit. Two consequences followed:
+
+1. The independent searches did not overlap in time, so latency was the sum of
+   both lookups.
+2. A full web result budget suppressed every Qdrant-only candidate, because web
+   results were always placed first and the merge was truncated.
+
+The local page index is not a substitute for open-web search: it stores an
+embedding plus URL/title metadata, not page Markdown or a complete web corpus.
+However, its URLs can be combined with the Valkey scrape cache to avoid repeat
+network work when cached content meets the caller's freshness policy.
+
+This change (issue #532) introduces a single hybrid retrieval planner that runs
+the two discovery branches concurrently, blends them deterministically with a
+floor guarantee, and reuses compatible cached Markdown before live-scraping
+misses.
+
+## Decision
+
+We introduce `agent-svc/agent/research/hybrid.py` with one
+`plan_hybrid_retrieval(...)` function. The three existing `hybrid_vector` call
+sites (`routes/search.py`, `research/search.py:run_search_stream`, and
+`research/rerank.py:_rerank_answer_sources`) delegate to it rather than each
+maintaining a copy of the merge.
+
+**Concurrent, independently timeout-bounded discovery.** SlopSearX and Qdrant
+(`semantic.search_vector`) run via `asyncio.gather(..., return_exceptions=True)`,
+each wrapped in `asyncio.wait_for` (web 15s, vector 8s by default). The
+concurrent work runs inside the global admission budget
+(`app.state.admission.acquire("lightweight_fetch", ...)`); a cancelled or timed-out
+branch releases its budget via the `resource()` context manager.
+
+**Deterministic blend with a floor guarantee.** URLs are normalised (lowercased
+scheme/host, default ports dropped, fragment stripped, trailing slash stripped)
+and deduplicated by that normalised form, recording per-URL provenance
+(`web`/`vector`/`both`). The blend uses::
+
+    floor_web    = max(0, limit - len(vector_unique))
+    floor_vector = max(0, limit - len(web_unique))
+
+The web floor and vector floor are emitted first (each in its source's rank
+order), then the remaining slots are filled by round-robin interleaving of the
+two rank orders (web first). Rank order within a source is preserved, keeping
+each source's own relevance signal; the round-robin interleave is the
+deterministic cross-source tie-break, and overlapping URLs are emitted once,
+keeping web's richer metadata and the vector score when present. This guarantees
+a full budget from either source cannot starve the other — a Qdrant-only
+candidate always has a chance to enter the final candidate set.
+
+**Cache-assisted acquisition.** When a scraper is supplied, each surviving
+candidate consults `CrawlCache.check_cache(url, max_age_ms=...)` (default
+1-hour freshness window). A fresh, compatible entry (non-empty Markdown) is
+reused and recorded with `cache_state="from_cache"` and `cache_age_ms`; misses
+and stale entries are live-scraped via the existing `_scrape_urls` machinery and
+recorded with `cache_state="live"`. Cache lookups are best-effort: a failure
+degrades to a live scrape. Canonically-equivalent URLs are scraped or cache-read
+once because they are deduplicated before acquisition.
+
+**Provenance on the artifact.** `SourceArtifact` gains `retrieval`
+(`web`/`vector`/`both`), `score` (optional float), and `cache_age_ms` (optional
+int); the existing `cache_state` field records cache vs live acquisition. This
+metadata is carried into ranking and synthesis.
+
+**Graceful degradation.** If the semantic service is disabled or unavailable,
+the planner returns web-only results (equivalent to the keyword path). If
+SearXNG fails or returns nothing, it returns vector-only results. Transport
+failures never propagate to callers.
+
+The web/vector ratio is intentionally not configurable: the deterministic floor
+policy is hardcoded, as the ratio is a cross-cutting retrieval-quality concern
+that warrants a dedicated experiment (the benchmark script) before any tuning
+knob is added.
+
+## Consequences
+
+- Positive: web and vector discovery overlap, bounded independently, so hybrid
+  latency is the max of the two branches rather than their sum.
+- Positive: Qdrant-only candidates can enter the final set even when web returns
+  a full budget, improving source diversity.
+- Positive: fresh, compatible cached Markdown is reused for both web and vector
+  candidates, avoiding repeat network work; provenance is observable per source.
+- Positive: semantic failure degrades to keyword behaviour and SearXNG failure to
+  vector-only behaviour, with no exceptions leaking to callers.
+- Negative: the cache freshness window (default 1 hour) is a hardcoded policy;
+  the cache-contract issue (#529) owns stale-serving semantics, and this planner
+  never reuses stale content.
+- Negative: the floor/blend policy is deterministic but not yet tuned against a
+  live workload; the benchmark script compares latency, source diversity,
+  citation validity, and answer quality but explicitly makes no universal claim
+  from a single run.
+
+## Links
+
+- [ADR-0050 Request-Scoped Source Artifact](0050-source-artifact-and-lightweight-only-scrape.md)
+- [ADR-0051 Global Admission Control and End-to-End Cancellation](0051-global-admission-control-and-cancellation.md)
+- [ADR-0048 Stage-Level Telemetry](0048-stage-level-telemetry.md)

--- a/docs/adr/0052-hybrid-retrieval-planner.md
+++ b/docs/adr/0052-hybrid-retrieval-planner.md
@@ -48,14 +48,22 @@ and deduplicated by that normalised form, recording per-URL provenance
     floor_web    = max(0, limit - len(vector_unique))
     floor_vector = max(0, limit - len(web_unique))
 
+A diversity floor then reserves one slot for each source that has at least one
+exclusive candidate while the other source also contributes candidates::
+
+    if has_web_only and vector_unique:    floor_web    = max(floor_web, 1)
+    if has_vector_only and web_unique:    floor_vector = max(floor_vector, 1)
+
 The web floor and vector floor are emitted first (each in its source's rank
 order), then the remaining slots are filled by round-robin interleaving of the
 two rank orders (web first). Rank order within a source is preserved, keeping
 each source's own relevance signal; the round-robin interleave is the
 deterministic cross-source tie-break, and overlapping URLs are emitted once,
 keeping web's richer metadata and the vector score when present. This guarantees
-a full budget from either source cannot starve the other — a Qdrant-only
-candidate always has a chance to enter the final candidate set.
+a full budget from either source cannot starve the other — an exclusive
+(`web`-only or `vector`-only) candidate always has a chance to enter the final
+candidate set. Malformed URLs (invalid IPv6 literals, non-numeric ports) fall
+back to their raw text during normalisation rather than aborting the blend.
 
 **Cache-assisted acquisition.** When a scraper is supplied, each surviving
 candidate consults `CrawlCache.check_cache(url, max_age_ms=...)` (default

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ An Architecture Decision Record captures an important architectural decision mad
 
 **Status legend:** accepted ADRs describe decisions used by the current implementation. Proposed ADRs are design work, not promises of current behavior. Superseded ADRs are historical context only; use their successor when documenting current behavior.
 
-**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, 0049, 0050, and 0051.
+**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, 0049, 0050, 0051, and 0052.
 
 **Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, and 0040–0042.
 
@@ -76,5 +76,5 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0049 | [Research Memory Compatibility Fingerprint, Freshness, and Stale-While-Revalidate](0049-research-memory-compatibility-freshness-swr.md) | accepted |
 | 0050 | [Request-Scoped Source Artifact and Lightweight-Only Scrape Contract](0050-source-artifact-and-lightweight-only-scrape.md) | accepted |
 | 0051 | [Global Admission Control and End-to-End Cancellation](0051-global-admission-control-and-cancellation.md) | accepted |
-
+| 0052 | [Concurrent Cache-Assisted Hybrid Retrieval Planner](0052-hybrid-retrieval-planner.md) | accepted |
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -56,6 +56,20 @@ URLs, content, and tokens are never metric labels.
 | `fetches_deduped_total` | `reason` (`rerank_reuse`) | Scrapes avoided by reusing source content already fetched during ranking |
 | `scrape_retries_total` | `stage` (`generic_to_browser`) | Explicit scrape retries by stage transition |
 
+## Hybrid retrieval blend policy
+
+`hybrid_vector` retrieval is planned by `agent-svc/agent/research/hybrid.py`
+(ADR-0052). Its discovery branches (SlopSearX and Qdrant) run concurrently and
+are independently timeout-bounded (web 15s, vector 8s) inside the
+`lightweight_fetch` admission budget. The blend is deterministic and has no
+raw-URL metric labels: candidates are normalised and deduplicated, emitted via a
+floor guarantee (`floor_web = max(0, limit - vector_unique)`,
+`floor_vector = max(0, limit - web_unique)`) followed by round-robin
+interleaving. Per-source provenance (`web`/`vector`/`both`) and acquisition
+origin (`cache_state`: `from_cache`/`live`, plus `cache_age_ms`) are carried on
+the internal `SourceArtifact`, not exported as metric labels.
+
+
 ## Verification
 
 1. Validate the deployment's Prometheus configuration and rules with its native check commands.

--- a/scripts/benchmark_hybrid_retrieval.py
+++ b/scripts/benchmark_hybrid_retrieval.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Deterministic old-vs-new comparison for ``hybrid_vector`` retrieval.
+
+Simulates the pre-#532 sequential web-first merge against the #532 concurrent
+blend in-process (stdlib-only, no Docker) so the comparison is runnable and
+reproducible anywhere. It measures the four dimensions called out by the issue:
+
+- **latency** — old sums the web + vector discovery delays; new takes the max
+  (the two branches run concurrently).
+- **source diversity** — how many Qdrant-only candidates survive into the final
+  candidate set.
+- **citation validity** — fraction of returned URLs that are well-formed
+  ``http(s)`` URLs (a proxy for citable sources).
+- **answer quality** — recall@k against a fixed "golden" relevant-URL set
+  (a proxy; real answer quality needs an LLM-judge harness).
+
+Usage::
+
+    python scripts/benchmark_hybrid_retrieval.py --runs 5
+    python scripts/benchmark_hybrid_retrieval.py --runs 5 --json
+
+This is NOT a CI gate and NOT a live-stack benchmark. The delays and result
+sets are deterministic fixtures, and the metrics are structural proxies, not
+end-user quality measurements.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from statistics import mean
+from urllib.parse import urlparse
+
+# ── Deterministic fixtures ───────────────────────────────────────
+# web_urls and vector_urls intentionally overlap so both the dedup path and the
+# vector-only path are exercised. ``golden_urls`` is the set a perfect ranking
+# would surface first.
+WEB_URLS = [f"https://web{i}.example/page" for i in range(6)]
+VECTOR_URLS = [
+    "https://web0.example/page",  # overlap
+    "https://web1.example/page",  # overlap
+    "https://vec0.example/page",  # vector-only
+    "https://vec1.example/page",  # vector-only
+]
+GOLDEN_URLS = {"https://web0.example/page", "https://vec0.example/page"}
+
+WEB_DELAY = 0.150  # seconds, simulated SlopSearX latency
+VECTOR_DELAY = 0.080  # seconds, simulated Qdrant latency
+LIMIT = 5
+
+
+def _normalize(url: str) -> str:
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return url
+    display_host = f"[{host}]" if ":" in host else host
+    port = parsed.port
+    default = (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    if port is not None and not default:
+        display_host = f"{display_host}:{port}"
+    path = parsed.path.rstrip("/") or "/"
+    out = f"{scheme}://{display_host}{path}"
+    if parsed.query:
+        out += f"?{parsed.query}"
+    return out
+
+
+def _old_merge(web: list[str], vector: list[str], limit: int) -> list[str]:
+    """Pre-#532 behaviour: web first, then vector, dedup by raw URL, truncate."""
+    seen: set[str] = set()
+    merged: list[str] = []
+    for url in [*web, *vector]:
+        if url not in seen:
+            seen.add(url)
+            merged.append(url)
+    return merged[:limit]
+
+
+def _new_merge(web: list[str], vector: list[str], limit: int) -> list[str]:
+    """#532 behaviour: normalise, dedup, floor guarantee, round-robin interleave."""
+    by_norm: dict[str, str] = {}
+    web_order: list[str] = []
+    vector_order: list[str] = []
+    for url in web:
+        norm = _normalize(url)
+        if norm in by_norm:
+            continue
+        by_norm[norm] = url
+        web_order.append(norm)
+    for url in vector:
+        norm = _normalize(url)
+        if norm not in by_norm:
+            by_norm[norm] = url
+        vector_order.append(norm)
+
+    floor_web = max(0, limit - len(vector_order))
+    floor_vector = max(0, limit - len(web_order))
+
+    result: list[str] = []
+    seen: set[str] = set()
+
+    def take(order: list[str], count: int) -> None:
+        taken = 0
+        for norm in order:
+            if taken >= count or len(result) >= limit:
+                return
+            if norm in seen:
+                continue
+            result.append(by_norm[norm])
+            seen.add(norm)
+            taken += 1
+
+    take(web_order, floor_web)
+    take(vector_order, floor_vector)
+
+    wi = vi = 0
+    while len(result) < limit and (wi < len(web_order) or vi < len(vector_order)):
+        while wi < len(web_order) and web_order[wi] in seen:
+            wi += 1
+        while vi < len(vector_order) and vector_order[vi] in seen:
+            vi += 1
+        advanced = False
+        if wi < len(web_order):
+            result.append(by_norm[web_order[wi]])
+            seen.add(web_order[wi])
+            wi += 1
+            advanced = True
+        if len(result) < limit and vi < len(vector_order):
+            result.append(by_norm[vector_order[vi]])
+            seen.add(vector_order[vi])
+            vi += 1
+            advanced = True
+        if not advanced:
+            break
+    return result
+
+
+def _metrics(urls: list[str]) -> dict:
+    vector_only = [u for u in urls if "vec" in urlparse(u).hostname]
+    valid = sum(1 for u in urls if urlparse(u).scheme in ("http", "https"))
+    recall = len(set(urls) & GOLDEN_URLS) / len(GOLDEN_URLS)
+    return {
+        "vector_only_candidates": len(vector_only),
+        "citation_validity": valid / len(urls) if urls else 0.0,
+        "answer_quality_recall_at_k": recall,
+    }
+
+
+def run_once(run_index: int) -> dict:
+    """Run one simulated comparison of the old and new strategies."""
+    # Jitter the simulated delays so latency percentiles are meaningful.
+    web_delay = WEB_DELAY + (run_index % 3) * 0.01
+    vector_delay = VECTOR_DELAY + (run_index % 2) * 0.01
+
+    old_latency = web_delay + vector_delay
+    new_latency = max(web_delay, vector_delay)
+
+    old_urls = _old_merge(WEB_URLS, VECTOR_URLS, LIMIT)
+    new_urls = _new_merge(WEB_URLS, VECTOR_URLS, LIMIT)
+
+    return {
+        "run": run_index,
+        "old": {
+            "latency_s": round(old_latency, 4),
+            "urls": old_urls,
+            **_metrics(old_urls),
+        },
+        "new": {
+            "latency_s": round(new_latency, 4),
+            "urls": new_urls,
+            **_metrics(new_urls),
+        },
+    }
+
+
+def _summarize(runs: list[dict]) -> dict:
+    def agg(key: str) -> dict:
+        old_samples = [r["old"][key] for r in runs]
+        new_samples = [r["new"][key] for r in runs]
+        return {
+            "old_mean": round(mean(old_samples), 4),
+            "new_mean": round(mean(new_samples), 4),
+        }
+
+    return {
+        "runs": len(runs),
+        "latency_s": agg("latency_s"),
+        "vector_only_candidates": agg("vector_only_candidates"),
+        "citation_validity": agg("citation_validity"),
+        "answer_quality_recall_at_k": agg("answer_quality_recall_at_k"),
+        "caveat": (
+            "Deterministic in-process simulation with structural proxies; "
+            "no universal quality claim should be drawn from a single run. "
+            "Real latency/diversity/citation/quality numbers require the live "
+            "Docker stack and an LLM-judge harness (documented follow-up)."
+        ),
+    }
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=3, help="runs per strategy")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print the summary as JSON to stdout",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if args.runs < 1:
+        print("error: --runs must be >= 1", file=sys.stderr)
+        return 2
+
+    runs = [run_once(i) for i in range(args.runs)]
+    summary = _summarize(runs)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    print("old-vs-new hybrid_vector retrieval (simulated, stdlib-only)")
+    print(f"runs={summary['runs']} limit={LIMIT}\n")
+    header = f"{'metric':<28} {'old (mean)':>14} {'new (mean)':>14}"
+    print(header)
+    print("-" * len(header))
+    for key, label in (
+        ("latency_s", "latency (s)"),
+        ("vector_only_candidates", "vector-only candidates"),
+        ("citation_validity", "citation validity"),
+        ("answer_quality_recall_at_k", "answer quality (recall@k)"),
+    ):
+        print(
+            f"{label:<28} {summary[key]['old_mean']:>14.4f} "
+            f"{summary[key]['new_mean']:>14.4f}"
+        )
+    print("\n" + summary["caveat"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_research.py
+++ b/tests/integration/test_research.py
@@ -1545,8 +1545,17 @@ class TestRerankAnswerSources:
         )
         mock_semantic.close = AsyncMock()
 
-        mock_scraper = MagicMock()
-        mock_scraper.close = AsyncMock()
+        class _Scraper:
+            async def scrape_with_fallback(self, url: str, **kwargs) -> dict:
+                return {
+                    "success": True,
+                    "data": {"markdown": f"content {url}", "source": "test"},
+                }
+
+            async def close(self) -> None:
+                pass
+
+        mock_scraper = _Scraper()
 
         with (
             patch("agent.research.rerank.SemanticClient", return_value=mock_semantic),
@@ -1565,4 +1574,5 @@ class TestRerankAnswerSources:
         assert len(ranked) == 3
         urls = [r["url"] for r in ranked]
         assert urls == ["https://a.com", "https://b.com", "https://c.com"]
-        assert artifacts == []
+        assert {a.url for a in artifacts} == set(urls)
+        assert all(a.markdown for a in artifacts)

--- a/tests/service/test_hybrid_retrieval.py
+++ b/tests/service/test_hybrid_retrieval.py
@@ -1,0 +1,390 @@
+"""Tests for the concurrent, cache-assisted hybrid retrieval planner.
+
+Covers ``agent-svc/agent/research/hybrid.py``:
+
+- concurrent, independently timeout-bounded web + vector discovery
+- deterministic blend with the floor guarantee (no web-first starvation)
+- URL normalization and overlap deduplication (provenance ``both``)
+- Qdrant-only candidates surviving a full web budget
+- provenance fields on every acquired artifact
+- cache-hit vs live-scrape acquisition provenance
+- graceful degradation (semantic down → keyword-only; web down → vector-only)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from agent.admission import AdmissionController
+from agent.crawl_cache import CrawlCache
+from agent.research.hybrid import plan_hybrid_retrieval
+
+
+def _admission() -> AdmissionController:
+    return AdmissionController(
+        limits={"lightweight_fetch": 64, "browser": 32, "llm": 32}
+    )
+
+
+def _searxng(results: list[dict]) -> MagicMock:
+    searxng = MagicMock()
+    searxng.search = AsyncMock(return_value=(results, MagicMock()))
+    return searxng
+
+
+def _semantic(results: list[dict]) -> MagicMock:
+    semantic = MagicMock()
+    semantic.search_vector = AsyncMock(return_value=results)
+    return semantic
+
+
+def _make_cache() -> CrawlCache:
+    """Build a dict-backed CrawlCache (mirrors test_crawl_cache.py mock pattern)."""
+    store: dict[str, str] = {}
+
+    mock = MagicMock()
+    mock.get.side_effect = lambda key: store.get(key)
+    mock.set.side_effect = lambda key, value, ex=None: store.update({key: value})
+    mock.delete.side_effect = lambda key: store.pop(key, None)
+
+    cache = CrawlCache("redis://localhost:6379/0")
+    cache.redis = mock
+    return cache
+
+
+class FakeScraper:
+    """Duck-typed scraper used by ``_scrape_urls`` (scrape_with_fallback)."""
+
+    def __init__(self) -> None:
+        self.scraped: list[str] = []
+
+    async def scrape_with_fallback(self, url: str, **kwargs) -> dict:
+        self.scraped.append(url)
+        return {
+            "success": True,
+            "data": {"markdown": f"md {url}", "source": "test"},
+        }
+
+    async def close(self) -> None:
+        pass
+
+
+def _web(n: int) -> list[dict]:
+    return [
+        {"url": f"https://w{i}.com", "title": f"W{i}", "description": f"d{i}"}
+        for i in range(n)
+    ]
+
+
+def _vec(n: int, offset: int = 0) -> list[dict]:
+    return [
+        {"url": f"https://v{i}.com", "title": f"V{i}", "score": 0.9 - i * 0.05}
+        for i in range(offset, offset + n)
+    ]
+
+
+# ── Concurrent, timeout-bounded discovery ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_discovery_branches_run_concurrently():
+    """Web and vector discovery overlap in time (not sequential)."""
+    state = {"active": 0, "max_active": 0}
+
+    async def slow_web(*_args, **_kwargs):
+        state["active"] += 1
+        state["max_active"] = max(state["max_active"], state["active"])
+        await asyncio.sleep(0.05)
+        state["active"] -= 1
+        return [{"url": "https://w.com", "title": "W"}], MagicMock()
+
+    async def slow_vector(*_args, **_kwargs):
+        state["active"] += 1
+        state["max_active"] = max(state["max_active"], state["active"])
+        await asyncio.sleep(0.05)
+        state["active"] -= 1
+        return [{"url": "https://v.com", "title": "V"}]
+
+    searxng = MagicMock()
+    searxng.search = slow_web
+    semantic = MagicMock()
+    semantic.search_vector = slow_vector
+
+    plan = await plan_hybrid_retrieval(
+        "q", 5, searxng=searxng, semantic=semantic, admission=_admission()
+    )
+
+    assert state["max_active"] == 2
+    assert {r["url"] for r in plan.results} == {"https://w.com", "https://v.com"}
+
+
+@pytest.mark.asyncio
+async def test_web_timeout_yields_vector_only():
+    """A web branch that exceeds its timeout is dropped; vector results remain."""
+
+    async def slow_web(*_args, **_kwargs):
+        await asyncio.sleep(0.5)
+        return [{"url": "https://w.com", "title": "W"}], MagicMock()
+
+    searxng = MagicMock()
+    searxng.search = slow_web
+    semantic = _semantic(_vec(2))
+
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=searxng,
+        semantic=semantic,
+        admission=_admission(),
+        web_timeout=0.05,
+    )
+
+    assert [r["url"] for r in plan.results] == ["https://v0.com", "https://v1.com"]
+    assert plan.web_count == 0
+
+
+@pytest.mark.asyncio
+async def test_vector_timeout_yields_web_only():
+    """A vector branch that exceeds its timeout is dropped; web results remain."""
+
+    async def slow_vector(*_args, **_kwargs):
+        await asyncio.sleep(0.5)
+        return [{"url": "https://v.com", "title": "V"}]
+
+    searxng = _searxng(_web(2))
+    semantic = MagicMock()
+    semantic.search_vector = slow_vector
+
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=searxng,
+        semantic=semantic,
+        admission=_admission(),
+        vector_timeout=0.05,
+    )
+
+    assert [r["url"] for r in plan.results] == ["https://w0.com", "https://w1.com"]
+
+
+# ── Deterministic blend / floor guarantee ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_web_full_vector_empty():
+    """A full web budget with no vector results yields the web order."""
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng(_web(5)),
+        semantic=_semantic([]),
+        admission=_admission(),
+    )
+    assert [r["url"] for r in plan.results] == [f"https://w{i}.com" for i in range(5)]
+    assert all(r["retrieval"] == "web" for r in plan.results)
+
+
+@pytest.mark.asyncio
+async def test_vector_full_web_empty():
+    """A full vector budget with no web results yields the vector order."""
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng([]),
+        semantic=_semantic(_vec(5)),
+        admission=_admission(),
+    )
+    assert [r["url"] for r in plan.results] == [f"https://v{i}.com" for i in range(5)]
+    assert all(r["retrieval"] == "vector" for r in plan.results)
+
+
+@pytest.mark.asyncio
+async def test_both_full_interleaves_deterministically():
+    """Two full budgets interleave round-robin (web first), deterministically."""
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng(_web(5)),
+        semantic=_semantic(_vec(5)),
+        admission=_admission(),
+    )
+    assert [r["url"] for r in plan.results] == [
+        "https://w0.com",
+        "https://v0.com",
+        "https://w1.com",
+        "https://v1.com",
+        "https://w2.com",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_overlapping_urls_normalized_and_deduped():
+    """Canonically-equivalent URLs collapse to one candidate (provenance both)."""
+    web = [
+        {"url": "https://Example.com/a/", "title": "A", "description": "desc a"},
+        {"url": "https://example.com/b", "title": "B", "description": "desc b"},
+        {"url": "https://example.com/c", "title": "C", "description": "desc c"},
+    ]
+    vector = [
+        {"url": "https://example.com/a", "title": "A", "score": 0.95},
+        {"url": "https://example.com/d", "title": "D", "score": 0.8},
+    ]
+    plan = await plan_hybrid_retrieval(
+        "q",
+        4,
+        searxng=_searxng(web),
+        semantic=_semantic(vector),
+        admission=_admission(),
+    )
+
+    urls = [r["url"] for r in plan.results]
+    # The overlap "a" keeps web's original URL; floors run before interleave.
+    assert urls == [
+        "https://Example.com/a/",
+        "https://example.com/b",
+        "https://example.com/d",
+        "https://example.com/c",
+    ]
+    by_url = {r["url"]: r for r in plan.results}
+    assert by_url["https://Example.com/a/"]["retrieval"] == "both"
+    assert by_url["https://Example.com/a/"]["score"] == 0.95
+    assert by_url["https://example.com/b"]["retrieval"] == "web"
+    assert by_url["https://example.com/d"]["retrieval"] == "vector"
+
+
+@pytest.mark.asyncio
+async def test_qdrant_only_candidate_survives_full_web_budget():
+    """The floor guarantee lets a Qdrant-only candidate into a full web set."""
+    web = _web(5)
+    vector = [
+        {"url": "https://w0.com", "title": "W0", "score": 0.9},  # overlap
+        {"url": "https://qdrant-only.com", "title": "Q", "score": 0.85},  # new
+    ]
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng(web),
+        semantic=_semantic(vector),
+        admission=_admission(),
+    )
+
+    urls = [r["url"] for r in plan.results]
+    assert "https://qdrant-only.com" in urls
+    by_url = {r["url"]: r for r in plan.results}
+    assert by_url["https://qdrant-only.com"]["retrieval"] == "vector"
+    # Exact deterministic order: web floor of 3, then w3 + the vector-only URL.
+    assert urls == [
+        "https://w0.com",
+        "https://w1.com",
+        "https://w2.com",
+        "https://w3.com",
+        "https://qdrant-only.com",
+    ]
+
+
+# ── Cache-assisted acquisition + provenance ──────────────────────
+
+
+def _cache_entry(markdown: str) -> dict:
+    return {"success": True, "data": {"markdown": markdown, "source": "tier1"}}
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_vs_live_scrape_provenance():
+    """Fresh cache content is reused; misses are live-scraped."""
+    cache = _make_cache()
+    cache.set("https://w0.com", _cache_entry("# Cached content"), ttl_ms=60000)
+
+    scraper = FakeScraper()
+    plan = await plan_hybrid_retrieval(
+        "q",
+        2,
+        searxng=_searxng(_web(2)),
+        semantic=_semantic([]),
+        admission=_admission(),
+        scraper=scraper,
+        cache=cache,
+        cache_max_age_ms=60000,
+    )
+
+    by_url = {a.url: a for a in plan.artifacts}
+    assert by_url["https://w0.com"].cache_state == "from_cache"
+    assert by_url["https://w0.com"].cache_age_ms is not None
+    assert by_url["https://w0.com"].markdown == "# Cached content"
+    assert by_url["https://w1.com"].cache_state == "live"
+    assert by_url["https://w1.com"].cache_age_ms is None
+    assert by_url["https://w1.com"].markdown == "md https://w1.com"
+    # Only the cache miss was live-scraped.
+    assert scraper.scraped == ["https://w1.com"]
+
+
+@pytest.mark.asyncio
+async def test_provenance_fields_present_on_every_artifact():
+    """Every acquired artifact records retrieval, score, cache state, and age."""
+    web = [
+        {"url": "https://a.com", "title": "A", "description": "d"},
+        {"url": "https://b.com", "title": "B", "description": "d"},
+    ]
+    vector = [
+        {"url": "https://a.com", "title": "A", "score": 0.9},
+        {"url": "https://c.com", "title": "C", "score": 0.7},
+    ]
+    plan = await plan_hybrid_retrieval(
+        "q",
+        3,
+        searxng=_searxng(web),
+        semantic=_semantic(vector),
+        admission=_admission(),
+        scraper=FakeScraper(),
+        cache=_make_cache(),
+        cache_max_age_ms=60000,
+    )
+
+    assert len(plan.artifacts) == 3
+    for artifact in plan.artifacts:
+        assert artifact.retrieval in ("web", "vector", "both")
+        assert artifact.score is None or isinstance(artifact.score, float)
+        assert artifact.cache_state in ("live", "from_cache")
+        assert artifact.cache_age_ms is None or isinstance(artifact.cache_age_ms, int)
+
+
+# ── Graceful degradation ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_semantic_down_falls_back_to_keyword_only():
+    """A failing semantic service yields the exact web (keyword) result order."""
+    web = _web(3)
+    semantic = MagicMock()
+    semantic.search_vector = AsyncMock(side_effect=Exception("semantic down"))
+
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng(web),
+        semantic=semantic,
+        admission=_admission(),
+    )
+
+    assert [r["url"] for r in plan.results] == [f"https://w{i}.com" for i in range(3)]
+    assert all(r["retrieval"] == "web" for r in plan.results)
+
+
+@pytest.mark.asyncio
+async def test_searxng_timeout_yields_vector_only():
+    """A failing web branch yields vector-only results."""
+    searxng = MagicMock()
+    searxng.search = AsyncMock(side_effect=TimeoutError())
+
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=searxng,
+        semantic=_semantic(_vec(2)),
+        admission=_admission(),
+    )
+
+    assert [r["url"] for r in plan.results] == ["https://v0.com", "https://v1.com"]
+    assert all(r["retrieval"] == "vector" for r in plan.results)

--- a/tests/service/test_hybrid_retrieval.py
+++ b/tests/service/test_hybrid_retrieval.py
@@ -274,14 +274,145 @@ async def test_qdrant_only_candidate_survives_full_web_budget():
     assert "https://qdrant-only.com" in urls
     by_url = {r["url"]: r for r in plan.results}
     assert by_url["https://qdrant-only.com"]["retrieval"] == "vector"
-    # Exact deterministic order: web floor of 3, then w3 + the vector-only URL.
+    # Exact deterministic order: web floor of 3, then the reserved vector slot
+    # (the diversity floor emits the vector-only URL before the round-robin
+    # interleave pulls in w3).
+    assert urls == [
+        "https://w0.com",
+        "https://w1.com",
+        "https://w2.com",
+        "https://qdrant-only.com",
+        "https://w3.com",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_overlap_full_web_budget_keeps_vector_only_candidate():
+    """A vector-only candidate survives a full, non-overlapping web budget."""
+    web = _web(5)
+    vector = [{"url": "https://v0.com", "title": "V0", "score": 0.9}]
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng(web),
+        semantic=_semantic(vector),
+        admission=_admission(),
+    )
+
+    urls = [r["url"] for r in plan.results]
+    assert "https://v0.com" in urls
+    by_url = {r["url"]: r for r in plan.results}
+    assert by_url["https://v0.com"]["retrieval"] == "vector"
+    # Deterministic order: web floor of 4 (w0..w3), then the reserved vector slot.
     assert urls == [
         "https://w0.com",
         "https://w1.com",
         "https://w2.com",
         "https://w3.com",
-        "https://qdrant-only.com",
+        "https://v0.com",
     ]
+
+
+@pytest.mark.asyncio
+async def test_no_overlap_full_vector_budget_keeps_web_only_candidate():
+    """A web-only candidate survives a full, non-overlapping vector budget."""
+    web = [{"url": "https://w0.com", "title": "W0", "description": "d"}]
+    vector = _vec(5)
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng(web),
+        semantic=_semantic(vector),
+        admission=_admission(),
+    )
+
+    urls = [r["url"] for r in plan.results]
+    assert "https://w0.com" in urls
+    by_url = {r["url"]: r for r in plan.results}
+    assert by_url["https://w0.com"]["retrieval"] == "web"
+    assert urls == [
+        "https://w0.com",
+        "https://v0.com",
+        "https://v1.com",
+        "https://v2.com",
+        "https://v3.com",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("web", "vector", "limit", "expected"),
+    [
+        # Identical rank orders: the round-robin interleave must not emit the
+        # overlapping URL at the shared pointer twice.
+        (
+            [
+                {"url": "https://a.com", "title": "a"},
+                {"url": "https://b.com", "title": "b"},
+                {"url": "https://c.com", "title": "c"},
+            ],
+            [
+                {"url": "https://a.com", "score": 0.9},
+                {"url": "https://b.com", "score": 0.8},
+                {"url": "https://c.com", "score": 0.7},
+            ],
+            4,
+            ["https://a.com", "https://b.com", "https://c.com"],
+        ),
+        # Two overlapping top results under a tight budget.
+        (
+            [
+                {"url": "https://a.com", "title": "a"},
+                {"url": "https://x.com", "title": "x"},
+            ],
+            [
+                {"url": "https://a.com", "score": 0.9},
+                {"url": "https://y.com", "score": 0.8},
+            ],
+            2,
+            ["https://a.com", "https://y.com"],
+        ),
+    ],
+)
+async def test_interleave_never_emits_duplicate_urls(web, vector, limit, expected):
+    """Overlapping top results interleave without ever duplicating a URL."""
+    plan = await plan_hybrid_retrieval(
+        "q",
+        limit,
+        searxng=_searxng(web),
+        semantic=_semantic(vector),
+        admission=_admission(),
+    )
+
+    urls = [r["url"] for r in plan.results]
+    assert urls == expected
+    assert len(urls) == len(set(urls))
+
+
+@pytest.mark.asyncio
+async def test_malformed_urls_fall_back_and_do_not_crash():
+    """Malformed result URLs degrade to raw text instead of aborting retrieval."""
+    web = [
+        {"url": "http://host:abc", "title": "bad port"},
+        {"url": "http://[::1/path", "title": "bad ipv6"},
+        {"url": "https://good.com", "title": "good"},
+    ]
+    plan = await plan_hybrid_retrieval(
+        "q",
+        5,
+        searxng=_searxng(web),
+        semantic=_semantic([]),
+        admission=_admission(),
+    )
+
+    # The two malformed URLs fall back to their raw text; the healthy candidate
+    # is still returned alongside them.
+    assert [r["url"] for r in plan.results] == [
+        "http://host:abc",
+        "http://[::1/path",
+        "https://good.com",
+    ]
+    assert all(r["retrieval"] == "web" for r in plan.results)
 
 
 # ── Cache-assisted acquisition + provenance ──────────────────────

--- a/tests/service/test_issue530_dedup.py
+++ b/tests/service/test_issue530_dedup.py
@@ -276,8 +276,8 @@ async def test_rerank_vector_mode_returns_no_artifacts():
 
 
 @pytest.mark.asyncio
-async def test_rerank_hybrid_vector_mode_returns_no_artifacts():
-    """Hybrid-vector mode merges keyword + vector results without scraping."""
+async def test_rerank_hybrid_vector_mode_returns_provenance_artifacts():
+    """Hybrid-vector mode delegates to the shared planner and acquires content."""
     from agent.research.rerank import _rerank_answer_sources
 
     semantic = MagicMock()
@@ -288,8 +288,7 @@ async def test_rerank_hybrid_vector_mode_returns_no_artifacts():
         ]
     )
     semantic.close = AsyncMock()
-    scraper = MagicMock()
-    scraper.close = AsyncMock()
+    scraper = TrackingScraper()
 
     with (
         patch("agent.research.rerank.SemanticClient", return_value=semantic),
@@ -309,7 +308,11 @@ async def test_rerank_hybrid_vector_mode_returns_no_artifacts():
 
     urls = [r["url"] for r in ranked]
     assert urls == ["https://a.com", "https://b.com", "https://c.com"]
-    assert artifacts == []
+    # Artifacts now carry Markdown + provenance for the answer pipeline.
+    assert {a.url for a in artifacts} == set(urls)
+    assert all(a.markdown for a in artifacts)
+    assert all(a.retrieval in ("web", "vector", "both") for a in artifacts)
+    assert all(a.cache_state in ("live", "from_cache") for a in artifacts)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #532

## Summary

Replaces the three duplicated sequential web-then-Qdrant `hybrid_vector` merges with a single
`agent-svc/agent/research/hybrid.py::plan_hybrid_retrieval(...)` planner that:

- runs SlopSearX and Qdrant discovery **concurrently** (`asyncio.gather(..., return_exceptions=True)`),
  each independently timeout-bounded (web 15s, vector 8s), inside the global `lightweight_fetch`
  admission budget;
- **normalizes** URLs (lowercased scheme/host, default ports dropped, fragment stripped, trailing
  slash stripped) and dedups by normalized URL, recording per-URL provenance (`web`/`vector`/`both`);
- blends with a **floor guarantee** (`floor_web = max(0, limit - vector_unique)`,
  `floor_vector = max(0, limit - web_unique)`) followed by round-robin interleaving, so a full web
  budget cannot starve Qdrant-only candidates;
- performs **cache-assisted acquisition**: reuses fresh, compatible Valkey scrape-cache Markdown
  (`cache_state="from_cache"`, `cache_age_ms`) and live-scrapes misses via `_scrape_urls`
  (`cache_state="live"`), reading/scraping canonically-equivalent URLs once;
- degrades gracefully: semantic-svc down → keyword-only, SearXNG failure → vector-only, cache
  failure → live scrape, and never raises on transport failures.

The three call sites (`routes/search.py`, `research/search.py:run_search_stream`,
`research/rerank.py:_rerank_answer_sources`) now delegate to the planner. `SourceArtifact` gains
`retrieval`, `score`, and `cache_age_ms` provenance fields (using the existing `cache_state`).

## Acceptance criteria mapping

- Concurrent, independently timeout-bounded discovery → `plan_hybrid_retrieval` gather + `wait_for`.
- Documented deterministic blend, tested for full-budget cases → ADR-0052 + `_blend` + tests.
- Qdrant-only candidates get a real chance → floor guarantee + `test_qdrant_only_candidate_survives_full_web_budget`.
- Canonically-equivalent URLs scraped/cache-read once → normalized dedup before acquisition.
- Cached Markdown reused only when freshness/compatibility passes → `CrawlCache.check_cache(max_age_ms)` + non-empty Markdown gate; stale → live scrape.
- Every final source records web/vector/both and cache/live → `SourceArtifact.retrieval` + `cache_state`/`cache_age_ms`.
- Works without semantic services, preserves keyword-only behavior → `test_semantic_down_falls_back_to_keyword_only`.
- Context-equivalent benchmark with no universal claim → `scripts/benchmark_hybrid_retrieval.py` (simulation, explicit caveat; live numbers are a documented follow-up).

## Tests added

- `tests/service/test_hybrid_retrieval.py` — concurrent discovery, per-branch timeout, web/vector
  full-budget blends, normalization/dedup, floor guarantee, provenance fields, cache-hit vs
  live-scrape, semantic-down and SearXNG-timeout degradation.
- Updated `tests/service/test_issue530_dedup.py` (hybrid_vector now returns provenance artifacts).
- Updated `tests/integration/test_research.py` (hybrid_vector now returns scraped artifacts).

## Non-goals (deferred per issue)

- Qdrant is not made authoritative for open-web discovery.
- No live-stack benchmark (Docker unavailable locally); the benchmark script is a deterministic
  in-process simulation with an explicit "no universal claim from a single run" caveat.
- Stale-serving behavior is left to the cache-contract issue (#529); only fresh cache is reused.