### PR TITLE
ci: publish parse-svc and mcp-svc images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,6 +84,14 @@ jobs:
             context: .
             dockerfile: portal-svc/Dockerfile
             image: ghcr.io/groktopus/groktocrawl-portal
+          - service: parse-svc
+            context: .
+            dockerfile: parse-svc/Dockerfile
+            image: ghcr.io/groktopus/groktocrawl-parse
+          - service: mcp-svc
+            context: mcp-svc
+            dockerfile: Dockerfile
+            image: ghcr.io/groktopus/groktocrawl-mcp
       max-parallel: 2
 
     permissions:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,11 +216,13 @@ services:
     build:
       context: .
       dockerfile: parse-svc/Dockerfile
+    image: ghcr.io/groktopus/groktocrawl-parse
     restart: unless-stopped
 
   mcp-svc:
     build:
       context: ./mcp-svc
+    image: ghcr.io/groktopus/groktocrawl-mcp
     ports:
       - '${MCP_PORT:-8002}:8002'
     environment:


### PR DESCRIPTION
Adds parse-svc and mcp-svc to the Docker Build & Publish matrix and adds image: directives in docker-compose.yml so `docker compose pull` can fetch all first-party services from GHCR. Fixtures (llm-svc, test-site, tier3-fixture) remain build-only.