### PR TITLE
docs: add contribution intake and Now/Next/Later roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 > **Before you file:** bugs and features are triaged best-effort with **no
 > response SLA**. See [Contribution intake](https://github.com/groktopus/groktocrawl/blob/main/CONTRIBUTING.md#contribution-intake-and-triage)
-> and the [roadmap](https://github.com/groktopus/groktocrawl/blob/main/ROADMAP.md).
+> and the [roadmap](https://github.com/groktopus/groktocrawl/blob/main/docs/roadmap.md).
 
 ## Bug Description
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+> **Before you file:** bugs and features are triaged best-effort with **no
+> response SLA**. See [Contribution intake](https://github.com/groktopus/groktocrawl/blob/main/CONTRIBUTING.md#contribution-intake-and-triage)
+> and the [roadmap](https://github.com/groktopus/groktocrawl/blob/main/ROADMAP.md).
+
 ## Bug Description
 
 A clear, concise description of the bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,11 @@ assignees: ''
 
 ---
 
+> **Before you file:** issues are triaged best-effort with **no response SLA**.
+> See [Contribution intake](https://github.com/groktopus/groktocrawl/blob/main/CONTRIBUTING.md#contribution-intake-and-triage)
+> and the [roadmap](https://github.com/groktopus/groktocrawl/blob/main/ROADMAP.md) —
+> especially **Now / Next** — to check whether your idea is already in flight.
+
 ## Problem
 
 What user need or pain point does this address? Describe the scenario where this matters.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ assignees: ''
 
 > **Before you file:** issues are triaged best-effort with **no response SLA**.
 > See [Contribution intake](https://github.com/groktopus/groktocrawl/blob/main/CONTRIBUTING.md#contribution-intake-and-triage)
-> and the [roadmap](https://github.com/groktopus/groktocrawl/blob/main/ROADMAP.md) —
+> and the [roadmap](https://github.com/groktopus/groktocrawl/blob/main/docs/roadmap.md) —
 > especially **Now / Next** — to check whether your idea is already in flight.
 
 ## Problem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@ matches what you want to do and use the route below.
 |---------------------|-------|
 | Report a bug | Open a [bug report](.github/ISSUE_TEMPLATE/bug_report.md) |
 | Propose a feature | Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.md) |
-| Signal implementation interest | Comment "I'd like to work on this" on an existing issue, or open a feature request stating what you intend to build and reference the [roadmap](ROADMAP.md) |
+| Signal implementation interest | Comment "I'd like to work on this" on an existing issue, or open a feature request stating what you intend to build and reference the [roadmap](docs/roadmap.md) |
 
 **Triage is best-effort, with no SLA.** A small maintainer team runs this
 project and responds as time allows. We do **not** promise a response or
 resolution time. Issues are scoped, labelled, and prioritized as the backlog
-allows; the [roadmap](ROADMAP.md) shows the current **Now / Next / Later**
+allows; the [roadmap](docs/roadmap.md) shows the current **Now / Next / Later**
 priorities and how they relate to the open backlog.
 
 What makes triage and prioritization fastest:
@@ -53,7 +53,7 @@ Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.md) with:
 
 ### Signaling Implementation Interest
 
-If an open issue or a [roadmap](ROADMAP.md) item matches something you want to
+If an open issue or a [roadmap](docs/roadmap.md) item matches something you want to
 build, say so on the issue thread before starting large work: "I'd like to work
 on this." For brand-new ideas, open a feature request and state your intent to
 implement. Coordination up front avoids two people building the same thing and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,39 @@ Thanks for your interest! GroktoCrawl is MIT-licensed and contributions of all k
 
 Be excellent to each other. This project is small but aims to be a welcoming space for contributors of all experience levels.
 
+## Contribution intake and triage
+
+Issue filing on this repository is **open** — anyone can create an issue
+directly, with no invitation or blank-issue gate. The issue templates exist to
+keep reports structured, not to restrict who can file. Pick the template that
+matches what you want to do and use the route below.
+
+| What you want to do | Route |
+|---------------------|-------|
+| Report a bug | Open a [bug report](.github/ISSUE_TEMPLATE/bug_report.md) |
+| Propose a feature | Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.md) |
+| Signal implementation interest | Comment "I'd like to work on this" on an existing issue, or open a feature request stating what you intend to build and reference the [roadmap](ROADMAP.md) |
+
+**Triage is best-effort, with no SLA.** A small maintainer team runs this
+project and responds as time allows. We do **not** promise a response or
+resolution time. Issues are scoped, labelled, and prioritized as the backlog
+allows; the [roadmap](ROADMAP.md) shows the current **Now / Next / Later**
+priorities and how they relate to the open backlog.
+
+What makes triage and prioritization fastest:
+
+- A concrete, reproducible bug — steps, `docker compose logs` output, and a
+  redacted `.env` (no real API keys)
+- A feature proposal framed as a user problem and use case, not just a desired
+  flag or endpoint
+- A clear statement of what you're willing to build, test, or investigate
+  yourself
+
 ## How to Contribute
 
 ### Reporting Bugs
 
-Open a GitHub issue with:
+Open a [bug report](.github/ISSUE_TEMPLATE/bug_report.md) with:
 - A clear description of the bug
 - Steps to reproduce
 - The output of `docker compose logs` for the affected service
@@ -18,10 +46,18 @@ Open a GitHub issue with:
 
 ### Suggesting Features
 
-Open a GitHub issue with:
+Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.md) with:
 - What you want to accomplish
 - Why it doesn't fit as a post-MVP improvement
 - A sketch of the API or behavior change (optional but helpful)
+
+### Signaling Implementation Interest
+
+If an open issue or a [roadmap](ROADMAP.md) item matches something you want to
+build, say so on the issue thread before starting large work: "I'd like to work
+on this." For brand-new ideas, open a feature request and state your intent to
+implement. Coordination up front avoids two people building the same thing and
+lets maintainers flag scope or design concerns early.
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ curl -N -X POST http://localhost:8080/v2/crawl \
 - [Deployment and configuration](docs/guides/deployment.md) — services, profiles, configuration, security, and operations.
 - [Feature guides](docs/guides/features.md) — scraping, crawl, search, research, sessions, browser, monitors, parse, portal, and MCP.
 - [Architecture](docs/architecture.md) — current service and data-flow design.
-- [Contributor guide](CONTRIBUTING.md) — local development, tests, API/CLI parity, and ADRs.
+- [Contributor guide](CONTRIBUTING.md) — contribution intake, local development, tests, API/CLI parity, and ADRs.
+- [Roadmap](ROADMAP.md) — Now / Next / Later priorities.
 - [Public surface inventory](docs/reference/public-surface.md) — validated route, CLI, compose, and configuration indexes.
 
 When the stack is running, FastAPI publishes the canonical request/response schema at [Swagger UI](http://localhost:8080/docs) and [OpenAPI JSON](http://localhost:8080/openapi.json). The Markdown guides explain behavior and workflows; OpenAPI is authoritative for wire schemas.
@@ -99,7 +100,7 @@ Set `API_KEY` for authentication, restrict network exposure, and review outbound
 
 ## Status
 
-Core Firecrawl-compatible workflows and GroktoCrawl extensions are actively developed. Review the [changelog](CHANGELOG.md), [ADRs](docs/adr/README.md), and [issues](https://github.com/groktopus/groktocrawl/issues) for change history and planned work.
+Core Firecrawl-compatible workflows and GroktoCrawl extensions are actively developed. Review the [roadmap](ROADMAP.md) for Now / Next / Later priorities, the [changelog](CHANGELOG.md), [ADRs](docs/adr/README.md), and [issues](https://github.com/groktopus/groktocrawl/issues) for change history and planned work. Bugs and feature ideas are filed through the [contribution intake](CONTRIBUTING.md#contribution-intake-and-triage) route.
 
 ## Development policy
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ curl -N -X POST http://localhost:8080/v2/crawl \
 - [Feature guides](docs/guides/features.md) — scraping, crawl, search, research, sessions, browser, monitors, parse, portal, and MCP.
 - [Architecture](docs/architecture.md) — current service and data-flow design.
 - [Contributor guide](CONTRIBUTING.md) — contribution intake, local development, tests, API/CLI parity, and ADRs.
-- [Roadmap](ROADMAP.md) — Now / Next / Later priorities.
+- [Roadmap](docs/roadmap.md) — Now / Next / Later priorities.
 - [Public surface inventory](docs/reference/public-surface.md) — validated route, CLI, compose, and configuration indexes.
 
 When the stack is running, FastAPI publishes the canonical request/response schema at [Swagger UI](http://localhost:8080/docs) and [OpenAPI JSON](http://localhost:8080/openapi.json). The Markdown guides explain behavior and workflows; OpenAPI is authoritative for wire schemas.
@@ -100,7 +100,7 @@ Set `API_KEY` for authentication, restrict network exposure, and review outbound
 
 ## Status
 
-Core Firecrawl-compatible workflows and GroktoCrawl extensions are actively developed. Review the [roadmap](ROADMAP.md) for Now / Next / Later priorities, the [changelog](CHANGELOG.md), [ADRs](docs/adr/README.md), and [issues](https://github.com/groktopus/groktocrawl/issues) for change history and planned work. Bugs and feature ideas are filed through the [contribution intake](CONTRIBUTING.md#contribution-intake-and-triage) route.
+Core Firecrawl-compatible workflows and GroktoCrawl extensions are actively developed. Review the [roadmap](docs/roadmap.md) for Now / Next / Later priorities, the [changelog](CHANGELOG.md), [ADRs](docs/adr/README.md), and [issues](https://github.com/groktopus/groktocrawl/issues) for change history and planned work. Bugs and feature ideas are filed through the [contribution intake](CONTRIBUTING.md#contribution-intake-and-triage) route.
 
 ## Development policy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,58 @@
+# GroktoCrawl Roadmap
+
+A lightweight, best-effort view of where GroktoCrawl is heading. It is **not a
+commitment** to ship any specific item by a date. Priorities shift as
+contributors engage, bugs surface, and the project's direction evolves. See
+[Contribution intake](CONTRIBUTING.md#contribution-intake-and-triage) if you
+want to influence what appears here.
+
+Buckets:
+
+- **Now** — actively being worked or the immediate next focus.
+- **Next** — high-signal, plausible near-term work that needs design or a
+  champion to move into *Now*.
+- **Later** — exploratory or dependent on earlier work; nothing here is planned.
+
+## Now
+
+- **SlopSearX search fallback resilience.** Make the default DuckDuckGo search
+  backend more robust so the zero-config search path degrades gracefully
+  instead of failing ([#413](https://github.com/groktopus/groktocrawl/issues/413)).
+- **Contributor skills directory.** Add `.agent/skills/` with reusable,
+  documented skills so contributors can pick up common tasks quickly
+  ([#394](https://github.com/groktopus/groktocrawl/issues/394)).
+- **Community process hygiene.** Keep the contribution intake, release/dependency
+  triage routine, and this roadmap accurate as the backlog changes.
+
+## Next
+
+- **Restart-safe async job execution.** Jobs currently run in-process and are
+  not resume-safe after a restart (see [ADR-0047](docs/adr/0047-defer-restart-safe-execution.md)).
+  Making execution durable needs an explicit design (ownership, leases,
+  retries, cancellation, artifact consistency, webhook idempotency) before any
+  queue technology is chosen.
+- **Semantic index operations.** Smarter retention and a migration path for
+  embedding models are on the table as design work
+  ([ADR-0027](docs/adr/0027-smarter-index-retention.md),
+  [ADR-0028](docs/adr/0028-embedding-model-migration-path.md)).
+- **Adopter-driven hardening.** Surface reliability gaps reported through the
+  intake route that are scoped and well-evidenced.
+
+## Later
+
+- **Multi-user / multi-tenant authentication.** Explicitly out of the MVP; may
+  become relevant if adoption grows beyond self-host single-operator use.
+- **Managed / hosted offering.** Deliberately out of scope today — GroktoCrawl
+  is self-hosted and MIT-licensed. If this ever changes, it would be separate
+  from this repository.
+- **Additional site adapters.** Grows organically with community contributions
+  through the intake route.
+
+## How items move between buckets
+
+The maintainers review the open backlog and this roadmap periodically and
+re-balance the buckets as contributors engage and new evidence surfaces. A
+well-scoped issue with a reproducible bug report or a concrete feature proposal
+— raised through the [intake route](CONTRIBUTING.md#contribution-intake-and-triage) —
+is the most reliable way to get a candidate into **Now** or **Next**. Triage is
+best-effort; there is **no guaranteed response or resolution SLA**.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,8 +3,8 @@
 A lightweight, best-effort view of where GroktoCrawl is heading. It is **not a
 commitment** to ship any specific item by a date. Priorities shift as
 contributors engage, bugs surface, and the project's direction evolves. See
-[Contribution intake](CONTRIBUTING.md#contribution-intake-and-triage) if you
-want to influence what appears here.
+[Contribution intake](../CONTRIBUTING.md#contribution-intake-and-triage) if
+you want to influence what appears here.
 
 Buckets:
 
@@ -27,14 +27,14 @@ Buckets:
 ## Next
 
 - **Restart-safe async job execution.** Jobs currently run in-process and are
-  not resume-safe after a restart (see [ADR-0047](docs/adr/0047-defer-restart-safe-execution.md)).
+  not resume-safe after a restart (see [ADR-0047](adr/0047-defer-restart-safe-execution.md)).
   Making execution durable needs an explicit design (ownership, leases,
   retries, cancellation, artifact consistency, webhook idempotency) before any
   queue technology is chosen.
 - **Semantic index operations.** Smarter retention and a migration path for
   embedding models are on the table as design work
-  ([ADR-0027](docs/adr/0027-smarter-index-retention.md),
-  [ADR-0028](docs/adr/0028-embedding-model-migration-path.md)).
+  ([ADR-0027](adr/0027-smarter-index-retention.md),
+  [ADR-0028](adr/0028-embedding-model-migration-path.md)).
 - **Adopter-driven hardening.** Surface reliability gaps reported through the
   intake route that are scoped and well-evidenced.
 
@@ -53,6 +53,6 @@ Buckets:
 The maintainers review the open backlog and this roadmap periodically and
 re-balance the buckets as contributors engage and new evidence surfaces. A
 well-scoped issue with a reproducible bug report or a concrete feature proposal
-— raised through the [intake route](CONTRIBUTING.md#contribution-intake-and-triage) —
+— raised through the [intake route](../CONTRIBUTING.md#contribution-intake-and-triage) —
 is the most reliable way to get a candidate into **Now** or **Next**. Triage is
 best-effort; there is **no guaranteed response or resolution SLA**.


### PR DESCRIPTION
## Summary
Fixes #474. Publish a public contribution-intake section and a lightweight Now/Next/Later roadmap, and link both from README and the issue templates.

## Changes
- **CONTRIBUTING.md** — new **Contribution intake and triage** section documenting the open routes to report bugs, propose features, and signal implementation interest, with best-effort triage and **no response SLA**. Added a "Signaling Implementation Interest" subsection.
- **ROADMAP.md** (new) — Now / Next / Later buckets reflecting live priorities; **Now** lists genuinely open, active items (#413 SlopSearX search fallback resilience, #394 contributor skills directory) and does not reference work resolved by this mission as pending.
- **README.md** — links the roadmap in the Documentation section and the Status section, and points bugs/ideas at the intake route.
- **.github/ISSUE_TEMPLATE/bug_report.md** and **feature_request.md** — "Before you file" notes linking the intake section and roadmap.

## Premise verification
The issue's "restricted issue route" premise has drifted: there is **no `.github/ISSUE_TEMPLATE/config.yml`**, so issue creation is the **open** route. No `blank_issues_enabled: false` restriction was introduced; docs describe issue filing as public and open.

## Validation
- `python3 scripts/check-docs-surface.py` exits 0.
- Docs-only change -> Runtime Gate reports a successful no-op (integration skipped).

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
