### PR TITLE
fix(ci): classify root *.md as docs-only and contract-test RUNTIME_SERVICES

### DIFF
--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -37,16 +37,28 @@ _CROSS_CUTTING_PATHS = ("docker-compose.yml",)
 _COMMON_PREFIX = "common/"
 
 
+def _is_docs_only(path: str) -> bool:
+    """Return whether a path is documentation-only.
+
+    A path is docs-only when it is an allowlisted root-level prose file, sits
+    under a docs-only prefix, or is a root-level markdown file (e.g. ROADMAP.md,
+    CHANGELOG.md). Any other root-level file (e.g. requirements.txt) stays
+    runtime-relevant and preserves the unknown-path escalation.
+    """
+    return (
+        path in DOCS_ONLY_FILES
+        or path.startswith(DOCS_ONLY_PREFIXES)
+        or ("/" not in path and path.endswith(".md"))
+    )
+
+
 def requires_full_runtime(paths: Iterable[str]) -> bool:
     """Return whether changed paths require the Docker integration runtime."""
     path_list = list(paths)
     if not path_list:
         return True
 
-    return any(
-        path not in DOCS_ONLY_FILES and not path.startswith(DOCS_ONLY_PREFIXES)
-        for path in path_list
-    )
+    return any(not _is_docs_only(path) for path in path_list)
 
 
 def affected_services(paths: Iterable[str]) -> frozenset[str]:
@@ -74,7 +86,7 @@ def affected_services(paths: Iterable[str]) -> frozenset[str]:
             continue
         # Path is not under a known service dir. If it is runtime-relevant at
         # all (i.e. not docs-only), escalate to a full rebuild.
-        if path not in DOCS_ONLY_FILES and not path.startswith(DOCS_ONLY_PREFIXES):
+        if not _is_docs_only(path):
             return frozenset({"all"})
 
     return frozenset(affected)

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -41,14 +41,16 @@ def _is_docs_only(path: str) -> bool:
     """Return whether a path is documentation-only.
 
     A path is docs-only when it is an allowlisted root-level prose file, sits
-    under a docs-only prefix, or is a root-level markdown file (e.g. ROADMAP.md,
-    CHANGELOG.md). Any other root-level file (e.g. requirements.txt) stays
-    runtime-relevant and preserves the unknown-path escalation.
+    under a docs-only prefix, or is markdown at the repo root or under
+    ``.github/`` (e.g. ROADMAP.md, CHANGELOG.md, .github/PULL_REQUEST_TEMPLATE.md).
+    Any other root-level file (e.g. requirements.txt) stays runtime-relevant and
+    preserves the unknown-path escalation.
     """
     return (
         path in DOCS_ONLY_FILES
         or path.startswith(DOCS_ONLY_PREFIXES)
         or ("/" not in path and path.endswith(".md"))
+        or (path.startswith(".github/") and path.endswith(".md"))
     )
 
 

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -97,13 +97,30 @@ class CiChangeClassificationTests(unittest.TestCase):
         self.assertEqual(MODULE.affected_services(["docs/guides/ci.md"]), frozenset())
 
     def test_root_level_markdown_files_are_docs_only(self) -> None:
-        # #561: a root-level *.md (e.g. ROADMAP.md, CHANGELOG.md, LICENSE.md) is
+        # #561: a root-level *.md (e.g. ROADMAP.md, CHANGELOG.md, SECURITY.md) is
         # documentation, not runtime code, so it must not require full runtime
         # validation nor trigger any image rebuild.
-        for path in ("ROADMAP.md", "CHANGELOG.md", "LICENSE.md"):
+        for path in ("ROADMAP.md", "CHANGELOG.md", "SECURITY.md", "VISION.md"):
             with self.subTest(path=path):
                 self.assertFalse(MODULE.requires_full_runtime([path]))
                 self.assertEqual(MODULE.affected_services([path]), frozenset())
