### PR TITLE
ci(docker): fix mcp-svc build-and-push context

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,8 +89,8 @@ jobs:
             dockerfile: parse-svc/Dockerfile
             image: ghcr.io/groktopus/groktocrawl-parse
           - service: mcp-svc
-            context: mcp-svc
-            dockerfile: Dockerfile
+            context: .
+            dockerfile: mcp-svc/Dockerfile
             image: ghcr.io/groktopus/groktocrawl-mcp
       max-parallel: 2
 


### PR DESCRIPTION
Fixes a pre-existing CI bug in `.github/workflows/docker.yml`.

**Problem:** the `build-and-push` matrix entry for `mcp-svc` used `context: mcp-svc` with `dockerfile: Dockerfile`. Buildx resolves the `file` path against the given `context`, so it looked for `Dockerfile` at the repo root — where none exists — failing every push-to-main image build for `mcp-svc` with `open Dockerfile: no such file or directory`, which in turn kept the push `Runtime Gate` red.

**Fix:** align `mcp-svc` with the other services: `context: .` with `dockerfile: mcp-svc/Dockerfile` (`mcp-svc/Dockerfile` exists). Now every push to `main` builds all services including `mcp-svc`, and the push `Runtime Gate` can go green.

This is a `push`-only matrix job (`if: github.event_name == 'push'`), so this PR's own run only exercises the `changes` classifier path; the fix is validated by the next push-to-main build.