### PR TITLE
ci(docker): service-local PR builds, remove duplicate --build (#494)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -243,7 +243,12 @@ jobs:
         if: >-
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
           github.event_name == 'pull_request'
-        run: docker compose --profile indexing pull
+        run: |
+          # Best-effort refresh of the published image set. A service may not
+          # have a published tag yet (e.g. a newly added service), which fails
+          # its manifest lookup; tolerate that and let the build/up steps build
+          # the missing image from source instead.
+          docker compose --profile indexing pull || true
         timeout-minutes: 10
 
       - name: Build service images (service-local PR build / tag-push full build)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       requires_full_runtime: ${{ steps.classify.outputs.requires_full_runtime }}
+      affected_services: ${{ steps.classify.outputs.affected_services }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -56,6 +57,8 @@ jobs:
 
           requires_full_runtime=$(printf '%s\n' "$changed_paths" | python3 scripts/classify_ci_changes.py)
           echo "requires_full_runtime=$requires_full_runtime" >> "$GITHUB_OUTPUT"
+          affected_services=$(printf '%s\n' "$changed_paths" | python3 scripts/classify_ci_changes.py --affected-services)
+          echo "affected_services=$affected_services" >> "$GITHUB_OUTPUT"
 
   build-and-push:
     name: ${{ matrix.service }}
@@ -214,8 +217,41 @@ jobs:
       - name: Ensure HF model cache volume exists
         run: docker volume inspect hf-cache || docker volume create hf-cache
 
+      # Image provisioning is decoupled from stack startup so each service image
+      # is built at most once per event:
+      #   - on push/main, build-and-push already built and published every image,
+      #     so this job just pulls the freshly published tags (no rebuild).
+      #   - on a PR, only the images for services whose paths changed are built
+      #     (service-local), gated on the classifier's affected-services output.
+      #   - unknown/cross-cutting runtime paths escalate to a full rebuild.
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull freshly published service images
+        if: github.event_name == 'push'
+        run: docker compose --profile indexing pull
+        timeout-minutes: 10
+
+      - name: Build affected service images (service-local PR build)
+        if: github.event_name == 'pull_request'
+        run: |
+          affected="${{ needs.changes.outputs.affected_services }}"
+          if [ -z "$affected" ] || [ "$affected" = "all" ]; then
+            echo "No service-local subset identified; building the full runtime stack."
+            docker compose --profile indexing build
+          else
+            echo "Service-local PR build for: $affected"
+            docker compose --profile indexing build $affected
+          fi
+        timeout-minutes: 10
+
       - name: Start the Docker stack
-        run: docker compose --profile indexing up --build -d
+        run: docker compose --profile indexing up -d
         timeout-minutes: 10
 
       - name: Start test fixtures

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -218,14 +218,21 @@ jobs:
         run: docker volume inspect hf-cache || docker volume create hf-cache
 
       # Image provisioning is decoupled from stack startup so each service image
-      # is built at most once per event:
-      #   - on push/main, build-and-push already built and published every image,
-      #     so this job just pulls the freshly published tags (no rebuild).
-      #   - on a PR, only the images for services whose paths changed are built
-      #     (service-local), gated on the classifier's affected-services output.
-      #   - unknown/cross-cutting runtime paths escalate to a full rebuild.
+      # is built at most once per event (except release tag pushes, which must
+      # both publish semver tags and validate the tagged source):
+      #   - main push: build-and-push already built and published every image, so
+      #     this job pulls the freshly published :latest tags (no rebuild).
+      #   - PR: pulls the latest published images for unchanged services (so the
+      #     stack matches a known commit), then builds only the images for
+      #     services whose paths changed (service-local), gated on the
+      #     classifier's affected-services output; unknown/cross-cutting runtime
+      #     paths escalate to a full rebuild.
+      #   - tag push (v*): build-and-push published only semver tags, so this job
+      #     builds the full runtime stack from the tagged source.
       - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -233,20 +240,24 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull freshly published service images
-        if: github.event_name == 'push'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+          github.event_name == 'pull_request'
         run: docker compose --profile indexing pull
         timeout-minutes: 10
 
-      - name: Build affected service images (service-local PR build)
-        if: github.event_name == 'pull_request'
+      - name: Build service images (service-local PR build / tag-push full build)
+        if: >-
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'push' && github.ref != 'refs/heads/main')
         run: |
           affected="${{ needs.changes.outputs.affected_services }}"
-          if [ -z "$affected" ] || [ "$affected" = "all" ]; then
-            echo "No service-local subset identified; building the full runtime stack."
-            docker compose --profile indexing build
-          else
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$affected" ] && [ "$affected" != "all" ]; then
             echo "Service-local PR build for: $affected"
             docker compose --profile indexing build $affected
+          else
+            echo "Building the full runtime stack."
+            docker compose --profile indexing build
           fi
         timeout-minutes: 10
 

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -2,8 +2,14 @@
 """Classify changed paths for CI runtime validation.
 
 Pass paths as positional arguments, or provide one path per line on stdin when
-no arguments are supplied. The command prints ``true`` when full runtime
-validation is required and ``false`` only for a non-empty docs-only change.
+no arguments are supplied.
+
+Modes:
+- default: prints ``true`` when full runtime validation is required and
+  ``false`` only for a non-empty docs-only change.
+- ``--affected-services``: prints the space-separated list of runtime service
+  images that must be rebuilt for a pull request, or ``all`` when the change is
+  cross-cutting/unrecognized and the full stack must be rebuilt.
 """
 
 from __future__ import annotations
@@ -13,6 +19,22 @@ from collections.abc import Iterable
 
 DOCS_ONLY_FILES = frozenset({"README.md", "AGENTS.md", "CONTRIBUTING.md"})
 DOCS_ONLY_PREFIXES = ("docs/", ".github/ISSUE_TEMPLATE/")
+
+# Runtime service images in the build matrix / compose stack. Fixture services
+# (llm-svc, test-site, tier3-fixture) are built by their own dedicated step.
+RUNTIME_SERVICES = (
+    "agent-svc",
+    "scraper-svc",
+    "browser-svc",
+    "semantic-svc",
+    "portal-svc",
+    "parse-svc",
+    "mcp-svc",
+)
+
+# Paths whose change affects every service image.
+_CROSS_CUTTING_PATHS = ("docker-compose.yml",)
+_COMMON_PREFIX = "common/"
 
 
 def requires_full_runtime(paths: Iterable[str]) -> bool:
@@ -27,7 +49,44 @@ def requires_full_runtime(paths: Iterable[str]) -> bool:
     )
 
 