+
+    def test_github_markdown_files_are_docs_only(self) -> None:
+        # #561: prose markdown under .github/ (e.g. PULL_REQUEST_TEMPLATE.md) is
+        # documentation too, mirroring the existing .github/ISSUE_TEMPLATE/ prefix.
+        # Non-markdown workflow/config files under .github/ still escalate.
+        self.assertFalse(
+            MODULE.requires_full_runtime([".github/PULL_REQUEST_TEMPLATE.md"])
+        )
+        self.assertEqual(
+            MODULE.affected_services([".github/PULL_REQUEST_TEMPLATE.md"]),
+            frozenset(),
+        )
+        self.assertTrue(MODULE.requires_full_runtime([".github/workflows/docker.yml"]))
+        self.assertEqual(
+            MODULE.affected_services([".github/workflows/docker.yml"]),
+            frozenset({"all"}),
+        )
 
     def test_root_level_markdown_is_ignored_in_mixed_set(self) -> None:
         self.assertEqual(

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -96,6 +96,32 @@ class CiChangeClassificationTests(unittest.TestCase):
     def test_affected_services_docs_only_paths_are_ignored(self) -> None:
         self.assertEqual(MODULE.affected_services(["docs/guides/ci.md"]), frozenset())
 
+    def test_root_level_markdown_files_are_docs_only(self) -> None:
+        # #561: a root-level *.md (e.g. ROADMAP.md, CHANGELOG.md, LICENSE.md) is
+        # documentation, not runtime code, so it must not require full runtime
+        # validation nor trigger any image rebuild.
+        for path in ("ROADMAP.md", "CHANGELOG.md", "LICENSE.md"):
+            with self.subTest(path=path):
+                self.assertFalse(MODULE.requires_full_runtime([path]))
+                self.assertEqual(MODULE.affected_services([path]), frozenset())
+
+    def test_root_level_markdown_is_ignored_in_mixed_set(self) -> None:
+        self.assertEqual(
+            MODULE.affected_services(["ROADMAP.md", "agent-svc/agent/app.py"]),
+            frozenset({"agent-svc"}),
+        )
+        self.assertTrue(
+            MODULE.requires_full_runtime(["ROADMAP.md", "agent-svc/agent/app.py"])
+        )
+
+    def test_root_level_non_markdown_still_escalates(self) -> None:
+        # The root-*.md extension must not swallow unknown root-level files:
+        # only markdown becomes docs-only; anything else escalates to all.
+        for path in ("requirements.txt", "notes.txt", "Makefile"):
+            with self.subTest(path=path):
+                self.assertTrue(MODULE.requires_full_runtime([path]))
+                self.assertEqual(MODULE.affected_services([path]), frozenset({"all"}))
+
     def test_affected_services_ignores_docs_paths_in_mixed_set(self) -> None:
         self.assertEqual(
             MODULE.affected_services(["docs/guides/ci.md", "agent-svc/agent/app.py"]),
@@ -127,6 +153,16 @@ class CiChangeClassificationTests(unittest.TestCase):
         )
         self.assertEqual(result.stdout, "true\n")
 
+    def test_cli_classifies_root_markdown_as_docs_only(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(CLASSIFIER)],
+            input="ROADMAP.md\n",
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout, "false\n")
+
 
 class RuntimeGateWorkflowContractTests(unittest.TestCase):
     def setUp(self) -> None:
@@ -134,6 +170,11 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         self.build_and_push = workflow.split("\n  build-and-push:\n", maxsplit=1)[
             1
         ].split("\n  integration-tests:\n", maxsplit=1)[0]
+        self.build_matrix_services = {
+            line.split("service:", 1)[1].strip()
+            for line in self.build_and_push.splitlines()
+            if line.strip().startswith("- service:")
+        }
         self.integration_tests = workflow.split("\n  integration-tests:\n", maxsplit=1)[
             1
         ].split("\n  runtime-gate:\n", maxsplit=1)[0]
@@ -173,6 +214,15 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         self.assertIn("matrix:\n        include:", self.build_and_push)
         self.assertIn("- service: agent-svc", self.build_and_push)
         self.assertIn("- service: scraper-svc", self.build_and_push)
+
+    def test_runtime_services_match_build_and_push_matrix(self) -> None:
+        # Contract (#561): the classifier's RUNTIME_SERVICES must exactly mirror
+        # the docker.yml build-and-push image matrix. A service added to the
+        # compose/build matrix but not to RUNTIME_SERVICES would silently break
+        # service-local PR builds and runtime classification, so this guard keeps
+        # the two from drifting apart.
+        self.assertTrue(self.build_matrix_services)
+        self.assertEqual(set(MODULE.RUNTIME_SERVICES), self.build_matrix_services)
 
     def test_docs_only_pull_request_cannot_run_integration_tests(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary

Closes #561. Two maintainability gaps in `scripts/classify_ci_changes.py`:

1. **Root-level `*.md` misclassified as full-runtime.** The `DOCS_ONLY_FILES` allowlist only named `README.md`/`AGENTS.md`/`CONTRIBUTING.md` plus the `docs/` and `.github/ISSUE_TEMPLATE/` prefixes, so a root-level markdown file (e.g. `ROADMAP.md`, `CHANGELOG.md`) escalated to full runtime validation. Extend the docs-only allowlist to any root-level `*.md` via a shared `_is_docs_only()` helper, preserving unknown-path escalation for root-level non-markdown files (`requirements.txt`, `notes.txt`, etc.).

2. **`RUNTIME_SERVICES` can drift from the compose/build matrix.** Added a contract test that cross-checks the classifier's runtime service set against the `docker.yml` `build-and-push` image matrix so a service added to the build/compose stack cannot silently drop out of the classifier.

## Tests

- `tests/service/test_ci_change_classification.py`: added root-`*.md` docs-only cases (requires_full_runtime false, affected-services empty), root-`*.md` in mixed sets, root non-markdown still escalating, a CLI case asserting `ROADMAP.md` -> `false`, and the `RUNTIME_SERVICES` == build-matrix cross-check.
- Local: `uv run pytest tests/unit/ tests/service/` -> 1554 passed, 0 failed; ruff clean; `docker.yml` YAML parses; `printf 'ROADMAP.md\n' | python3 scripts/classify_ci_changes.py` -> `false`.
