### PR TITLE
ci(docker): drop dead parse deps from integration lane

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -405,7 +405,7 @@ jobs:
 
       - name: Critical journey smoke
         run: |
-          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.1.9 pypdf -q
+          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-timeout jinja2 tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.1.9 pypdf -q
           docker compose exec -T agent-svc mkdir -p /app/coverage
           set +e
           docker compose exec -T agent-svc env \
@@ -444,7 +444,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-xdist pytest-timeout jinja2 python-docx python-pptx openpyxl tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.1.9 pypdf PyYAML -q
+          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-xdist pytest-timeout jinja2 tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.1.9 pypdf PyYAML -q
           docker compose exec -T agent-svc mkdir -p /app/coverage
           set +e
           docker compose exec -T agent-svc env \


### PR DESCRIPTION
## What

Fixes #560. parse-svc dropped `python-docx`, `python-pptx`, and `openpyxl` in #523/#554. This PR removes the now-dead `pip install` references to them from the docker.yml integration lane (both the Critical journey smoke and Run integration tests steps).

Verified no repo code imports these libraries (grep for `import/from docx|pptx|openpyxl` returns nothing; only file-extension strings remain).

## Change

Two lines in `.github/workflows/docker.yml` drop `python-docx python-pptx openpyxl` while keeping the deps the lane actually needs: `firecrawl-anydoc==0.1.9`, `pypdf`, `tabulate`, etc.

Closes #560