### PR TITLE
chore: ignore parallel-mode coverage data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pypackages__/
 .hermes/
 .opencode/
 .planning/
-.coverage
+.coverage*
 graphify-out/
 docker-compose.override.yml
 ofelia/config.local.ini


### PR DESCRIPTION
## What

Widen the `.coverage` ignore rule to `.coverage*`.

## Why

Coverage runs with parallel mode (e.g. pytest-xdist) write per-worker data files named `.coverage.<host>.<pid>.<random>` rather than a single `.coverage`. The current rule only ignores the plain file, so parallel coverage runs leave a stream of untracked files in the working tree.

## Scope

One line in `.gitignore`. No behavior change to the product.