### PR TITLE
fix(semantic): bound Qdrant query timeout and degrade to 503 instead of 500

### DIFF
--- a/agent-svc/agent/research/similar.py
+++ b/agent-svc/agent/research/similar.py
@@ -3,6 +3,8 @@
 import logging
 import math
 
+import httpx
+
 from ..scraper_client import ScraperClient
 from ..searxng_client import SearXNGClient
 
@@ -70,7 +72,18 @@ async def _run_find_similar_qdrant(
         # 2. Search Qdrant using the scraped content as the query
         # search_vector() embeds the text server-side and searches the index
         query_text = f"{title} {markdown[:3000]}"
-        vector_results = await semantic.search_vector(query_text, limit=limit)
+        try:
+            vector_results = await semantic.search_vector(query_text, limit=limit)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 503:
+                # Vector index unavailable (e.g. models loading or a slow /
+                # unhealthy Qdrant). Degrade gracefully to no similar results
+                # rather than surfacing a 500 to the caller.
+                logger.warning(
+                    "find_similar: semantic vector index unavailable (503); returning no results"
+                )
+                return []
+            raise
 
         return [
             {

--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -173,6 +173,7 @@ _qdrant_ready: bool = False
 COLLECTION_NAME = "groktocrawl_pages"
 MAX_DOCS = int(os.getenv("VECTOR_INDEX_MAX_DOCS", "250000"))
 QDRANT_URL = os.getenv("QDRANT_URL", "http://qdrant:6333")
+QDRANT_QUERY_TIMEOUT = float(os.getenv("QDRANT_QUERY_TIMEOUT", "10"))
 
 # ── Migration state (in-memory, lost on restart) ──────────────────
 # For restart-surviving state, store in Valkey or a known Qdrant point.

--- a/semantic-svc/router_search.py
+++ b/semantic-svc/router_search.py
@@ -9,6 +9,7 @@ import logging
 import app as app_module
 from app import (
     COLLECTION_NAME,
+    QDRANT_QUERY_TIMEOUT,
     _ensure_qdrant,
     _get_active_model,
     _get_embed_model,
@@ -45,12 +46,32 @@ async def search_vector(body: VectorSearchRequest):
 
     active_nv = _get_active_model()
 
-    hits = qdrant.query_points(
-        collection_name=COLLECTION_NAME,
-        query=query_embedding,
-        using=active_nv,
-        limit=body.limit,
-    ).points
+    # Qdrant query_points() is a blocking call. Run it off the event loop
+    # with a bounded timeout so a slow or unhealthy index degrades to a
+    # structured 503 instead of escaping as an unhandled 500.
+    try:
+        hits = await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                lambda: (
+                    qdrant.query_points(
+                        collection_name=COLLECTION_NAME,
+                        query=query_embedding,
+                        using=active_nv,
+                        limit=body.limit,
+                    ).points
+                ),
+            ),
+            timeout=QDRANT_QUERY_TIMEOUT,
+        )
+    except TimeoutError:
+        logger.error(
+            "Vector search timed out querying Qdrant after %ss", QDRANT_QUERY_TIMEOUT
+        )
+        raise HTTPException(503, "Vector index query timed out")
+    except Exception:
+        logger.exception("Vector search failed querying Qdrant")
+        raise HTTPException(503, "Vector index unavailable")
 
     results = [
         VectorSearchResult(

--- a/tests/unit/test_find_similar_degradation.py
+++ b/tests/unit/test_find_similar_degradation.py
@@ -1,0 +1,112 @@
+"""Tests for graceful degradation of the find-similar qdrant path.
+
+Covers ``agent-svc/agent/research/similar.py:_run_find_similar_qdrant``:
+when semantic-svc returns 503 for the vector search (models loading or a
+slow/unhealthy Qdrant index), find-similar should degrade to an empty result
+instead of letting the HTTPStatusError escape as a 500.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from agent.research.similar import _run_find_similar_qdrant
+
+
+class _FakeScraper:
+    def __init__(self):
+        self.closed = False
+
+    async def scrape(self, url):
+        return {
+            "success": True,
+            "data": {
+                "markdown": "# Herbs\nHydroponic herb gardening tips.",
+                "metadata": {"title": "Herb Garden"},
+            },
+        }
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeSemantic:
+    def __init__(self, search_vector):
+        self._search_vector = search_vector
+        self.closed = False
+
+    async def search_vector(self, query, limit=5):
+        return await self._search_vector(query, limit)
+
+    async def close(self):
+        self.closed = True
+
+
+def _mock_http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://semantic-svc:8003/search/vector")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_qdrant_503_returns_empty_results():
+    """A 503 from semantic-svc degrades to no similar results, not a 500."""
+    semantic = _FakeSemantic(AsyncMock(side_effect=_mock_http_status_error(503)))
+
+    with (
+        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
+        patch("agent.semantic_client.SemanticClient", return_value=semantic),
+    ):
+        results = await _run_find_similar_qdrant(
+            url="https://example.com/herbs",
+            limit=5,
+            scraper_url="http://scraper-svc:8001",
+            semantic_url="http://semantic-svc:8003",
+        )
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_qdrant_non_503_status_re_raises():
+    """A non-503 upstream error still propagates."""
+    semantic = _FakeSemantic(AsyncMock(side_effect=_mock_http_status_error(500)))
+
+    with (
+        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
+        patch("agent.semantic_client.SemanticClient", return_value=semantic),
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await _run_find_similar_qdrant(
+                url="https://example.com/herbs",
+                limit=5,
+                scraper_url="http://scraper-svc:8001",
+                semantic_url="http://semantic-svc:8003",
+            )
+
+
+@pytest.mark.asyncio
+async def test_qdrant_success_returns_results():
+    """A healthy vector search returns mapped results unchanged."""
+
+    async def _ok(query, limit):
+        return [{"url": "https://a.com", "title": "A", "content": "content A"}]
+
+    semantic = _FakeSemantic(_ok)
+
+    with (
+        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
+        patch("agent.semantic_client.SemanticClient", return_value=semantic),
+    ):
+        results = await _run_find_similar_qdrant(
+            url="https://example.com/herbs",
+            limit=5,
+            scraper_url="http://scraper-svc:8001",
+            semantic_url="http://semantic-svc:8003",
+        )
+
+    assert results == [
+        {"url": "https://a.com", "title": "A", "description": "content A"}
+    ]

--- a/tests/unit/test_semantic_svc_unit.py
+++ b/tests/unit/test_semantic_svc_unit.py
@@ -879,3 +879,104 @@ class TestTargetEmbedModelCache:
 
         # Initially empty string
         assert isinstance(_target_embed_model_name, str)
+
+
+# ── Search vector: Qdrant failure boundary ───────────────────────
+
+
+def _async_return(value):
+    async def _wrap(*_args, **_kwargs):
+        return value
+
+    return _wrap
+
+
+class TestSearchVectorQdrantBoundary:
+    """POST /search/vector must convert a slow or failing Qdrant query
+    into a structured 503 instead of an unhandled 500.
+
+    Regression for the live 500 observed when the local Qdrant index is
+    unhealthy: ``router_search.search_vector`` previously called the
+    blocking ``qdrant.query_points`` with no timeout and no error boundary,
+    so a slow/stuck index escaped as a generic internal error.
+    """
+
+    @staticmethod
+    def _ready_router(monkeypatch, qdrant):
+        import app as app_module
+        import router_search
+
+        class _FakeModel:
+            def encode(self, text, normalize_embeddings=True):
+                import numpy as np
+
+                return np.array([[0.1, 0.2, 0.3]])
+
+        monkeypatch.setattr(app_module, "_models_ready", True)
+        monkeypatch.setattr(router_search, "_ensure_qdrant", _async_return(qdrant))
+        monkeypatch.setattr(router_search, "_get_embed_model", lambda: _FakeModel())
+        monkeypatch.setattr(router_search, "_get_active_model", lambda: "v_bge-m3")
+        return router_search
+
+    @pytest.mark.asyncio
+    async def test_qdrant_timeout_returns_503(self, monkeypatch):
+        """A Qdrant query that exceeds the bound returns 503, not 500."""
+
+        from fastapi import HTTPException
+        from models import VectorSearchRequest
+
+        class _SlowQdrant:
+            def query_points(self, **kwargs):
+                raise TimeoutError("timed out")
+
+        router_search = self._ready_router(monkeypatch, _SlowQdrant())
+        with pytest.raises(HTTPException) as exc_info:
+            await router_search.search_vector(
+                VectorSearchRequest(query="herbs", limit=5)
+            )
+        assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_qdrant_failure_returns_503(self, monkeypatch):
+        """A Qdrant connection/query error returns 503, not 500."""
+        from fastapi import HTTPException
+        from models import VectorSearchRequest
+
+        class _BadQdrant:
+            def query_points(self, **kwargs):
+                raise RuntimeError("connection refused")
+
+        router_search = self._ready_router(monkeypatch, _BadQdrant())
+        with pytest.raises(HTTPException) as exc_info:
+            await router_search.search_vector(
+                VectorSearchRequest(query="herbs", limit=5)
+            )
+        assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_success_still_returns_results(self, monkeypatch):
+        """A healthy Qdrant query still returns scored results unchanged."""
+        from models import VectorSearchRequest, VectorSearchResponse
+
+        class _Hit:
+            def __init__(self, url, title, score):
+                self.payload = {"url": url, "title": title}
+                self.score = score
+
+        class _OkQdrant:
+            def query_points(self, **kwargs):
+                class _Resp:
+                    points = [
+                        _Hit("https://a.com", "A", 0.91),
+                        _Hit("https://b.com", "B", 0.82),
+                    ]
+
+                return _Resp()
+
+        router_search = self._ready_router(monkeypatch, _OkQdrant())
+        resp = await router_search.search_vector(
+            VectorSearchRequest(query="herbs", limit=5)
+        )
+        assert isinstance(resp, VectorSearchResponse)
+        assert [r.url for r in resp.results] == ["https://a.com", "https://b.com"]
+        assert [r.score for r in resp.results] == [0.91, 0.82]

--- a/tests/unit/test_semantic_svc_unit.py
+++ b/tests/unit/test_semantic_svc_unit.py
@@ -907,7 +907,7 @@ class TestSearchVectorQdrantBoundary:
         import router_search
 
         class _FakeModel:
-            def encode(self, text, normalize_embeddings=True):
+            def encode(self, text, **kwargs):
                 import numpy as np
 
                 return np.array([[0.1, 0.2, 0.3]])


### PR DESCRIPTION
## Problem

`GET /search/vector` (semantic-svc) called Qdrant's blocking `query_points()` directly on the event loop with no timeout and no error boundary. When the local Qdrant index is slow or unhealthy, the call escaped as an **unhandled HTTP 500**. This was observed live through the MCP `find_similar` tool: a Qdrant query timed out and surfaced as a 500 instead of a controlled error.

## Root cause

In `semantic-svc/router_search.py`, the query was run inline:

```python
hits = qdrant.query_points(collection_name=..., query=..., using=..., limit=...).points
```

- Blocking call on the event loop (not offloaded).
- No timeout bound.
- No `try/except` — so `ResponseHandlingException: timed out` (or any Qdrant error) propagated as a 500.

Additionally, agent-svc's `find_similar` qdrant path called `semantic.search_vector(...)` which calls `raise_for_status()`, so even a structured 503 from semantic-svc would have propagated as a 500 at the agent boundary.

## Fix

**semantic-svc (`router_search.py`)**
- Run the blocking Qdrant query in an executor with a bounded timeout (`QDRANT_QUERY_TIMEOUT`, default 10s, env-overridable).
- Convert a timeout to a structured `503 "Vector index query timed out"`.
- Convert any other Qdrant/query failure to `503 "Vector index unavailable"` (matching the existing error shape at `app.py:374`).
- Happy path is unchanged.

**agent-svc (`agent/research/similar.py`)**
- In `_run_find_similar_qdrant`, catch `httpx.HTTPStatusError` with status 503 from semantic-svc and degrade gracefully to an empty result list instead of propagating a 500. Non-503 errors still propagate.

## Tests

- `tests/unit/test_semantic_svc_unit.py::TestSearchVectorQdrantBoundary`
  - `test_qdrant_timeout_returns_503` — Qdrant timeout → 503 (not 500).
  - `test_qdrant_failure_returns_503` — Qdrant query error → 503.
  - `test_success_still_returns_results` — healthy query returns scored results unchanged.
- `tests/unit/test_find_similar_degradation.py`
  - `test_qdrant_503_returns_empty_results` — semantic 503 degrades to `[]`.
  - `test_qdrant_non_503_status_re_raises` — non-503 still propagates.
  - `test_qdrant_success_returns_results` — healthy path maps results.

Verified: regression tests fail on the pre-fix code and pass on the fix. Full fast-test lane (unit + service) passes: **1502 passed**.

## Behavior after the fix (end-to-end)

With an unhealthy/slow Qdrant index:
- `semantic-svc /search/vector` → `503` with a structured message (no more 500).
- agent-svc `find_similar` qdrant mode → empty result list (graceful degradation).
- MCP `find_similar` → structured error with `status_code: 503` (preserved by the client).

With a healthy index, behavior is unchanged.
