### PR TITLE
fix(semantic-svc): resolve 7 mypy errors surfaced by qdrant_client stubs

### DIFF
--- a/semantic-svc/retention.py
+++ b/semantic-svc/retention.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import math
 import urllib.parse
+from typing import Any
 
 from app import COLLECTION_NAME, MAX_DOCS
 from metrics import METRICS
@@ -175,8 +176,8 @@ async def _evict_if_needed(qdrant: QdrantClient):
         MAX_DOCS,
     )
 
-    scored_points: list[tuple[float, int]] = []
-    next_offset: int | None = None
+    scored_points: list[tuple[float, models.ExtendedPointId]] = []
+    next_offset: Any = None
     page_size = 2000
 
     while len(scored_points) < target_delete or next_offset is not None:

--- a/semantic-svc/router_index.py
+++ b/semantic-svc/router_index.py
@@ -301,7 +301,7 @@ async def index_batch(body: IndexBatchRequest):
         points.append(
             models.PointStruct(
                 id=point_id,
-                vector=vectors,
+                vector=vectors,  # type: ignore[arg-type]
                 payload=payload,
             )
         )

--- a/semantic-svc/router_migration.py
+++ b/semantic-svc/router_migration.py
@@ -172,7 +172,7 @@ async def migrate_start(body: MigrationStartRequest):
     try:
         collection_info = qdrant.get_collection(COLLECTION_NAME)
         vectors_config = collection_info.config.params.vectors
-        if hasattr(vectors_config, "get") and target_nv not in vectors_config:
+        if isinstance(vectors_config, dict) and target_nv not in vectors_config:
             raise HTTPException(
                 400,
                 f"Target named vector '{target_nv}' is not configured on the collection. "

--- a/semantic-svc/router_search.py
+++ b/semantic-svc/router_search.py
@@ -75,8 +75,8 @@ async def search_vector(body: VectorSearchRequest):
 
     results = [
         VectorSearchResult(
-            url=h.payload.get("url", ""),
-            title=h.payload.get("title", ""),
+            url=h.payload.get("url", ""),  # type: ignore[union-attr]
+            title=h.payload.get("title", ""),  # type: ignore[union-attr]
             score=float(h.score),
         )
         for h in hits


### PR DESCRIPTION
## Summary

Fixes #557 — resolves the 7 pre-existing mypy errors in `semantic-svc`
(`router_search.py:78,79`; `router_migration.py:175`; `router_index.py:304`;
`retention.py:183,196,208`) that surface only when `qdrant_client`'s real type
stubs are installed.

This is a **typing-only change — no runtime behavior change**. Verified:

- `PYTHONPATH=semantic-svc:. uv run --group fast-tests --with mypy mypy semantic-svc` → exit 0 (clean with real `qdrant_client` stubs).
- CI-style mypy (no `qdrant_client` installed, `ignore_missing_imports`) → clean (the `# type: ignore` comments are not flagged as unused because `warn_unused_ignores` is off).
- `pytest tests/unit/ tests/service/` → 1544 passed.

## Changes

- `router_search.py` — `# type: ignore[union-attr]` on the two `h.payload.get(...)` calls (payload is `dict | None` on `ScoredPoint`).
- `router_index.py` — `# type: ignore[arg-type]` on the named-vector `dict` passed to `PointStruct` (dict value invariance against qdrant's union).
- `router_migration.py` — `isinstance(vectors_config, dict)` replaces `hasattr(vectors_config, "get")`; runtime-equivalent since qdrant `VectorParams` has no `.get` attribute (verified via introspection).
- `retention.py` — widen `next_offset` pagination cursor to `Any` and `scored_points` point-id type to `models.ExtendedPointId` (matching qdrant's `int | str | UUID` point-id union).

## Validation

- mypy clean on `semantic-svc` with `qdrant_client` installed.
- mypy clean in the CI environment (no `qdrant_client`).
- 1544 unit/service tests pass (95 semantic-svc tests included).
