### PR TITLE
ci(docker): guard self-hosted integration against fork PRs (#483)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -166,7 +166,8 @@ jobs:
     needs: [changes, build-and-push]
     if: >-
       always() && ((github.event_name == 'pull_request' && needs.changes.result == 'success' &&
-      needs.changes.outputs.requires_full_runtime == 'true') ||
+      needs.changes.outputs.requires_full_runtime == 'true' &&
+      github.event.pull_request.head.repo.fork == false) ||
       (github.event_name == 'push' && needs.build-and-push.result == 'success'))
     runs-on: [self-hosted, groktopus, docker]
     concurrency:
@@ -539,6 +540,12 @@ jobs:
           needs.changes.outputs.requires_full_runtime == 'false'
         run: echo "Runtime integration was intentionally not needed for this docs-only pull request."
 
+      - name: Summarize fork pull request (integration skipped)
+        if: >-
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true &&
+          needs.changes.result == 'success'
+        run: 'echo "Fork pull request: self-hosted integration skipped for security."'
+
       - name: Summarize successful runtime validation
         if: >-
           github.event_name == 'pull_request' && needs.changes.result == 'success' &&
@@ -559,6 +566,8 @@ jobs:
           needs.changes.result == 'success' &&
           !(github.event_name == 'pull_request' &&
           needs.changes.outputs.requires_full_runtime == 'false') &&
+          !(github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == true) &&
           needs.integration-tests.result != 'success'
         run: |
           echo "Required runtime integration did not complete successfully."

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -164,6 +164,12 @@ jobs:
   integration-tests:
     name: Integration Tests
     needs: [changes, build-and-push]
+    # The fork guard (mirroring droid-review.yml) keeps untrusted fork PR code off the
+    # self-hosted runner. This is a best-effort in-workflow control: on `pull_request`
+    # events GitHub runs the workflow from the PR merge ref, so a fork that edits this
+    # file could bypass the guard. The authoritative, non-bypassable control is
+    # platform-level (deny fork PRs to the runner group / require workflow approval for
+    # outside collaborators), which is outside this repo and must be configured there.
     if: >-
       always() && ((github.event_name == 'pull_request' && needs.changes.result == 'success' &&
       needs.changes.outputs.requires_full_runtime == 'true' &&

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -115,12 +115,14 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         changes_result: str,
         requires_full_runtime: str,
         build_result: str,
+        fork: bool,
     ) -> bool:
-        """Evaluate the workflow's two supported integration-test lanes."""
+        """Evaluate the workflow's integration-test lanes (PR, fork-PR, push)."""
         return (
             event_name == "pull_request"
             and changes_result == "success"
             and requires_full_runtime == "true"
+            and not fork
         ) or (event_name == "push" and build_result == "success")
 
     def test_docker_build_matrix_is_push_only(self) -> None:
@@ -134,7 +136,8 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
             self.integration_condition,
             "always() && ((github.event_name == 'pull_request' && "
             "needs.changes.result == 'success' && "
-            "needs.changes.outputs.requires_full_runtime == 'true') || "
+            "needs.changes.outputs.requires_full_runtime == 'true' && "
+            "github.event.pull_request.head.repo.fork == false) || "
             "(github.event_name == 'push' && needs.build-and-push.result == 'success'))",
         )
         self.assertFalse(
@@ -143,6 +146,7 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
                 changes_result="success",
                 requires_full_runtime="false",
                 build_result="skipped",
+                fork=False,
             )
         )
 
@@ -153,6 +157,22 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
                 changes_result="success",
                 requires_full_runtime="true",
                 build_result="skipped",
+                fork=False,
+            )
+        )
+
+    def test_fork_pull_request_cannot_run_integration_tests(self) -> None:
+        self.assertIn(
+            "github.event.pull_request.head.repo.fork == false",
+            self.integration_condition,
+        )
+        self.assertFalse(
+            self.integration_tests_runs_for(
+                event_name="pull_request",
+                changes_result="success",
+                requires_full_runtime="true",
+                build_result="skipped",
+                fork=True,
             )
         )
 
@@ -259,6 +279,16 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         )
         self.assertIn(
             "needs.changes.outputs.requires_full_runtime == 'false'", self.runtime_gate
+        )
+
+    def test_fork_pr_runtime_gate_succeeds_noop(self) -> None:
+        self.assertIn("if: always()", self.runtime_gate)
+        self.assertIn(
+            "github.event.pull_request.head.repo.fork == true", self.runtime_gate
+        )
+        self.assertIn(
+            "Fork pull request: self-hosted integration skipped for security.",
+            self.runtime_gate,
         )
 
     def test_runtime_gate_fails_when_classification_or_required_runtime_fails(

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -284,10 +284,14 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
     def test_fork_pr_runtime_gate_succeeds_noop(self) -> None:
         self.assertIn("if: always()", self.runtime_gate)
         self.assertIn(
-            "github.event.pull_request.head.repo.fork == true", self.runtime_gate
-        )
-        self.assertIn(
             "Fork pull request: self-hosted integration skipped for security.",
+            self.runtime_gate,
+        )
+        # Pin the fork exclusion to the fail-when-runtime-failed step
+        # specifically (the closing paren before `&&` only appears there, not in
+        # the summarize-fork step), so removing it regresses this test.
+        self.assertIn(
+            "github.event.pull_request.head.repo.fork == true) &&",
             self.runtime_gate,
         )
 


### PR DESCRIPTION
## Summary

Closes #483 (security): untrusted fork PR code must never execute on the self-hosted Docker integration runner (`[self-hosted, groktopus, docker]`).

## Changes

- **`integration-tests`** now requires `github.event.pull_request.head.repo.fork == false` on the PR lane (mirroring `droid-review.yml`), so a fork PR can never schedule the self-hosted integration job — even when `requires_full_runtime == 'true'`.
- **`runtime-gate`** gains an explicit fork no-op lane ("Fork pull request: self-hosted integration skipped for security.") so the required `Runtime Gate` always resolves to success for fork PRs.
- The **fail-when-runtime-failed** step now excludes the fork-skipped path, so a fork PR with runtime changes does not trip a false failure.
- Added contract tests in `tests/service/test_ci_change_classification.py` covering the fork integration-tests block and the fork Runtime-Gate no-op.

Required-check job names (`Code Quality Gate`, `Runtime Gate`) are unchanged.