### PR TITLE
ci(docker): fix mcp-svc build-and-push context (#494)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,7 +92,7 @@ jobs:
             dockerfile: parse-svc/Dockerfile
             image: ghcr.io/groktopus/groktocrawl-parse
           - service: mcp-svc
-            context: .
+            context: mcp-svc
             dockerfile: mcp-svc/Dockerfile
             image: ghcr.io/groktopus/groktocrawl-mcp
       max-parallel: 2


### PR DESCRIPTION
Follow-up to #494. The first push-to-main run after #494 merged exposed a latent build-and-push bug (surfaced by the previous #546 context fix being incomplete).

## Problem
The `mcp-svc` build-and-push matrix entry used `context: .` with `dockerfile: mcp-svc/Dockerfile`. But `mcp-svc/Dockerfile` does `COPY groktocrawl_client.py .` / `COPY mcp_server.py .` etc. — files that live inside `mcp-svc/`, not at the repo-root build context. The push-to-main `build-and-push` job failed with `failed to calculate checksum ... "/session_store.py": not found`, which skipped `Integration Tests` and turned `Runtime Gate` red on main.

## Fix
Set `context: mcp-svc` for the matrix entry (the `file: mcp-svc/Dockerfile` path still resolves from the workspace). This mirrors how `docker-compose.yml` builds mcp-svc (`build: context: ./mcp-svc`), which the integration job already exercises successfully.

## Validation
- `yaml.safe_load` on docker.yml → OK
- `uv run pytest tests/service/test_ci_change_classification.py` → 38 passed
- The compose-based mcp-svc build (same context) already builds successfully in integration.
- The authoritative check is the push-to-main run after merge, which now builds all 7 images and runs integration with a green Runtime Gate.