### PR TITLE
fix(ashbyhq): escape pipes and newlines in markdown table cells

### DIFF
--- a/scraper-svc/scraper/adapters/ashbyhq.py
+++ b/scraper-svc/scraper/adapters/ashbyhq.py
@@ -455,6 +455,18 @@ def _format_job(data: dict, company: str, uuid: str) -> tuple[str, dict]:
 # ── API-tier formatting ──────────────────────────────────────────
 
 
+def _escape_cell(value) -> str:
+    """Escape a value for use inside a single markdown table cell.
+
+    Replaces ``|`` with ``\\|`` and collapses newlines to ``<br>`` so a field
+    containing a pipe or line break renders as one cell instead of breaking
+    the table layout.
+    """
+    text = "" if value is None else str(value)
+    text = text.replace("|", "\\|")
+    return text.replace("\r\n", "<br>").replace("\r", "<br>").replace("\n", "<br>")
+
+
 def _location_string(job: dict) -> str:
     """Combine ``location`` and ``secondaryLocations`` into one string."""
     primary = job.get("location")
@@ -538,13 +550,13 @@ def _format_api_listing(jobs: list, board: str) -> tuple[str, dict]:
 
     for job in jobs:
         row = [
-            job.get("title", ""),
-            job.get("department", "") or "",
-            job.get("team", "") or "",
-            _location_string(job),
-            job.get("workplaceType", "") or "",
-            job.get("employmentType", "") or "",
-            _format_compensation(job.get("compensation")),
+            _escape_cell(job.get("title", "")),
+            _escape_cell(job.get("department", "") or ""),
+            _escape_cell(job.get("team", "") or ""),
+            _escape_cell(_location_string(job)),
+            _escape_cell(job.get("workplaceType", "") or ""),
+            _escape_cell(job.get("employmentType", "") or ""),
+            _escape_cell(_format_compensation(job.get("compensation"))),
         ]
         parts.append("| " + " | ".join(row) + " |")
 
@@ -600,7 +612,7 @@ def _format_api_job(job: dict, board: str, uuid: str) -> tuple[str, dict]:
     parts.append("|-------|-------|")
     for label, val in detail_items:
         if val:
-            parts.append(f"| **{label}** | {val} |")
+            parts.append(f"| **{label}** | {_escape_cell(val)} |")
     parts.append("")
 
     description_html = job.get("descriptionHtml", "")

--- a/tests/unit/test_ashbyhq.py
+++ b/tests/unit/test_ashbyhq.py
@@ -212,6 +212,74 @@ def test_listing_empty():
     assert "Job Openings" in markdown
 
 
+def test_api_listing_escapes_pipe_in_cell():
+    # VAL-FU-003: a title containing a pipe must render as one cell, not
+    # split the table into extra columns.
+    job = {
+        "id": JOB_1_UUID,
+        "title": "Engineer | Senior",
+        "department": "Product",
+        "team": "Engineering",
+        "location": "North America",
+        "secondaryLocations": [],
+        "workplaceType": "Hybrid",
+        "employmentType": "FullTime",
+        "compensation": {},
+    }
+    markdown, _ = _format_api_listing([job], "acme")
+    assert "| Engineer \\| Senior |" in markdown
+    # The title pipe is escaped, so the data row keeps the same number of
+    # cells as the header (7 columns) instead of splitting into an extra one.
+    header = next(line for line in markdown.splitlines() if line.startswith("| Title"))
+    row = next(line for line in markdown.splitlines() if line.startswith("| Engineer"))
+    assert row.count(" | ") == header.count(" | ")
+
+
+def test_api_listing_escapes_newline_in_cell():
+    # VAL-FU-003: a location containing a newline must render as a single
+    # escaped cell rather than breaking onto a new line.
+    job = {
+        "id": JOB_1_UUID,
+        "title": "Engineer",
+        "department": "Product",
+        "team": "Engineering",
+        "location": "North America",
+        "secondaryLocations": ["San Francisco\nCA"],
+        "workplaceType": "Hybrid",
+        "employmentType": "FullTime",
+        "compensation": {},
+    }
+    markdown, _ = _format_api_listing([job], "acme")
+    assert "San Francisco<br>CA" in markdown
+    # Only the header (2 rows) and this job row plus blank/spacer lines; the
+    # newline must not have introduced an extra table row.
+    table_lines = [line for line in markdown.splitlines() if line.startswith("|")]
+    assert len(table_lines) == 3  # header, separator, single data row
+
+
+def test_api_job_escapes_pipe_and_newline_in_cells():
+    # VAL-FU-003: individual-job detail table cells must escape pipes and
+    # newlines in title/location so the table stays intact.
+    job = {
+        "id": JOB_1_UUID,
+        "title": "Engineer\nSenior",
+        "department": "Product",
+        "team": "Engineering",
+        "location": "NYC|Remote",
+        "secondaryLocations": [],
+        "workplaceType": "Hybrid",
+        "employmentType": "FullTime",
+        "publishedAt": "2024-01-15T10:00:00.000+00:00",
+        "jobUrl": f"https://jobs.ashbyhq.com/acme/{JOB_1_UUID}",
+        "descriptionHtml": "<p>Build great software.</p>",
+        "compensation": {},
+    }
+    markdown, _ = _format_api_job(job, "acme", JOB_1_UUID)
+    assert "| **Location** | NYC\\|Remote |" in markdown
+    # A field with a newline must not inject a line break into the table.
+    assert "| Field | Value |" in markdown
+
+
 # ── Dispatch: listing vs individual (VAL-ASHBY-010) ──────────────
 
 


### PR DESCRIPTION
Fixes #559

## Problem
`scraper-svc/scraper/adapters/ashbyhq.py` builds markdown tables by interpolating raw API values into cells without escaping `|` or newlines. A job title/location containing a pipe or newline would split the table into extra columns/rows, breaking the layout.

## Change
Adds a shared `_escape_cell` helper that escapes `|` as `\|` and collapses `\r\n`/`\r`/`\n` to `<br>`, applied to every table cell in `_format_api_listing` and `_format_api_job`. Each field now renders as a single escaped cell.

## Tests
Adds 3 unit tests to `tests/unit/test_ashbyhq.py` covering:
- a title with a `|` (column count stays equal to the header)
- a location with a newline (renders as one cell, no extra row)
- an individual-job detail row with a pipe in location

`uv run pytest tests/unit/test_ashbyhq.py` → 29 passed. Full `tests/unit/` + `tests/service/` → 1549 passed. mypy and ruff TD clean on scraper-svc.