### PR TITLE
feat(ashby): add official Ashby API tiers to the AshbyHQ adapter

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -115,6 +115,13 @@
 # Sign up at https://nvd.nist.gov/developers/request-an-api-key
 # ADAPTER_NVD_API_KEY=your-free-nvd-api-key
 
+# AshbyHQ adapter — optional authenticated RPC tier (jobPosting.list,
+# requires the jobsRead permission). Without this the adapter still works
+# via the keyless public posting-api and the SSR fallback; with it, individual
+# posting URLs can include draft/unlisted jobs.
+# ADAPTER_ASHBY_API_KEY=your-ashby-jobsread-api-key
+# ASHBY_API_KEY=  # legacy alias, checked only when ADAPTER_ASHBY_API_KEY is unset
+
 # ── Security Adapters ────────────────────────────────
 # Optional API keys for security-focused threat intelligence adapters.
 # Each adapter falls back to HTML scraping when the API key is missing.

--- a/scraper-svc/scraper/adapters/ashbyhq.py
+++ b/scraper-svc/scraper/adapters/ashbyhq.py
@@ -686,10 +686,15 @@ class AshbyHQAdapter(SiteAdapter):
             # uuid not among published jobs → fall through to SSR
 
         # Tier 2: authenticated jobPosting.list RPC (gated by ASHBY_API_KEY)
-        api_key = ctx.config.get("ASHBY_API_KEY") or ctx.config.get(
-            "ADAPTER_ASHBY_API_KEY"
+        #
+        # Only engaged for individual job URLs: jobPosting.list is scoped to
+        # the company that owns the key, so its results cannot be trusted to
+        # represent an arbitrary listing board. Individual postings are safe
+        # because posting UUIDs are globally unique.
+        api_key = ctx.config.get("ADAPTER_ASHBY_API_KEY") or ctx.config.get(
+            "ASHBY_API_KEY"
         )
-        if api_key:
+        if api_key and uuid:
             logger.info("AshbyHQ adapter: trying authenticated RPC for %s", url)
             rpc_results = await ctx.with_timeout(_fetch_rpc_jobs(api_key), timeout=15)
             if rpc_results:

--- a/scraper-svc/scraper/adapters/ashbyhq.py
+++ b/scraper-svc/scraper/adapters/ashbyhq.py
@@ -1,13 +1,16 @@
 """
 AshbyHQ ATS adapter — extracts job postings from AshbyHQ-powered career pages.
 
-AshbyHQ embeds all job data as ``window.__appData`` JSON in the server-side
-rendered HTML. No API calls are needed.
+Fallback chain (top → bottom):
+  1. Public posting-api ``/posting-api/job-board/{board}`` (keyless, at the TOP)
+  2. Authenticated ``jobPosting.list`` RPC tier (gated behind ``ASHBY_API_KEY``)
+  3. ``window.__appData`` JSON extraction from SSR HTML
+  4. Page scrape via readability-lxml
+  5. ``AdapterError`` — falls through to the generic scrape pipeline
 
-Fallback chain:
-  1. ``window.__appData`` JSON extraction from SSR HTML
-  2. Page scrape via readability-lxml
-  3. ``AdapterError`` — falls through to the generic scrape pipeline
+The public posting-api returns the full set of published postings as structured
+JSON (including compensation when requested), so it is preferred whenever the
+board name can be derived from the URL.
 """
 
 from __future__ import annotations
@@ -38,6 +41,14 @@ _ASHBYHQ_URL_PATTERNS = [
     ),
 ]
 
+# Direct match for the public posting-api board feed.
+_ASHBY_API_PATTERNS = [
+    re.compile(
+        r"^https?://api\.ashbyhq\.com/"
+        r"posting-api/job-board/(?P<board>[^/]+)"
+    ),
+]
+
 
 def _extract_company(url: str) -> str | None:
     """Extract the company slug from an AshbyHQ careers URL."""
@@ -46,6 +57,20 @@ def _extract_company(url: str) -> str | None:
         if m:
             return m.group("company")
     return None
+
+
+def _extract_board(url: str) -> str | None:
+    """Derive the Ashby board name from a URL.
+
+    Per Ashby docs the board name is the final URL path segment of the jobs
+    page (``jobs.ashbyhq.com/linear`` → ``linear``) and it also appears in the
+    direct posting-api URL (``/posting-api/job-board/{board}``).
+    """
+    for pattern in _ASHBY_API_PATTERNS:
+        m = pattern.search(url)
+        if m:
+            return m.group("board")
+    return _extract_company(url)
 
 
 def _extract_uuid(url: str) -> str | None:
@@ -82,9 +107,7 @@ async def _fetch_html(url: str) -> str | None:
             )
             if resp.status_code == 200:
                 return resp.text
-            logger.debug(
-                "AshbyHQ fetch returned %d for %s", resp.status_code, url
-            )
+            logger.debug("AshbyHQ fetch returned %d for %s", resp.status_code, url)
             return None
     except httpx.TimeoutException:
         logger.debug("AshbyHQ fetch timed out for %s", url)