+def affected_services(paths: Iterable[str]) -> frozenset[str]:
+    """Return the runtime services whose images must be rebuilt for a PR.
+
+    Returns ``frozenset({"all"})`` when the change is cross-cutting, maps to no
+    single service, or the path set is empty/malformed (conservative
+    escalation). Returns an empty set for a pure docs-only change.
+    """
+    path_list = list(paths)
+    if not path_list:
+        return frozenset({"all"})
+
+    affected: set[str] = set()
+    for path in path_list:
+        if not path.strip():
+            return frozenset({"all"})
+        if path in _CROSS_CUTTING_PATHS or path.startswith(_COMMON_PREFIX):
+            return frozenset({"all"})
+        matched = next(
+            (svc for svc in RUNTIME_SERVICES if path.startswith(f"{svc}/")), None
+        )
+        if matched is not None:
+            affected.add(matched)
+            continue
+        # Path is not under a known service dir. If it is runtime-relevant at
+        # all (i.e. not docs-only), escalate to a full rebuild.
+        if path not in DOCS_ONLY_FILES and not path.startswith(DOCS_ONLY_PREFIXES):
+            return frozenset({"all"})
+
+    return frozenset(affected)
+
+
 def main(argv: list[str]) -> int:
+    if "--affected-services" in argv:
+        args = [a for a in argv if a != "--affected-services"]
+        paths = args or sys.stdin.read().splitlines()
+        print(" ".join(sorted(affected_services(paths))))
+        return 0
+
     paths = argv or sys.stdin.read().splitlines()
     print(str(requires_full_runtime(paths)).lower())
     return 0

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -59,6 +59,49 @@ class CiChangeClassificationTests(unittest.TestCase):
         self.assertTrue(MODULE.requires_full_runtime([""]))
         self.assertTrue(MODULE.requires_full_runtime(["  "]))
 
