### PR TITLE
fix(agent): degrade find_similar on any semantic backend failure, not just 503

### DIFF
--- a/agent-svc/agent/research/similar.py
+++ b/agent-svc/agent/research/similar.py
@@ -74,16 +74,20 @@ async def _run_find_similar_qdrant(
         query_text = f"{title} {markdown[:3000]}"
         try:
             vector_results = await semantic.search_vector(query_text, limit=limit)
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 503:
-                # Vector index unavailable (e.g. models loading or a slow /
-                # unhealthy Qdrant). Degrade gracefully to no similar results
-                # rather than surfacing a 500 to the caller.
-                logger.warning(
-                    "find_similar: semantic vector index unavailable (503); returning no results"
-                )
-                return []
-            raise
+        except httpx.HTTPError as e:
+            # Vector index unavailable or slow (503, timeout, connection
+            # error). Degrade gracefully to no similar results rather than
+            # surfacing a 500 to the caller.
+            response = getattr(e, "response", None)
+            status = (
+                getattr(response, "status_code", None) if response is not None else None
+            )
+            detail = f" (HTTP {status})" if status else f" ({type(e).__name__})"
+            logger.warning(
+                "find_similar: semantic vector search failed%s; returning no results",
+                detail,
+            )
+            return []
 
         return [
             {

--- a/tests/unit/test_find_similar_degradation.py
+++ b/tests/unit/test_find_similar_degradation.py
@@ -1,9 +1,9 @@
 """Tests for graceful degradation of the find-similar qdrant path.
 
 Covers ``agent-svc/agent/research/similar.py:_run_find_similar_qdrant``:
-when semantic-svc returns 503 for the vector search (models loading or a
-slow/unhealthy Qdrant index), find-similar should degrade to an empty result
-instead of letting the HTTPStatusError escape as a 500.
+when semantic-svc fails for the vector search (503 index unavailable,
+timeout on a slow backend, or connection error), find-similar should
+degrade to an empty result instead of letting the error escape as a 500.
 """
 
 from __future__ import annotations
@@ -70,21 +70,44 @@ async def test_qdrant_503_returns_empty_results():
 
 
 @pytest.mark.asyncio
-async def test_qdrant_non_503_status_re_raises():
-    """A non-503 upstream error still propagates."""
+async def test_qdrant_http_error_returns_empty():
+    """A 500 from semantic-svc degrades to no similar results, not a 500."""
     semantic = _FakeSemantic(AsyncMock(side_effect=_mock_http_status_error(500)))
 
     with (
         patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
         patch("agent.semantic_client.SemanticClient", return_value=semantic),
     ):
-        with pytest.raises(httpx.HTTPStatusError):
-            await _run_find_similar_qdrant(
-                url="https://example.com/herbs",
-                limit=5,
-                scraper_url="http://scraper-svc:8001",
-                semantic_url="http://semantic-svc:8003",
-            )
+        results = await _run_find_similar_qdrant(
+            url="https://example.com/herbs",
+            limit=5,
+            scraper_url="http://scraper-svc:8001",
+            semantic_url="http://semantic-svc:8003",
+        )
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_qdrant_timeout_returns_empty():
+    """A timeout (slow backend) degrades to no similar results, not a 500."""
+    request = httpx.Request("POST", "http://semantic-svc:8003/search/vector")
+    semantic = _FakeSemantic(
+        AsyncMock(side_effect=httpx.ReadTimeout("timed out", request=request))
+    )
+
+    with (
+        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
+        patch("agent.semantic_client.SemanticClient", return_value=semantic),
+    ):
+        results = await _run_find_similar_qdrant(
+            url="https://example.com/herbs",
+            limit=5,
+            scraper_url="http://scraper-svc:8001",
+            semantic_url="http://semantic-svc:8003",
+        )
+
+    assert results == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`find_similar` in qdrant mode could still return an HTTP 500 when semantic-svc's vector search is slow or down. The prior fix (PR #544) made `semantic-svc` return a structured 503 on a Qdrant query timeout, and agent-svc degrades on a **503**. But the real-world failure is often a **timeout**: `semantic-svc` can take longer than the agent client's 30s timeout (e.g., cold embedding-model warm-up, ~43s observed live), which raises `httpx.ReadTimeout` — not `HTTPStatusError` — so it escaped as a 500.

## Fix

In `agent-svc/agent/research/similar.py`, catch `httpx.HTTPError` broadly (the parent of `HTTPStatusError`, `TimeoutException`/`ReadTimeout`, `ConnectError`) and degrade to an empty result list instead of surfacing a 500. Logs the failure class / HTTP status for visibility.

`find_similar` is optional enrichment; when the vector index backend is unavailable or slow, returning "no similar pages found" is correct graceful behavior.

## Tests

Updated `tests/unit/test_find_similar_degradation.py`:
- `test_qdrant_503_returns_empty_results` — unchanged (503 → empty).
- `test_qdrant_http_error_returns_empty` — 500 now degrades to empty (was: re-raises).
- `test_qdrant_timeout_returns_empty` — new: `httpx.ReadTimeout` → empty (the cold-start regression).
- `test_qdrant_success_returns_results` — unchanged.

Full fast-test lane: **1503 passed**.