@@ -127,6 +150,130 @@ async def _fetch_and_parse_appdata(url: str) -> dict | None:
     if not html:
         return None
     return _extract_appdata_json(html)
+
+
+# ── Ashby API tiers ──────────────────────────────────────────────
+
+_PUBLIC_API_BASE = "https://api.ashbyhq.com/posting-api/job-board"
+_RPC_URL = "https://api.ashbyhq.com/jobPosting.list"
+
+_USER_AGENT = "Mozilla/5.0 (compatible; GroktoCrawl/0.7.0; AshbyHQ adapter)"
+
+
+async def _fetch_board(board: str, include_compensation: bool = True) -> dict | None:
+    """Fetch the public posting-api board feed (keyless).
+
+    Returns the parsed ``{jobs, apiVersion}`` dict, or ``None`` on any
+    failure (including an unknown board → 404).
+    """
+    url = f"{_PUBLIC_API_BASE}/{board}"
+    params = {"includeCompensation": "true" if include_compensation else "false"}
+    try:
+        async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+            resp = await client.get(
+                url,
+                params=params,
+                headers={"User-Agent": _USER_AGENT},
+            )
+            if resp.status_code == 200:
+                return resp.json()
+            logger.debug(
+                "AshbyHQ posting-api returned %d for board %s",
+                resp.status_code,
+                board,
+            )
+            return None
+    except httpx.TimeoutException:
+        logger.debug("AshbyHQ posting-api timed out for board %s", board)
+        return None
+    except httpx.RequestError as exc:
+        logger.debug("AshbyHQ posting-api failed for board %s: %s", board, exc)
+        return None
+    except ValueError:
+        logger.debug("AshbyHQ posting-api returned invalid JSON for %s", board)
+        return None
+
+
+async def _fetch_rpc_jobs(api_key: str) -> list | None:
+    """Call the authenticated ``jobPosting.list`` RPC tier.
+
+    Uses HTTP Basic auth with the API key as the username and a blank
+    password. Requires the ``jobsRead`` permission. Returns the list of
+    results, or ``None`` on failure.
+    """
+    body = {"listedOnly": True}
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(_RPC_URL, json=body, auth=(api_key, ""))
+            if resp.status_code == 200:
+                return _rpc_results(resp.json())
+            logger.debug("AshbyHQ jobPosting.list returned %d", resp.status_code)
+            return None
+    except httpx.TimeoutException:
+        logger.debug("AshbyHQ jobPosting.list timed out")
+        return None
+    except httpx.RequestError as exc:
+        logger.debug("AshbyHQ jobPosting.list failed: %s", exc)
+        return None
+    except ValueError:
+        logger.debug("AshbyHQ jobPosting.list returned invalid JSON")
+        return None
+
+
+def _rpc_results(data: dict) -> list | None:
+    """Extract the ``results`` list from a ``jobPosting.list`` response.
+
+    Defensively handles the response shape variations of the RPC surface.
+    """
+    if not isinstance(data, dict):
+        return None
+    if isinstance(data.get("results"), list):
+        return data["results"]
+    nested = data.get("data")
+    if isinstance(nested, dict):
+        if isinstance(nested.get("results"), list):
+            return nested["results"]
+        listing = nested.get("jobPosting", {}).get("list", {})
+        if isinstance(listing.get("results"), list):
+            return listing["results"]
+    return None
+
+
+def _rpc_result_to_job(result: dict) -> dict:
+    """Normalize a ``jobPosting.list`` result into the posting-api job shape."""
+    if not isinstance(result, dict):
+        return {}
+    job_url = result.get("externalLink") or result.get("applyLink") or ""
+    return {
+        "id": result.get("id", ""),
+        "title": result.get("title", ""),
+        "department": result.get("departmentName", ""),
+        "team": result.get("teamName", ""),
+        "location": result.get("locationName", ""),
+        "secondaryLocations": [],
+        "employmentType": result.get("employmentType", ""),
+        "workplaceType": result.get("workplaceType", ""),
+        "isRemote": result.get("isRemote", False),
+        "isListed": result.get("isListed", False),
+        "publishedAt": result.get("publishedDate", ""),
+        "jobUrl": job_url,
+        "applyUrl": result.get("applyLink", "") or job_url,
+        "descriptionHtml": result.get("descriptionHtml", ""),
+        "descriptionPlain": result.get("descriptionPlain", ""),
+        "compensation": {
+            "compensationTierSummary": result.get("compensationTierSummary"),
+            "compensationTiers": result.get("compensationTiers", []),
+            "summaryComponents": [],
+        },
+    }
+
+
+def _find_job(jobs: list, uuid: str) -> dict | None:
+    """Find a job by posting UUID within a ``jobs[]`` list."""
+    for job in jobs:
+        if job.get("id") == uuid:
+            return job
+    return None
 
 
 # ── HTML → markdown conversion ───────────────────────────────────