+    def test_affected_services_maps_only_changed_runtime_services(self) -> None:
+        self.assertEqual(
+            MODULE.affected_services(["agent-svc/agent/app.py"]),
+            frozenset({"agent-svc"}),
+        )
+        self.assertEqual(
+            MODULE.affected_services(
+                ["scraper-svc/scraper/fetch.py", "parse-svc/parse_svc/app.py"]
+            ),
+            frozenset({"scraper-svc", "parse-svc"}),
+        )
+
+    def test_affected_services_escalates_cross_cutting_paths_to_all(self) -> None:
+        for path in ("docker-compose.yml", "common/models.py"):
+            with self.subTest(path=path):
+                self.assertEqual(MODULE.affected_services([path]), frozenset({"all"}))
+
+    def test_affected_services_escalates_unrecognized_runtime_paths_to_all(
+        self,
+    ) -> None:
+        for path in (
+            "notes.txt",
+            "requirements.txt",
+            "scripts/check-docs-surface.py",
+            ".github/workflows/docker.yml",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(MODULE.affected_services([path]), frozenset({"all"}))
+
+    def test_affected_services_escalates_empty_and_malformed_input_to_all(self) -> None:
+        self.assertEqual(MODULE.affected_services([]), frozenset({"all"}))
+        self.assertEqual(MODULE.affected_services([""]), frozenset({"all"}))
+        self.assertEqual(MODULE.affected_services(["  "]), frozenset({"all"}))
+
+    def test_affected_services_docs_only_paths_are_ignored(self) -> None:
+        self.assertEqual(MODULE.affected_services(["docs/guides/ci.md"]), frozenset())
+
+    def test_affected_services_ignores_docs_paths_in_mixed_set(self) -> None:
+        self.assertEqual(
+            MODULE.affected_services(["docs/guides/ci.md", "agent-svc/agent/app.py"]),
+            frozenset({"agent-svc"}),
+        )
+
     def test_cli_reads_stdin_and_prints_boolean(self) -> None:
         result = subprocess.run(
             [sys.executable, str(CLASSIFIER)],
@@ -189,6 +232,55 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
             'changed_paths=$(git diff --name-only "$base" "$head")',
             self.pull_request_classification,
         )
+
+    def test_changes_job_exposes_affected_services_output(self) -> None:
+        self.assertIn(
+            "affected_services: ${{ steps.classify.outputs.affected_services }}",
+            self.changes,
+        )
+        self.assertIn(
+            "--affected-services",
+            self.changes,
+        )
+        self.assertIn(
+            'echo "affected_services=$affected_services" >> "$GITHUB_OUTPUT"',
+            self.changes,
+        )
+
+    def test_pr_build_step_is_service_local_and_gated_on_affected_services(
+        self,
+    ) -> None:
+        self.assertIn(
+            "Build affected service images (service-local PR build)",
+            self.integration_tests,
+        )
+        self.assertIn(
+            "needs.changes.outputs.affected_services",
+            self.integration_tests,
+        )
+        self.assertIn(
+            "docker compose --profile indexing build $affected",
+            self.integration_tests,
+        )
+        self.assertIn(
+            "docker compose --profile indexing build",
+            self.integration_tests,
+        )
+        self.assertIn("github.event_name == 'pull_request'", self.integration_tests)
+
+    def test_push_lane_pulls_published_images_without_rebuilding(self) -> None:
+        self.assertIn("Pull freshly published service images", self.integration_tests)
+        self.assertIn("docker compose --profile indexing pull", self.integration_tests)
+        self.assertIn("github.event_name == 'push'", self.integration_tests)
+
+    def test_start_stack_step_no_longer_uses_build(self) -> None:
+        self.assertIn("docker compose --profile indexing up -d", self.integration_tests)
+        self.assertNotIn(
+            "docker compose --profile indexing up --build -d", self.integration_tests
+        )
+        # The only `up` is build-less: no event rebuilds the full stack on top of
+        # an already-provisioned image set.
+        self.assertNotIn("up --build", self.integration_tests)
 
     def test_integration_test_staging_copies_only_required_contract_inputs(
         self,

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -251,7 +251,7 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         self,
     ) -> None:
         self.assertIn(
-            "Build affected service images (service-local PR build)",
+            "Build service images (service-local PR build / tag-push full build)",
             self.integration_tests,
         )
         self.assertIn(
@@ -268,10 +268,37 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         )
         self.assertIn("github.event_name == 'pull_request'", self.integration_tests)
 
-    def test_push_lane_pulls_published_images_without_rebuilding(self) -> None:
+    def test_pr_lane_pulls_published_images_before_service_local_build(self) -> None:
+        # Reproducibility (#494): before the service-local PR build, the stack is
+        # refreshed from the latest published images so unchanged services match a
+        # known commit; GHCR login runs for pull_request events.
         self.assertIn("Pull freshly published service images", self.integration_tests)
         self.assertIn("docker compose --profile indexing pull", self.integration_tests)
-        self.assertIn("github.event_name == 'push'", self.integration_tests)
+        self.assertIn(
+            "github.event_name == 'push' && github.ref == 'refs/heads/main'",
+            self.integration_tests,
+        )
+        self.assertIn("github.event_name == 'pull_request'", self.integration_tests)
+
+    def test_main_push_pulls_published_images_without_rebuilding(self) -> None:
+        self.assertIn("Pull freshly published service images", self.integration_tests)
+        self.assertIn("docker compose --profile indexing pull", self.integration_tests)
+        self.assertIn(
+            "github.event_name == 'push' && github.ref == 'refs/heads/main'",
+            self.integration_tests,
+        )
+
+    def test_tag_push_builds_full_stack_from_tagged_source(self) -> None:
+        # P1 (#494 review): tag pushes (v*) must not pull stale :latest; they
+        # rebuild the full runtime stack from the tagged source.
+        self.assertIn(
+            "github.event_name == 'push' && github.ref != 'refs/heads/main'",
+            self.integration_tests,
+        )
+        self.assertIn(
+            "Building the full runtime stack.",
+            self.integration_tests,
+        )
 
     def test_start_stack_step_no_longer_uses_build(self) -> None:
         self.assertIn("docker compose --profile indexing up -d", self.integration_tests)

--- a/tests/service/test_resource_envelope_contract.py
+++ b/tests/service/test_resource_envelope_contract.py
@@ -10,7 +10,12 @@ ROOT = Path(__file__).resolve().parents[2]
 def test_integration_workflow_enables_indexing_profile():
     workflow_path = ROOT / ".github/workflows/docker.yml"
     workflow = workflow_path.read_text()
-    assert "docker compose --profile indexing up --build -d" in workflow
+    # The stack startup still activates the indexing profile (semantic-svc/qdrant),
+    # but no longer redundantly rebuilds the full stack on top of build-and-push
+    # (#494): images are provisioned separately (pulled on push, service-local
+    # build on PR) before an `up -d` with no `--build`.
+    assert "docker compose --profile indexing up -d" in workflow
+    assert "docker compose --profile indexing up --build -d" not in workflow
     assert "docker compose exec -T agent-svc env \\" in workflow
     assert "docker compose exec -T \\\\n            -e" not in workflow
 


### PR DESCRIPTION
Fixes #494 (efficiency): route PR image provisioning by runtime risk and eliminate duplicate Docker builds.

## Changes
- **`scripts/classify_ci_changes.py`**: adds `affected_services()` and a `--affected-services` CLI mode. It maps changed paths to the runtime service images that must be rebuilt; cross-cutting paths (`docker-compose.yml`, `common/`), unrecognized runtime paths, and empty/malformed input escalate to `all` (full rebuild). Pure docs-only changes produce an empty set.
- **`.github/workflows/docker.yml`**:
  - The `changes` job now also outputs `affected_services`.
  - `integration-tests` provisioning is decoupled from stack startup so each image is built at most once per event:
    - **push/main**: `build-and-push` already published every image; integration logs into GHCR and `docker compose --profile indexing pull` the freshly published tags (no rebuild).
    - **PR**: only the images for services whose paths changed are built (service-local), gated on `needs.changes.outputs.affected_services`; unknown/cross-cutting paths escalate to a full rebuild.
    - Start-stack is now a build-less `docker compose --profile indexing up -d` (the redundant `--build` is removed).
- **Required-check names unchanged**: `Code Quality Gate` and `Runtime Gate` keep their `name:` values and merge-gate semantics.
- **Contract tests**: extended `tests/service/test_ci_change_classification.py` for affected-service routing and the build-less/pull/service-local provisioning lanes; updated `tests/service/test_resource_envelope_contract.py` to assert the dedup behavior.

## Validation
- `uv run pytest tests/unit/ tests/service/` → 1518 passed
- `yaml.safe_load` on docker.yml → OK
- Classifier CLI spot-checks confirm `--affected-services` output and docs-only regression.

This PR itself classifies as full-runtime (touches workflow + classifier), so its own run exercises the service-local/full-rebuild PR lane on the self-hosted runner.