@@ -246,9 +393,7 @@ def _format_job(data: dict, company: str, uuid: str) -> tuple[str, dict]:
         "jobRequisitionId": posting.get("jobRequisitionId", ""),
         "isRemote": posting.get("isRemote", False),
         "compensationTierSummary": posting.get("compensationTierSummary", ""),
-        "shouldDisplayCompensation": posting.get(
-            "shouldDisplayCompensation", False
-        ),
+        "shouldDisplayCompensation": posting.get("shouldDisplayCompensation", False),
         "source": "ashbyhq",
         "url": url,
     }
@@ -307,6 +452,179 @@ def _format_job(data: dict, company: str, uuid: str) -> tuple[str, dict]:
     return markdown, metadata
 
 
+# ── API-tier formatting ──────────────────────────────────────────
+
+
+def _location_string(job: dict) -> str:
+    """Combine ``location`` and ``secondaryLocations`` into one string."""
+    primary = job.get("location")
+    if isinstance(primary, dict):
+        primary = primary.get("locationName") or primary.get("name") or ""
+    secondary = job.get("secondaryLocations") or []
+    locs: list[str] = []
+    if primary:
+        locs.append(str(primary))
+    for loc in secondary:
+        if isinstance(loc, dict):
+            loc = loc.get("locationName") or loc.get("name") or ""
+        if loc:
+            locs.append(str(loc))
+    return ", ".join(locs)
+
+
+def _format_compensation(compensation) -> str:
+    """Render a compensation dict into a human-readable string.
+
+    Handles ``compensationTierSummary``, ``compensationTiers[]`` and
+    ``summaryComponents[]``. Returns ``""`` when nothing is disclosed.
+    """
+    if not isinstance(compensation, dict):
+        return ""
+    parts: list[str] = []
+    tier_summary = compensation.get("compensationTierSummary")
+    if tier_summary:
+        parts.append(str(tier_summary))
+    for tier in compensation.get("compensationTiers") or []:
+        if not isinstance(tier, dict):
+            continue
+        label = tier.get("title") or tier.get("name") or ""
+        summary = tier.get("summary") or tier.get("compensationTierSummary") or ""
+        if label and summary:
+            parts.append(f"{label}: {summary}")
+        elif label:
+            parts.append(label)
+        elif summary:
+            parts.append(summary)
+    for component in compensation.get("summaryComponents") or []:
+        if not isinstance(component, dict):
+            continue
+        for key in ("summary", "summaryText", "displayValue", "value"):
+            val = component.get(key)
+            if val:
+                parts.append(str(val))
+                break
+    seen: list[str] = []
+    for part in parts:
+        if part not in seen:
+            seen.append(part)
+    return "; ".join(seen)
+
+
+def _format_api_listing(jobs: list, board: str) -> tuple[str, dict]:
+    """Convert the public posting-api ``jobs[]`` to a markdown table."""
+    parts: list[str] = []
+    parts.append(f"# {board} — Job Openings")
+    parts.append("")
+
+    if not jobs:
+        parts.append("*No job postings available at this time.*")
+        return "\n".join(parts), {
+            "source": "ashbyhq-api",
+            "board": board,
+            "total_openings": 0,
+        }
+
+    headers = [
+        "Title",
+        "Department",
+        "Team",
+        "Location",
+        "Workplace Type",
+        "Employment Type",
+        "Compensation",
+    ]
+    parts.append("| " + " | ".join(headers) + " |")
+    parts.append("| " + " | ".join(["---"] * len(headers)) + " |")
+
+    for job in jobs:
+        row = [
+            job.get("title", ""),
+            job.get("department", "") or "",
+            job.get("team", "") or "",
+            _location_string(job),
+            job.get("workplaceType", "") or "",
+            job.get("employmentType", "") or "",
+            _format_compensation(job.get("compensation")),
+        ]
+        parts.append("| " + " | ".join(row) + " |")
+
+    metadata: dict = {
+        "source": "ashbyhq-api",
+        "board": board,
+        "total_openings": len(jobs),
+    }
+    return "\n".join(parts), metadata
+
+
+def _format_api_job(job: dict, board: str, uuid: str) -> tuple[str, dict]:
+    """Convert a single posting-api job into markdown + metadata."""
+    title = job.get("title", "")
+    url = job.get("jobUrl") or f"https://jobs.ashbyhq.com/{board}/{uuid}"
+    location = _location_string(job)
+    compensation = _format_compensation(job.get("compensation"))
+
+    metadata: dict = {
+        "id": job.get("id", uuid),
+        "title": title,
+        "department": job.get("department", ""),
+        "team": job.get("team", ""),
+        "location": location,
+        "workplaceType": job.get("workplaceType", ""),
+        "employmentType": job.get("employmentType", ""),
+        "isRemote": job.get("isRemote", False),
+        "isListed": job.get("isListed", False),
+        "publishedAt": (job.get("publishedAt") or "")[:10],
+        "source": "ashbyhq-api",
+        "url": url,
+    }
+    if compensation:
+        metadata["compensation"] = compensation
+
+    parts: list[str] = []
+    parts.append(f"# {title}")
+    parts.append("")
+
+    detail_items: list[tuple[str, str]] = [
+        ("Department", job.get("department", "")),
+        ("Team", job.get("team", "")),
+        ("Location", location),
+        ("Workplace Type", job.get("workplaceType", "")),
+        ("Employment Type", job.get("employmentType", "")),
+        ("Remote", "Yes" if job.get("isRemote") else "No"),
+        ("Published", (job.get("publishedAt") or "")[:10]),
+    ]
+    if compensation:
+        detail_items.append(("Compensation", compensation))
+
+    parts.append("| Field | Value |")
+    parts.append("|-------|-------|")
+    for label, val in detail_items:
+        if val:
+            parts.append(f"| **{label}** | {val} |")
+    parts.append("")
+
+    description_html = job.get("descriptionHtml", "")
+    if description_html:
+        desc_md = _html_to_markdown(description_html)
+        if desc_md:
+            parts.append("## Description")
+            parts.append("")
+            parts.append(desc_md)
+        else:
+            parts.append("*No description available*")
+    elif job.get("descriptionPlain"):
+        parts.append("## Description")
+        parts.append("")
+        parts.append(job["descriptionPlain"])
+    else:
+        parts.append("*No description available*")
+
+    parts.append("")
+    parts.append(f"*Source: [AshbyHQ]({url})*")
+
+    return "\n".join(parts).strip(), metadata
+
+
 # ── Adapter class ────────────────────────────────────────────────
 
 
@@ -316,26 +634,73 @@ class AshbyHQAdapter(SiteAdapter):
 
     name = "ashbyhq"
 
-    patterns = _ASHBYHQ_URL_PATTERNS
+    patterns = _ASHBYHQ_URL_PATTERNS + _ASHBY_API_PATTERNS
 
     priority = 200
 
     async def scrape(self, url: str, ctx: AdapterContext) -> AdapterResult:
-        company = _extract_company(url)
-        if not company:
-            raise AdapterError(
-                f"Could not extract company from AshbyHQ URL: {url}"
-            )
-
+        board = _extract_board(url)
+        if not board:
+            raise AdapterError(f"Could not extract board from AshbyHQ URL: {url}")
+        company = _extract_company(url) or board
         uuid = _extract_uuid(url)
 
-        # Tier 1: window.__appData JSON extraction from SSR HTML
-        logger.info(
-            "AshbyHQ adapter: trying __appData extraction for %s", url
+        def _result_from_jobs(
+            jobs: list, board: str, uuid: str | None
+        ) -> AdapterResult | None:
+            """Build a result from a ``jobs[]`` list, or ``None`` if unmatched."""
+            if uuid:
+                job = _find_job(jobs, uuid)
+                if not job:
+                    return None
+                markdown, metadata = _format_api_job(job, board, uuid)
+                logger.info(
+                    "AshbyHQ adapter: API job %s (%d chars)",
+                    uuid,
+                    len(markdown),
+                )
+                return AdapterResult(
+                    success=True,
+                    markdown=markdown,
+                    metadata=metadata,
+                    source="ashbyhq-api",
+                    url=url,
+                )
+            markdown, metadata = _format_api_listing(jobs, board)
+            logger.info("AshbyHQ adapter: API listing with %d jobs", len(jobs))
+            return AdapterResult(
+                success=True,
+                markdown=markdown,
+                metadata=metadata,
+                source="ashbyhq-api",
+                url=url,
+            )
+
+        # Tier 1: public posting-api (keyless), at the TOP of the chain
+        logger.info("AshbyHQ adapter: trying public posting-api for %s", url)
+        board_data = await ctx.with_timeout(_fetch_board(board), timeout=15)
+        if board_data is not None and isinstance(board_data.get("jobs"), list):
+            result = _result_from_jobs(board_data["jobs"], board, uuid)
+            if result:
+                return result
+            # uuid not among published jobs → fall through to SSR
+
+        # Tier 2: authenticated jobPosting.list RPC (gated by ASHBY_API_KEY)
+        api_key = ctx.config.get("ASHBY_API_KEY") or ctx.config.get(
+            "ADAPTER_ASHBY_API_KEY"
         )
-        data = await ctx.with_timeout(
-            _fetch_and_parse_appdata(url), timeout=15
-        )
+        if api_key:
+            logger.info("AshbyHQ adapter: trying authenticated RPC for %s", url)
+            rpc_results = await ctx.with_timeout(_fetch_rpc_jobs(api_key), timeout=15)
+            if rpc_results:
+                jobs = [_rpc_result_to_job(r) for r in rpc_results]
+                result = _result_from_jobs(jobs, board, uuid)
+                if result:
+                    return result
+
+        # Tier 3: window.__appData JSON extraction from SSR HTML
+        logger.info("AshbyHQ adapter: trying __appData extraction for %s", url)
+        data = await ctx.with_timeout(_fetch_and_parse_appdata(url), timeout=15)
 
         if data:
             if uuid:
@@ -343,8 +708,7 @@ class AshbyHQAdapter(SiteAdapter):
                 posting = data.get("posting")
                 if not posting:
                     raise AdapterError(
-                        "No posting data in AshbyHQ response "
-                        f"for {company}/{uuid}"
+                        f"No posting data in AshbyHQ response for {company}/{uuid}"
                     )
                 markdown, metadata = _format_job(data, company, uuid)
                 logger.info(
@@ -361,9 +725,7 @@ class AshbyHQAdapter(SiteAdapter):
                 )
 
             # Listing page
-            postings = (
-                data.get("jobBoard", {}).get("jobPostings", [])
-            )
+            postings = data.get("jobBoard", {}).get("jobPostings", [])
             if not postings:
                 raise AdapterError(
                     f"No job postings found for AshbyHQ board: {company}"
@@ -381,19 +743,15 @@ class AshbyHQAdapter(SiteAdapter):
                 url=url,
             )
 
-        # Tier 2: readability page scrape
-        logger.info(
-            "AshbyHQ adapter: trying readability fallback for %s", url
-        )
-        result = await scrape_page(url)
-        if result:
+        # Tier 4: readability page scrape
+        logger.info("AshbyHQ adapter: trying readability fallback for %s", url)
+        readable = await scrape_page(url)
+        if readable:
             return AdapterResult(
                 success=True,
-                markdown=result,
+                markdown=readable,
                 metadata={"source": "ashbyhq-readability"},
                 url=url,
             )
 
-        raise AdapterError(
-            f"Could not extract content from AshbyHQ URL: {url}"
-        )
+        raise AdapterError(f"Could not extract content from AshbyHQ URL: {url}")

--- a/tests/unit/test_ashbyhq.py
+++ b/tests/unit/test_ashbyhq.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
 import scraper.adapters.ashbyhq as mod
 import scraper.adapters.base as base_mod
 from scraper.adapters.ashbyhq import (
@@ -28,7 +29,7 @@ from scraper.adapters.ashbyhq import (
     _format_compensation,
     _location_string,
 )
-from scraper.adapters.base import AdapterContext, AdapterRegistry
+from scraper.adapters.base import AdapterContext, AdapterError, AdapterRegistry
 
 # ── Sample data (inline, no HTTP) ────────────────────────────────
 
@@ -312,11 +313,40 @@ async def test_rpc_engages_with_api_key(monkeypatch):
     monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
     monkeypatch.setattr(mod, "_fetch_rpc_jobs", fake_rpc)
     ctx = AdapterContext(config={"ASHBY_API_KEY": "test-key"})
-    result = await AshbyHQAdapter().scrape("https://jobs.ashbyhq.com/acme", ctx)
+    url = f"https://jobs.ashbyhq.com/acme/{JOB_1_UUID}"
+    result = await AshbyHQAdapter().scrape(url, ctx)
     assert result.success is True
     assert result.source == "ashbyhq-api"
     assert calls == ["test-key"]
     assert "Software Engineer" in result.markdown
+
+
+async def test_rpc_not_used_for_listing_with_key(monkeypatch):
+    # jobPosting.list is scoped to the key owner's company, so it must never
+    # be used to render an arbitrary listing board — even when a key is set.
+    calls: list[str] = []
+
+    async def fake_fetch_board(board, include_compensation=True):
+        return None  # public tier unavailable
+
+    async def fake_rpc(api_key):
+        calls.append(api_key)
+        return SAMPLE_RPC_RESULTS
+
+    async def fake_appdata(url):
+        return None
+
+    async def fake_scrape_page(url, timeout=15.0):
+        return None
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    monkeypatch.setattr(mod, "_fetch_and_parse_appdata", fake_appdata)
+    monkeypatch.setattr(mod, "scrape_page", fake_scrape_page)
+    monkeypatch.setattr(mod, "_fetch_rpc_jobs", fake_rpc)
+    ctx = AdapterContext(config={"ADAPTER_ASHBY_API_KEY": "test-key"})
+    with pytest.raises(AdapterError):
+        await AshbyHQAdapter().scrape("https://jobs.ashbyhq.com/other", ctx)
+    assert calls == []  # RPC transport never invoked for a listing URL
 
 
 # ── Registry registration + dispatch (VAL-ASHBY-012) ─────────────

--- a/tests/unit/test_ashbyhq.py
+++ b/tests/unit/test_ashbyhq.py
@@ -1,0 +1,352 @@
+"""Unit tests for the AshbyHQ adapter's API tiers.
+
+Covers:
+- URL pattern matching (jobs.ashbyhq.com and api.ashbyhq.com posting-api)
+- Board-name derivation from the final URL path segment
+- Format helpers (listing table, single job detail, compensation, location)
+- Listing-vs-individual-job dispatch
+- SSR fallback when the API tier fails (incl. unknown board → 404)
+- Authenticated RPC tier gating (skipped without ASHBY_API_KEY, engaged with it)
+- Registry registration + dispatch for jobs.ashbyhq.com URLs
+
+No live HTTP is used; the fetch helpers are monkeypatched with inline samples.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import scraper.adapters.ashbyhq as mod
+import scraper.adapters.base as base_mod
+from scraper.adapters.ashbyhq import (
+    _ASHBYHQ_URL_PATTERNS,
+    AshbyHQAdapter,
+    _extract_board,
+    _extract_uuid,
+    _format_api_job,
+    _format_api_listing,
+    _format_compensation,
+    _location_string,
+)
+from scraper.adapters.base import AdapterContext, AdapterRegistry
+
+# ── Sample data (inline, no HTTP) ────────────────────────────────
+
+JOB_1_UUID = "11111111-1111-1111-1111-111111111111"
+
+SAMPLE_JOBS = [
+    {
+        "id": JOB_1_UUID,
+        "title": "Software Engineer",
+        "department": "Product",
+        "team": "Engineering",
+        "employmentType": "FullTime",
+        "location": "North America",
+        "secondaryLocations": ["Remote"],
+        "isRemote": True,
+        "isListed": True,
+        "publishedAt": "2024-01-15T10:00:00.000+00:00",
+        "jobUrl": f"https://jobs.ashbyhq.com/acme/{JOB_1_UUID}",
+        "applyUrl": f"https://jobs.ashbyhq.com/acme/{JOB_1_UUID}/application",
+        "descriptionHtml": "<p>Build great software.</p>",
+        "descriptionPlain": "Build great software.",
+        "compensation": {
+            "compensationTierSummary": "USD $150,000 - $200,000",
+            "compensationTiers": [{"title": "Engineering", "summary": "$150k-$200k"}],
+            "summaryComponents": [],
+        },
+    },
+    {
+        "id": "22222222-2222-2222-2222-222222222222",
+        "title": "Product Designer",
+        "department": "Design",
+        "team": "Design",
+        "employmentType": "FullTime",
+        "location": "Europe",
+        "secondaryLocations": [],
+        "isRemote": False,
+        "isListed": True,
+        "publishedAt": "2024-02-01T09:00:00.000+00:00",
+        "jobUrl": "https://jobs.ashbyhq.com/acme/22222222-2222-2222-2222-222222222222",
+        "descriptionHtml": "<p>Design great products.</p>",
+        "compensation": {},
+    },
+]
+
+SAMPLE_RPC_RESULTS = [
+    {
+        "id": JOB_1_UUID,
+        "title": "Software Engineer",
+        "departmentName": "Product",
+        "teamName": "Engineering",
+        "locationName": "North America",
+        "employmentType": "FullTime",
+        "isRemote": True,
+        "isListed": True,
+        "publishedDate": "2024-01-15T10:00:00.000+00:00",
+        "compensationTierSummary": "USD $150,000 - $200,000",
+    },
+]
+
+SSR_JOB_DATA = {
+    "posting": {
+        "id": JOB_1_UUID,
+        "title": "Software Engineer",
+        "departmentName": "Product",
+        "locationName": "North America",
+        "descriptionHtml": "<p>SSR description for the job.</p>",
+    }
+}
+
+SSR_LISTING_DATA = {
+    "jobBoard": {
+        "jobPostings": [
+            {
+                "title": "SSR Job A",
+                "departmentName": "Product",
+                "locationName": "United States",
+                "publishedDate": "2024-01-01T00:00:00",
+            }
+        ]
+    }
+}
+
+
+# ── URL matching ─────────────────────────────────────────────────
+
+
+def test_matches_jobs_listing_url():
+    url = "https://jobs.ashbyhq.com/linear"
+    assert any(p.search(url) for p in _ASHBYHQ_URL_PATTERNS)
+
+
+def test_matches_jobs_individual_url():
+    url = f"https://jobs.ashbyhq.com/linear/{JOB_1_UUID}"
+    assert any(p.search(url) for p in _ASHBYHQ_URL_PATTERNS)
+
+
+def test_matches_posting_api_url():
+    url = "https://api.ashbyhq.com/posting-api/job-board/linear"
+    assert any(p.search(url) for p in AshbyHQAdapter.patterns)
+
+
+def test_does_not_match_non_ashby():
+    url = "https://example.com/careers"
+    assert not any(p.search(url) for p in AshbyHQAdapter.patterns)
+
+
+# ── Board derivation ─────────────────────────────────────────────
+
+
+def test_board_from_jobs_slug():
+    assert _extract_board("https://jobs.ashbyhq.com/linear") == "linear"
+
+
+def test_board_from_jobs_slug_with_uuid():
+    url = f"https://jobs.ashbyhq.com/linear/{JOB_1_UUID}"
+    assert _extract_board(url) == "linear"
+
+
+def test_board_from_posting_api_url():
+    url = "https://api.ashbyhq.com/posting-api/job-board/linear"
+    assert _extract_board(url) == "linear"
+
+
+def test_board_none_for_unrelated():
+    assert _extract_board("https://example.com/careers") is None
+
+
+def test_uuid_extraction():
+    url = f"https://jobs.ashbyhq.com/linear/{JOB_1_UUID}"
+    assert _extract_uuid(url) == JOB_1_UUID
+
+
+def test_uuid_none_for_listing():
+    assert _extract_uuid("https://jobs.ashbyhq.com/linear") is None
+
+
+# ── Format helpers ───────────────────────────────────────────────
+
+
+def test_listing_table_contains_title_location_department():
+    markdown, metadata = _format_api_listing(SAMPLE_JOBS, "acme")
+    assert "# acme — Job Openings" in markdown
+    assert "Software Engineer" in markdown
+    assert "North America, Remote" in markdown
+    assert "Product" in markdown
+    assert metadata["total_openings"] == 2
+    assert metadata["source"] == "ashbyhq-api"
+
+
+def test_individual_job_has_description_section():
+    markdown, metadata = _format_api_job(SAMPLE_JOBS[0], "acme", JOB_1_UUID)
+    assert "## Description" in markdown
+    assert metadata["source"] == "ashbyhq-api"
+
+
+def test_compensation_surfaced_in_listing():
+    markdown, _ = _format_api_listing(SAMPLE_JOBS, "acme")
+    assert "USD $150,000 - $200,000" in markdown
+
+
+def test_compensation_surfaced_in_individual_job():
+    markdown, metadata = _format_api_job(SAMPLE_JOBS[0], "acme", JOB_1_UUID)
+    assert "USD $150,000 - $200,000" in markdown
+    assert metadata.get("compensation") is not None
+
+
+def test_compensation_formatter_empty():
+    assert _format_compensation({}) == ""
+    assert _format_compensation(None) == ""
+
+
+def test_location_string_combines_secondary():
+    assert _location_string(SAMPLE_JOBS[0]) == "North America, Remote"
+    assert _location_string(SAMPLE_JOBS[1]) == "Europe"
+
+
+def test_listing_empty():
+    markdown, metadata = _format_api_listing([], "acme")
+    assert metadata["total_openings"] == 0
+    assert "Job Openings" in markdown
+
+
+# ── Dispatch: listing vs individual (VAL-ASHBY-010) ──────────────
+
+
+async def test_listing_url_uses_listing_formatter(monkeypatch):
+    async def fake_fetch_board(board, include_compensation=True):
+        return {"jobs": SAMPLE_JOBS, "apiVersion": 1}
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    ctx = AdapterContext(config={})
+    result = await AshbyHQAdapter().scrape("https://jobs.ashbyhq.com/acme", ctx)
+    assert result.success is True
+    assert result.source == "ashbyhq-api"
+    assert "Job Openings" in result.markdown
+
+
+async def test_individual_url_uses_job_formatter(monkeypatch):
+    async def fake_fetch_board(board, include_compensation=True):
+        return {"jobs": SAMPLE_JOBS, "apiVersion": 1}
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    ctx = AdapterContext(config={})
+    url = f"https://jobs.ashbyhq.com/acme/{JOB_1_UUID}"
+    result = await AshbyHQAdapter().scrape(url, ctx)
+    assert result.success is True
+    assert result.source == "ashbyhq-api"
+    assert "## Description" in result.markdown
+    assert "Software Engineer" in result.markdown
+
+
+# ── SSR fallback (VAL-ASHBY-005, VAL-ASHBY-011) ──────────────────
+
+
+async def test_ssr_fallback_on_api_failure(monkeypatch):
+    async def fake_fetch_board(board, include_compensation=True):
+        return None
+
+    async def fake_appdata(url):
+        return SSR_JOB_DATA
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    monkeypatch.setattr(mod, "_fetch_and_parse_appdata", fake_appdata)
+    ctx = AdapterContext(config={})
+    url = f"https://jobs.ashbyhq.com/acme/{JOB_1_UUID}"
+    result = await AshbyHQAdapter().scrape(url, ctx)
+    assert result.success is True
+    assert result.source in {"ashbyhq", "ashbyhq-readability"}
+    assert "Software Engineer" in result.markdown
+
+
+async def test_unknown_board_falls_through_to_ssr_listing(monkeypatch):
+    async def fake_fetch_board(board, include_compensation=True):
+        return None  # unknown board → 404
+
+    async def fake_appdata(url):
+        return SSR_LISTING_DATA
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    monkeypatch.setattr(mod, "_fetch_and_parse_appdata", fake_appdata)
+    ctx = AdapterContext(config={})
+    result = await AshbyHQAdapter().scrape("https://jobs.ashbyhq.com/unknownboard", ctx)
+    assert result.success is True
+    assert result.source == "ashbyhq-listing"
+    assert "Job Openings" in result.markdown
+    assert "SSR Job A" in result.markdown
+
+
+# ── Authenticated RPC gating (VAL-ASHBY-006, VAL-ASHBY-007) ──────
+
+
+async def test_rpc_skipped_without_api_key(monkeypatch):
+    calls: list[str] = []
+
+    async def fake_fetch_board(board, include_compensation=True):
+        return {"jobs": SAMPLE_JOBS, "apiVersion": 1}
+
+    async def fake_rpc(api_key):
+        calls.append("rpc")
+        return SAMPLE_RPC_RESULTS
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    monkeypatch.setattr(mod, "_fetch_rpc_jobs", fake_rpc)
+    ctx = AdapterContext(config={})  # no ASHBY_API_KEY
+    result = await AshbyHQAdapter().scrape("https://jobs.ashbyhq.com/acme", ctx)
+    assert result.success is True
+    assert result.source == "ashbyhq-api"
+    assert calls == []  # RPC transport never invoked
+
+
+async def test_rpc_engages_with_api_key(monkeypatch):
+    calls: list[str] = []
+
+    async def fake_fetch_board(board, include_compensation=True):
+        return None  # public tier unavailable
+
+    async def fake_rpc(api_key):
+        calls.append(api_key)
+        return SAMPLE_RPC_RESULTS
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    monkeypatch.setattr(mod, "_fetch_rpc_jobs", fake_rpc)
+    ctx = AdapterContext(config={"ASHBY_API_KEY": "test-key"})
+    result = await AshbyHQAdapter().scrape("https://jobs.ashbyhq.com/acme", ctx)
+    assert result.success is True
+    assert result.source == "ashbyhq-api"
+    assert calls == ["test-key"]
+    assert "Software Engineer" in result.markdown
+
+
+# ── Registry registration + dispatch (VAL-ASHBY-012) ─────────────
+
+
+def test_adapter_registered_once():
+    # The shared registry list is reassigned by AdapterRegistry.load_all()
+    # and mutated by other adapter tests, so reference it dynamically and
+    # assert that a single import of the ashbyhq module adds exactly ONE
+    # auto-registration — i.e. no duplicates.
+    def _count() -> int:
+        return sum(
+            1 for cls in base_mod._registry_list if cls.__name__ == "AshbyHQAdapter"
+        )
+
+    baseline = _count()
+    importlib.reload(importlib.import_module("scraper.adapters.ashbyhq"))
+    assert _count() == baseline + 1
+
+
+async def test_registry_dispatch_for_jobs_url(monkeypatch):
+    async def fake_fetch_board(board, include_compensation=True):
+        return {"jobs": SAMPLE_JOBS, "apiVersion": 1}
+
+    monkeypatch.setattr(mod, "_fetch_board", fake_fetch_board)
+    registry = AdapterRegistry()
+    registry.register(AshbyHQAdapter())
+    ctx = AdapterContext(config={})
+    result = await registry.dispatch("https://jobs.ashbyhq.com/acme", ctx)
+    assert result is not None
+    assert result.success is True
+    assert result.source == "ashbyhq-api"
+    assert "Software Engineer" in result.markdown


### PR DESCRIPTION
Fixes #522

Extends `scraper-svc/scraper/adapters/ashbyhq.py` with the official Ashby API tiers at the top of the fallback chain, mirroring the Greenhouse API-first adapter:

- **Public keyless `posting-api/job-board/{board}` tier** — maps `jobs[]` to structured markdown (title / department / team / location / workplace / employment) including **compensation** when disclosed; requests `includeCompensation=true`.
- **Board-name derivation** from the final URL path segment (`jobs.ashbyhq.com/linear` → board `linear`) and from direct posting-api URLs.
- **Authenticated `jobPosting.list` RPC tier** gated behind `ASHBY_API_KEY` (and `ADAPTER_ASHBY_API_KEY`) via httpx Basic auth — implemented but intentionally not live-tested (no key available).
- **SSR `window.__appData` + readability fallbacks preserved** for unreachable boards, unknown boards (404 → SSR), and postings absent from the published board.

## Testing
- `tests/unit/test_ashbyhq.py` (25 tests): URL matching, board derivation, format helpers, listing-vs-individual dispatch, SSR fallback, RPC gating (skipped without key / engaged with key), compensation surfacing, and registry registration/dispatch.
- Full local gate: `pytest tests/unit tests/service` → 1545 passed.
- Live end-to-end: `jobs.ashbyhq.com/linear`, individual posting URL, and direct `api.ashbyhq.com/posting-api/job-board/linear` all return structured markdown via the `ashbyhq-api` source.