### PR TITLE
ci: integrate dependency twin validation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -540,10 +540,10 @@ jobs:
       - name: Verify LLM fixture contract and agent routing
         run: |
           docker compose exec -T agent-svc python3 -c "
-           import os
-           assert os.environ['LLM_BASE_URL'].startswith('http://llm-svc:8011/v1?run_id='), os.environ.get('LLM_BASE_URL')
-           print('agent LLM routing verified')
-           "
+          import os
+          assert os.environ['LLM_BASE_URL'].startswith('http://llm-svc:8011/v1?run_id='), os.environ.get('LLM_BASE_URL')
+          print('agent LLM routing verified')
+          "
           docker compose exec -T agent-svc python3 -c "
           import json, urllib.request
           endpoint = 'http://llm-svc:8011/v1/chat/completions'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,7 +117,7 @@ jobs:
           if [ -n "$tests" ]; then
              uv run --no-sync python -m pytest $tests -q --no-cov -o addopts= --disable-socket --allow-hosts=127.0.0.1,localhost,::1 --junitxml=twin-out/twin-tests.xml
           fi
-           uv run --no-sync python -m pytest tests/service/test_twin_contract.py tests/service/test_twin_network_isolation.py -q --no-cov -o addopts= --disable-socket --allow-hosts=127.0.0.1,localhost,::1 --junitxml=twin-out/twin-contract-tests.xml
+           uv run --no-sync python -m pytest tests/service/test_twin_contract.py tests/service/test_twin_network_isolation.py tests/service/test_workflow_contract.py -q --no-cov -o addopts= --disable-socket --allow-hosts=127.0.0.1,localhost,::1 --junitxml=twin-out/twin-contract-tests.xml
       - name: Validate twin provenance
         if: always()
         env:
@@ -634,6 +634,9 @@ jobs:
             TIER3_FIXTURE_BASE_URL=http://tier3-fixture:8000 \
             SEMANTIC_BASE_URL=http://semantic-svc:8003 \
             python3 -m pytest /app/tests/integration/ /app/tests/service/ --timeout=120 --ignore-glob='*observability*' --ignore=/app/tests/integration/test_critical_journey.py -m 'not external' \
+            --ignore=/app/tests/service/test_twin_contract.py \
+            --ignore=/app/tests/service/test_twin_network_isolation.py \
+            --ignore=/app/tests/service/test_workflow_contract.py \
               --cov=/app/agent \
               --cov=/app/scraper-svc/scraper \
               --cov=/app/parse-svc/parse_svc \
@@ -741,7 +744,8 @@ jobs:
           TWIN_REQUIRE_IMAGES: "1"
           TWIN_RECORD_IMAGES: "1"
           TWIN_BUILT_FROM_CHECKOUT: llm-svc,slopsearx-fixture,agent-svc-fixture,test-site,tier3-fixture
-          TWIN_TESTS: '["tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable","tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005","tests/integration/test_critical_journey.py","tests/integration/","tests/service/","tests/integration/test_twin_failure_injection.py","mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity","tests/service/test_twin_contract.py","tests/service/test_twin_network_isolation.py"]'
+          TWIN_TESTS: '["tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable","tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005","tests/integration/test_critical_journey.py","tests/integration/","tests/service/","tests/integration/test_twin_failure_injection.py","mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity"]'
+          TWIN_EXCLUDED_TESTS: '["tests/service/test_twin_contract.py","tests/service/test_twin_network_isolation.py","tests/service/test_workflow_contract.py"]'
           TWIN_CHECKS: scenario-version-precheck,manifest-validation
         run: |
           uv run --no-sync python scripts/twin_provenance.py --output twin-compose-out --changed-paths-json "$TWIN_CHANGED_PATHS_JSON"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,9 @@ jobs:
     outputs:
       requires_full_runtime: ${{ steps.classify.outputs.requires_full_runtime }}
       affected_services: ${{ steps.classify.outputs.affected_services }}
+      requires_twin_contracts: ${{ steps.classify.outputs.requires_twin_contracts }}
+      twin_test_selection: ${{ steps.classify.outputs.twin_test_selection }}
+      changed_paths_json: ${{ steps.classify.outputs.changed_paths_json }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -49,16 +52,96 @@ jobs:
             base="${{ github.event.before }}"
             head="${{ github.sha }}"
             if [ "$base" = "0000000000000000000000000000000000000000" ]; then
-              changed_paths=$(git diff-tree --no-commit-id --name-only -r "$head")
+              changed_paths=$(git diff-tree --root --no-commit-id --name-only -r "$head")
             else
               changed_paths=$(git diff --name-only "$base" "$head")
             fi
           fi
 
+          changed_paths_json=$(printf '%s\n' "$changed_paths" | python3 -c 'import json, sys; print(json.dumps([line for line in sys.stdin.read().splitlines() if line]))')
+          echo "changed_paths_json=$changed_paths_json" >> "$GITHUB_OUTPUT"
+
           requires_full_runtime=$(printf '%s\n' "$changed_paths" | python3 scripts/classify_ci_changes.py)
           echo "requires_full_runtime=$requires_full_runtime" >> "$GITHUB_OUTPUT"
           affected_services=$(printf '%s\n' "$changed_paths" | python3 scripts/classify_ci_changes.py --affected-services)
           echo "affected_services=$affected_services" >> "$GITHUB_OUTPUT"
+          requires_twin_contracts=$(printf '%s\n' "$changed_paths" | python3 scripts/classify_ci_changes.py --requires-twin-contracts)
+          echo "requires_twin_contracts=$requires_twin_contracts" >> "$GITHUB_OUTPUT"
+          twin_test_selection=$(printf '%s\n' "$changed_paths" | python3 scripts/classify_ci_changes.py --twin-test-selection)
+          echo "twin_test_selection=$twin_test_selection" >> "$GITHUB_OUTPUT"
+
+  twin-contracts:
+    name: Twin Contracts
+    needs: changes
+    if: >-
+      always() && needs.changes.result == 'success' &&
+      needs.changes.outputs.requires_twin_contracts == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v7
+      - name: Install locked twin dependencies
+        run: uv sync --locked --no-dev --group fast-tests
+      - name: Run hermetic twin contracts
+        id: twin_tests
+        env:
+          HTTP_PROXY: http://127.0.0.1:9
+          HTTPS_PROXY: http://127.0.0.1:9
+          ALL_PROXY: http://127.0.0.1:9
+          NO_PROXY: localhost,127.0.0.1,::1
+          TWIN_SOCKET_GUARD: "1"
+          TWIN_SELECTION: ${{ needs.changes.outputs.twin_test_selection }}
+          RUNTIME_SELECTION: ${{ needs.changes.outputs.requires_full_runtime }}
+          PYTHONPATH: .:agent-svc:scraper-svc:llm-svc:slopsearx-fixture
+          QA_OUTCOME_PATH: twin-out/qa-outcomes.json
+        run: |
+          mkdir -p twin-out
+          # Validate the checked-in scenario/version contract before replay/parity.
+          uv run --no-sync python -c "from llm_svc.app import SCHEMA_VERSION as LLM_SCHEMA; from slopsearx_fixture.app import SCHEMA_VERSION as SEARCH_SCHEMA; assert isinstance(LLM_SCHEMA, str) and isinstance(SEARCH_SCHEMA, str) and LLM_SCHEMA and SEARCH_SCHEMA"
+          case "$TWIN_SELECTION" in
+            search) tests="tests/service/test_slopsearx_fixture.py tests/service/test_searxng_client.py" ;;
+            llm) tests="tests/service/test_llm_fixture_contract.py tests/service/test_llm.py" ;;
+            all) tests="tests/service/test_llm_fixture_contract.py tests/service/test_slopsearx_fixture.py tests/service/test_research_adapter_parity.py tests/service/test_searxng_client.py" ;;
+            none) tests="" ;;
+            *) echo "unknown twin selection: $TWIN_SELECTION"; exit 1 ;;
+          esac
+          if [ -n "$tests" ]; then
+             uv run --no-sync python -m pytest $tests -q --no-cov -o addopts= --disable-socket --allow-hosts=127.0.0.1,localhost,::1 --junitxml=twin-out/twin-tests.xml
+          fi
+           uv run --no-sync python -m pytest tests/service/test_twin_contract.py tests/service/test_twin_network_isolation.py -q --no-cov -o addopts= --disable-socket --allow-hosts=127.0.0.1,localhost,::1 --junitxml=twin-out/twin-contract-tests.xml
+      - name: Validate twin provenance
+        if: always()
+        env:
+          TWIN_SELECTION: ${{ needs.changes.outputs.twin_test_selection }}
+          RUNTIME_SELECTION: ${{ needs.changes.outputs.requires_full_runtime }}
+          TWIN_TEST_OUTCOME: ${{ steps.twin_tests.outcome }}
+          TWIN_RESULT: ${{ steps.twin_tests.outcome == 'success' && 'success' || 'failure' }}
+          TWIN_FAILURE_SOURCE: ${{ steps.twin_tests.outcome == 'success' && 'none' || 'twin' }}
+          TWIN_CHANGED_PATHS_JSON: ${{ needs.changes.outputs.changed_paths_json }}
+          TWIN_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          TWIN_EXECUTION_MODE: hosted
+        run: |
+          uv run --no-sync python scripts/twin_provenance.py --output twin-out --changed-paths-json "$TWIN_CHANGED_PATHS_JSON"
+          uv run --no-sync python -m jsonschema -i twin-out/twin-evidence.json provenance/twin-evidence.schema.json
+      - name: Upload twin outcomes and provenance
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: hosted-twin-contracts
+          path: twin-out/
+          if-no-files-found: error
+      - name: Fail after publishing twin evidence
+        if: always() && steps.twin_tests.outcome != 'success'
+        run: exit 1
 
   build-and-push:
     name: ${{ matrix.service }}
@@ -190,11 +273,15 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - uses: astral-sh/setup-uv@v7
+      - name: Install locked fast-test environment
+        run: uv sync --locked --no-dev --group fast-tests
 
       - name: Set up .env
         run: |
           cp .env.sample .env
-          echo "LLM_BASE_URL=http://llm-svc:8011/v1" >> .env
+          echo "TWIN_RUN_ID=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> .env
+          echo "LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> .env
           echo "LLM_MODEL=fixture-model" >> .env
           echo "CAPTCHA_VISION_BASE_URL=http://llm-svc:8011/v1" >> .env
           echo "CAPTCHA_VISION_API_KEY=fixture-only" >> .env
@@ -413,6 +500,9 @@ jobs:
         run: |
           docker compose exec -T valkey valkey-cli -n 0 FLUSHDB
           docker compose exec -T valkey valkey-cli -n 1 FLUSHDB
+          run_id="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8011/diagnostics/reset?run_id=' + '${run_id}', data=b'', timeout=5)"
+          python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8083/ledger/reset?run_id=' + '${run_id}', data=b'', timeout=5)"
 
       - name: Copy test files and source directories
         run: |
@@ -450,10 +540,10 @@ jobs:
       - name: Verify LLM fixture contract and agent routing
         run: |
           docker compose exec -T agent-svc python3 -c "
-          import os
-          assert os.environ['LLM_BASE_URL'] == 'http://llm-svc:8011/v1', os.environ.get('LLM_BASE_URL')
-          print('agent LLM routing verified')
-          "
+           import os
+           assert os.environ['LLM_BASE_URL'].startswith('http://llm-svc:8011/v1?run_id='), os.environ.get('LLM_BASE_URL')
+           print('agent LLM routing verified')
+           "
           docker compose exec -T agent-svc python3 -c "
           import json, urllib.request
           endpoint = 'http://llm-svc:8011/v1/chat/completions'
@@ -483,7 +573,7 @@ jobs:
         run: |
           docker compose exec -T agent-svc env \
             PYTHONPATH=/app/agent-svc:/app/scraper-svc:/app/llm-svc:/app/parse-svc:/app/portal-svc:/app/browser-svc:/app \
-            QA_OUTCOME_PATH=/tmp/qa-outcomes-targeted.json \
+            QA_OUTCOME_PATH=/app/qa-outcomes-targeted.json \
             python3 -m pytest /app/tests/integration/test_stack.py \
               -k 'test_cross_endpoint_compact_citations_resolvable or test_cross_plan_agent_structured_output_val_cross_005' \
               --no-cov -o 'addopts=' -p no:cacheprovider -q
@@ -495,11 +585,12 @@ jobs:
           set +e
           docker compose exec -T agent-svc env \
             QA_OUTCOME_PATH=/app/qa-outcomes-critical.json \
+            TWIN_RUN_ID=${{ github.run_id }}-${{ github.run_attempt }} \
             AGENT_BASE_URL=http://agent-svc-fixture:8080 \
             PYTHONPATH=/app/agent-svc:/app/scraper-svc:/app/llm-svc:/app/parse-svc:/app/portal-svc:/app/browser-svc:/app \
             SCRAPER_BASE_URL=http://scraper-svc:8001 \
-            SEARCH_BASE_URL=http://slopsearx:8080 \
-            LLM_BASE_URL=http://llm-svc:8011 \
+            SEARCH_BASE_URL=http://slopsearx-fixture:8080 \
+            LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${{ github.run_id }}-${{ github.run_attempt }} \
             TEST_SITE_BASE_URL=http://test-site:8000 \
             TIER3_FIXTURE_BASE_URL=http://tier3-fixture:8000 \
             SEMANTIC_BASE_URL=http://semantic-svc:8003 \
@@ -538,7 +629,7 @@ jobs:
             PYTHONPATH=/app/agent-svc:/app/scraper-svc:/app/llm-svc:/app/parse-svc:/app/portal-svc:/app/browser-svc:/app \
             SCRAPER_BASE_URL=http://scraper-svc:8001 \
             SEARCH_BASE_URL=http://slopsearx:8080 \
-            LLM_BASE_URL=http://llm-svc:8011 \
+            LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${{ github.run_id }}-${{ github.run_attempt }} \
             TEST_SITE_BASE_URL=http://test-site:8000 \
             TIER3_FIXTURE_BASE_URL=http://tier3-fixture:8000 \
             SEMANTIC_BASE_URL=http://semantic-svc:8003 \
@@ -602,10 +693,12 @@ jobs:
         run: |
           python3 - <<'PY'
           import json
+          import os
           import urllib.request
           allowed = {"request_id", "schema_version", "fixture_version", "scenario", "scenario_version", "run_id", "status", "classification", "model", "stream"}
           try:
-              with urllib.request.urlopen("http://localhost:8011/diagnostics", timeout=5) as response:
+              run_id = f"{os.environ.get('GITHUB_RUN_ID', 'local')}-{os.environ.get('GITHUB_RUN_ATTEMPT', '1')}"
+              with urllib.request.urlopen(f"http://localhost:8011/diagnostics?run_id={run_id}", timeout=5) as response:
                   payload = json.load(response)
               entries = [{key: value for key, value in entry.items() if key in allowed} for entry in payload.get("entries", [])]
               output = {"schema_version": payload.get("schema_version"), "fixture_version": payload.get("fixture_version"), "entries": entries}
@@ -614,6 +707,45 @@ jobs:
           with open("llm-fixture-diagnostics.json", "w") as file:
               json.dump(output, file, indent=2)
           PY
+
+      - name: Capture sanitized search fixture ledger
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+          run_id = f"{os.environ.get('GITHUB_RUN_ID', 'local')}-{os.environ.get('GITHUB_RUN_ATTEMPT', '1')}"
+          try:
+              with urllib.request.urlopen(f"http://localhost:8083/ledger?run_id={run_id}", timeout=5) as response:
+                  payload = json.load(response)
+              allowed = {"request_id", "scenario", "schema_version", "fixture_version", "status", "classification", "categories", "page", "result_count", "run_id"}
+              output = {"schema_version": payload.get("schema_version"), "fixture_version": payload.get("fixture_version"), "entries": [{key: value for key, value in entry.items() if key in allowed} for entry in payload.get("entries", [])]}
+          except Exception as exc:
+              output = {"error": "search ledger unavailable", "classification": type(exc).__name__}
+          with open("search-fixture-ledger.json", "w") as file:
+              json.dump(output, file, indent=2)
+          PY
+
+      - name: Write Compose twin evidence manifest
+        if: always()
+        env:
+          TWIN_SELECTION: ${{ needs.changes.outputs.twin_test_selection }}
+          RUNTIME_SELECTION: ${{ needs.changes.outputs.requires_full_runtime }}
+          TWIN_RESULT: ${{ job.status }}
+          TWIN_FAILURE_SOURCE: ${{ job.status == 'success' && 'none' || 'implementation' }}
+          TWIN_TEST_OUTCOME: ${{ job.status }}
+          TWIN_CHANGED_PATHS_JSON: ${{ needs.changes.outputs.changed_paths_json }}
+          TWIN_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          TWIN_EXECUTION_MODE: compose
+          TWIN_REQUIRE_IMAGES: "1"
+          TWIN_RECORD_IMAGES: "1"
+          TWIN_BUILT_FROM_CHECKOUT: llm-svc,slopsearx-fixture,agent-svc-fixture,test-site,tier3-fixture
+          TWIN_TESTS: '["tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable","tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005","tests/integration/test_critical_journey.py","tests/integration/","tests/service/","tests/integration/test_twin_failure_injection.py","mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity","tests/service/test_twin_contract.py","tests/service/test_twin_network_isolation.py"]'
+          TWIN_CHECKS: scenario-version-precheck,manifest-validation
+        run: |
+          uv run --no-sync python scripts/twin_provenance.py --output twin-compose-out --changed-paths-json "$TWIN_CHANGED_PATHS_JSON"
+          uv run --no-sync python -m jsonschema -i twin-compose-out/twin-evidence.json provenance/twin-evidence.schema.json
 
       - name: Publish coverage summary
         if: always()
@@ -644,6 +776,16 @@ jobs:
         with:
           name: llm-fixture-diagnostics
           path: llm-fixture-diagnostics.json
+          if-no-files-found: warn
+
+      - name: Upload search fixture ledger and twin manifest
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: search-fixture-ledger-and-twin-provenance
+          path: |
+            search-fixture-ledger.json
+            twin-compose-out/twin-evidence.json
           if-no-files-found: warn
 
       - name: Upload coverage reports
@@ -699,7 +841,7 @@ jobs:
 
   runtime-gate:
     name: Runtime Gate
-    needs: [changes, integration-tests]
+    needs: [changes, twin-contracts, integration-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -740,4 +882,13 @@ jobs:
           needs.integration-tests.result != 'success'
         run: |
           echo "Required runtime integration did not complete successfully."
+          exit 1
+
+      - name: Fail when required twin validation fails
+        if: >-
+          needs.changes.result == 'success' &&
+          needs.changes.outputs.requires_twin_contracts == 'true' &&
+          needs.twin-contracts.result != 'success'
+        run: |
+          echo "Required hosted twin contracts did not complete successfully."
           exit 1

--- a/.github/workflows/live-calibration.yml
+++ b/.github/workflows/live-calibration.yml
@@ -1,0 +1,90 @@
+name: Trusted Live Calibration
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  calibrate:
+    if: github.repository == 'groktopus/groktocrawl' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: live-calibration
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v7
+      - name: Install locked calibration dependencies
+        run: uv sync --locked --no-dev --group fast-tests
+      - name: Start source-owned twins
+        env:
+          PYTHONPATH: llm-svc:slopsearx-fixture:.
+        run: |
+          uv run --no-sync uvicorn llm_svc.app:app --host 127.0.0.1 --port 8011 > llm-twin.log 2>&1 &
+          uv run --no-sync uvicorn slopsearx_fixture.app:app --host 127.0.0.1 --port 8083 > search-twin.log 2>&1 &
+      - name: Wait for source-owned twins
+        run: |
+          uv run --no-sync python - <<'PY'
+          import time
+          import urllib.request
+          for url in ("http://127.0.0.1:8011/health", "http://127.0.0.1:8083/health"):
+              deadline = time.monotonic() + 60
+              while time.monotonic() < deadline:
+                  try:
+                      with urllib.request.urlopen(url, timeout=3) as response:
+                          if response.status == 200:
+                              break
+                  except OSError:
+                      time.sleep(1)
+              else:
+                  raise SystemExit(f"timed out waiting for {url}")
+      - name: Run bounded calibration harness
+        id: calibration
+        env:
+          BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          LLM_BASE_URL: ${{ vars.LLM_BASE_URL }}
+          LLM_MODEL: ${{ vars.LLM_MODEL }}
+          CALIBRATION_PROVIDER_URL: ${{ vars.LLM_BASE_URL }}
+          CALIBRATION_TWIN_LLM_URL: http://127.0.0.1:8011/v1/chat/completions
+          CALIBRATION_PROVIDER_SEARCH_URL: https://api.search.brave.com/res/v1/web/search
+          CALIBRATION_TWIN_SEARCH_URL: http://127.0.0.1:8083/search
+          LLM_COST_PER_1K_TOKENS_USD: ${{ vars.LLM_COST_PER_1K_TOKENS_USD }}
+          BRAVE_COST_PER_CALL_USD: ${{ vars.BRAVE_COST_PER_CALL_USD }}
+        run: uv run --no-sync python scripts/live_calibration.py --output calibration-out
+      - name: Verify source fixtures were not rewritten
+        if: always()
+        run: git diff --exit-code -- llm-svc slopsearx-fixture provenance .github/workflows/live-calibration.yml
+      - name: Write aggregate live twin evidence
+        if: always()
+        env:
+          TWIN_EXECUTION_MODE: live
+          TWIN_SELECTION: all
+          TWIN_CHECKS: scenario-version-precheck,manifest-validation,fixture-immutability-check
+          TWIN_TESTS: '["scripts/live_calibration.py"]'
+          TWIN_RESULT: ${{ steps.calibration.outcome == 'success' && 'success' || 'failure' }}
+          TWIN_FAILURE_SOURCE: ${{ steps.calibration.outcome == 'success' && 'none' || 'harness' }}
+          TWIN_TEST_OUTCOME: ${{ steps.calibration.outcome }}
+          TWIN_CHANGED_PATHS_JSON: '[]'
+        run: |
+          uv run --no-sync python scripts/twin_provenance.py \
+            --output calibration-out \
+            --changed-paths-json "$TWIN_CHANGED_PATHS_JSON" \
+            --calibration-artifact calibration-out/calibration.json
+          uv run --no-sync python -m jsonschema -i calibration-out/twin-evidence.json provenance/twin-evidence.schema.json
+      - name: Upload calibration artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-calibration-${{ github.run_id }}
+          path: calibration-out/
+          if-no-files-found: error

--- a/agent-svc/agent/searxng_client.py
+++ b/agent-svc/agent/searxng_client.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+import os
 import time
 from dataclasses import dataclass
 
@@ -167,6 +168,7 @@ class SearXNGClient:
         sources: list[str] | None = None,
         *,
         raise_on_rate_limit: bool = False,
+        scenario: str | None = None,
     ) -> tuple[list[dict], SearchHealth]:
         """Search the web and return structured results with health info.
 
@@ -218,6 +220,11 @@ class SearXNGClient:
                 "pageno": 1,
             }
             params["categories"] = ",".join(effective_categories)
+            run_id = os.getenv("TWIN_RUN_ID")
+            if run_id:
+                params["run_id"] = run_id
+            if scenario is not None:
+                params["scenario"] = scenario
 
             resp = await self._client.get(
                 f"{self.base_url}/search",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       retries: 20
 
   slopsearx:
-    image: ghcr.io/magnus919/slopsearx:latest
+    image: ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d
     restart: unless-stopped
     ports:
       - "8081:8080"
@@ -26,7 +26,7 @@ services:
       retries: 3
 
   slopsearx-mcp:
-    image: ghcr.io/magnus919/slopsearx:latest
+    image: ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d
     # The MCP companion must never run unauthenticated, but a required-token
     # guard using the Compose `:?` operator would abort a no-config
     # `docker compose up` at load time (Compose interpolates the whole file
@@ -105,6 +105,7 @@ services:
       - fixture
     environment:
       - FIXTURE_SITE_BASE_URL=http://test-site:8000
+      - TWIN_RUN_ID=${TWIN_RUN_ID:-}
     depends_on:
       test-site:
         condition: service_started
@@ -249,6 +250,7 @@ services:
       - SEARXNG_URL=${SEARXNG_URL:-http://slopsearx:8080}
       - SCRAPER_URL=${SCRAPER_URL:-http://scraper-svc:8001}
       - SEMANTIC_URL=${SEMANTIC_URL:-http://semantic-svc:8003}
+      - LLM_BASE_URL=${LLM_BASE_URL:-http://llm-svc:8011/v1}
       - HOST=0.0.0.0
       - PORT=8080
     healthcheck:
@@ -278,6 +280,8 @@ services:
         condition: service_started
     environment:
       - VALKEY_URL=redis://valkey:6379/1
+      - TWIN_RUN_ID=${TWIN_RUN_ID:-}
+      - LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-}
       - SEARXNG_URL=http://slopsearx-fixture:8080
       - SCRAPER_URL=http://scraper-svc:8001
       - SEMANTIC_URL=http://semantic-svc:8003

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -280,8 +280,8 @@ services:
         condition: service_started
     environment:
       - VALKEY_URL=redis://valkey:6379/1
-      - TWIN_RUN_ID=${TWIN_RUN_ID:-}
-      - LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-}
+      - TWIN_RUN_ID=${TWIN_RUN_ID:-local}
+      - LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-local}
       - SEARXNG_URL=http://slopsearx-fixture:8080
       - SCRAPER_URL=http://scraper-svc:8001
       - SEMANTIC_URL=http://semantic-svc:8003

--- a/docs/adr/0008-three-layer-testing-strategy.md
+++ b/docs/adr/0008-three-layer-testing-strategy.md
@@ -1,6 +1,6 @@
 # Three-Layer Testing Strategy
 
-* Status: accepted
+* Status: superseded by ADR-0056
 * Deciders: magnus, jasper
 * Date: 2025-06-05
 * Updated: 2025-07-05 — test directory structure reorganized per this ADR

--- a/docs/adr/0056-twin-ci-evidence-and-calibration.md
+++ b/docs/adr/0056-twin-ci-evidence-and-calibration.md
@@ -7,9 +7,10 @@
 ## Context
 
 The LLM and search fixtures are source-owned dependency twins. They must be
-safe on fork pull requests without credentials or self-hosted runner exposure,
-while trusted live calibration detects provider drift without changing the
-deterministic contract.
+safe on fork pull requests without credentials, while self-hosted execution is
+controlled by platform approval policy and runner-group access rather than by
+fork-editable workflow YAML alone. Trusted live calibration detects provider
+drift without changing the deterministic contract.
 
 ## Decision
 
@@ -46,9 +47,15 @@ and protected variables `LLM_BASE_URL`, `LLM_MODEL`,
 are assumptions used only to enforce a worst-case preflight ceiling, not claims
 of actual spend. Values are never documented or printed.
 
+The repository must require approval for all external-contributor workflow runs.
+Runner-group restrictions should add defense in depth where organization policy
+permits them. The workflow's same-repository condition is also defense in depth,
+not the security boundary.
+
 ## Consequences
 
-Fork pull requests receive hosted contract confidence without secrets;
-self-hosted and live-provider execution remain unavailable to forks. A live
+Fork pull requests receive hosted contract confidence without secrets. With the
+required platform approval and runner-group policy, self-hosted and live-provider
+execution remain unavailable to unapproved forks. A live
 divergence produces evidence for review but cannot redefine the pre-merge
 deterministic contract.

--- a/docs/adr/0056-twin-ci-evidence-and-calibration.md
+++ b/docs/adr/0056-twin-ci-evidence-and-calibration.md
@@ -1,0 +1,54 @@
+# Twin CI Evidence and Trusted Calibration
+
+* Status: accepted
+* Deciders: GroktoCrawl maintainers
+* Date: 2026-08-21
+
+## Context
+
+The LLM and search fixtures are source-owned dependency twins. They must be
+safe on fork pull requests without credentials or self-hosted runner exposure,
+while trusted live calibration detects provider drift without changing the
+deterministic contract.
+
+## Decision
+
+CI uses three lanes in the existing GitHub Actions system. Hosted `Twin
+Contracts` runs credential-free on `ubuntu-latest`, blocks non-loopback HTTP(S)
+egress during tests, and emits a versioned aggregate manifest. The existing
+`[self-hosted, groktopus, docker]` lane proves Compose networking and the
+critical fixture journey, recording sanitized LLM diagnostics, a run-scoped
+search ledger, and the same manifest shape. `Trusted Live Calibration` runs
+only from schedule or manual dispatch on protected `main` in the
+`live-calibration` environment.
+
+Calibration is bounded to six outbound calls, 20 seconds per request, no
+retries, 128 requested LLM tokens per call (and 512 total), and a configured
+worst-case cost estimate below $1. Provider-vs-twin shape/status divergence is
+advisory success; harness/configuration defects fail closed. Unknown failures
+are infrastructure/harness failures, never provider drift.
+
+The trust boundary is the checked-out source and deterministic fixtures.
+Artifacts contain IDs, hashes, schema fingerprints, latency bands,
+classifications, and requested/observed identities, but never raw query,
+prompt, or secret values. The validity ceiling is the recorded commit,
+scenario/schema versions, fixture versions, image IDs/digests, timestamps, and
+bounds in the manifest.
+
+Calibration writes only to its artifact directory and verifies fixture/scenario
+source paths remain byte-identical. It never auto-records or rewrites fixtures.
+
+## Required Protected Configuration
+
+The `live-calibration` environment must provide `BRAVE_API_KEY`, `LLM_API_KEY`,
+and protected variables `LLM_BASE_URL`, `LLM_MODEL`,
+`LLM_COST_PER_1K_TOKENS_USD`, and `BRAVE_COST_PER_CALL_USD`. The cost variables
+are assumptions used only to enforce a worst-case preflight ceiling, not claims
+of actual spend. Values are never documented or printed.
+
+## Consequences
+
+Fork pull requests receive hosted contract confidence without secrets;
+self-hosted and live-provider execution remain unavailable to forks. A live
+divergence produces evidence for review but cannot redefine the pre-merge
+deterministic contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ An Architecture Decision Record captures an important architectural decision mad
 
 **Status legend:** accepted ADRs describe decisions used by the current implementation. Proposed ADRs are design work, not promises of current behavior. Superseded ADRs are historical context only; use their successor when documenting current behavior.
 
-**Current accepted decisions:** ADR-0001–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, 0049, 0050, 0051, 0052, 0053, and 0054.
+**Current accepted decisions:** ADR-0001–0007, 0009–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, 0049, 0050, 0051, 0052, 0053, 0054, 0055, and 0056.
 
 **Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, and 0040–0042.
 
@@ -32,7 +32,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0005 | [In-Repo Adapters with Entry-Point Path Reserved](0005-in-repo-adapters-with-entry-point-path-reserved.md) | accepted |
 | 0006 | [Auto-Registration via @adapter Decorator](0006-auto-registration-via-adapter-decorator.md) | accepted |
 | 0007 | [Adapter Timeout and Circuit Breaker](0007-adapter-timeout-and-circuit-breaker.md) | accepted |
-| 0008 | [Three-Layer Testing Strategy](0008-three-layer-testing-strategy.md) | accepted |
+| 0008 | [Three-Layer Testing Strategy](0008-three-layer-testing-strategy.md) | superseded |
 | 0009 | [Zero CLI Surface Changes](0009-zero-cli-surface-changes.md) | accepted |
 | 0010 | [Five-Tier Scraper Pipeline with LLM Recovery](0010-five-tier-scraper-with-llm-recovery.md) | accepted |
 | 0011 | [Stealth Playwright Configuration](0011-stealth-playwright-configuration.md) | accepted |
@@ -80,4 +80,5 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0053 | [Retryable Rate-Limit Contract](0053-retryable-rate-limit-contract.md) | accepted |
 | 0054 | [Deterministic SlopSearX Contract Fixture](0054-deterministic-slopsearx-contract-fixture.md) | accepted |
 | 0055 | [Deterministic LLM Contract Fixture](0055-deterministic-llm-contract-fixture.md) | accepted |
+| 0056 | [Twin CI Evidence and Trusted Calibration](0056-twin-ci-evidence-and-calibration.md) | accepted |
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/llm-svc/Dockerfile
+++ b/llm-svc/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a
 WORKDIR /app
 COPY llm-svc/pyproject.toml .
 RUN pip install --no-cache-dir -e .

--- a/provenance/live-calibration-corpus.json
+++ b/provenance/live-calibration-corpus.json
@@ -1,0 +1,7 @@
+{
+  "id": "live-calibration-v2",
+  "cases": [
+    {"id": "search-fixed-1", "kind": "search", "input": "python asyncio"},
+    {"id": "llm-fixed-1", "kind": "llm", "input": "Explain HTTP caching."}
+  ]
+}

--- a/provenance/twin-corpus.json
+++ b/provenance/twin-corpus.json
@@ -1,0 +1,1 @@
+{"id":"dependency-twins-v1","cases":[{"id":"healthy-search","kind":"search","input":"calibration search"},{"id":"healthy-llm","kind":"llm","input":"calibration prompt"}]}

--- a/provenance/twin-evidence.schema.json
+++ b/provenance/twin-evidence.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://groktocrawl.dev/schemas/twin-evidence-v1.json",
+  "title": "GroktoCrawl twin evidence manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "execution_mode", "commit", "selection", "corpus", "versions", "identity", "images", "bounds", "outcome"],
+  "properties": {
+    "schema_version": {"const": "twin-evidence-v1"},
+    "execution_mode": {"enum": ["hosted", "compose", "live"]},
+    "started_at": {"type": "string"},
+    "commit": {
+      "type": "object", "additionalProperties": false, "required": ["sha", "event", "ref"],
+      "properties": {"sha": {"type": "string", "pattern": "^[a-f0-9]{40}$"}, "event": {"type": "string", "minLength": 1}, "ref": {"type": "string", "minLength": 1}}
+    },
+    "selection": {
+       "type": "object", "additionalProperties": false, "required": ["inputs", "twin", "runtime", "tests", "checks"],
+      "properties": {
+        "inputs": {"type": "array", "items": {"type": "string"}},
+        "twin": {"enum": ["search", "llm", "all", "none"]},
+        "runtime": {"type": "string"},
+        "tests": {"type": "array", "items": {"enum": ["tests/service/test_twin_contract.py", "tests/service/test_twin_network_isolation.py", "tests/integration/test_twin_failure_injection.py", "tests/service/test_slopsearx_fixture.py", "tests/service/test_searxng_client.py", "tests/service/test_llm_fixture_contract.py", "tests/service/test_llm.py", "tests/service/test_research_adapter_parity.py", "tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable", "tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005", "tests/integration/test_stack.py", "tests/integration/test_critical_journey.py", "tests/integration/", "tests/service/", "mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity", "scripts/live_calibration.py"]}},
+        "checks": {"type": "array", "items": {"enum": ["scenario-version-precheck", "manifest-validation", "fixture-immutability-check"]}}
+      }
+    },
+    "corpus": {
+      "type": "object", "additionalProperties": false, "required": ["id", "digest"],
+      "properties": {"id": {"type": "string", "minLength": 1}, "digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}}
+    },
+    "versions": {
+      "type": "object", "additionalProperties": false, "required": ["scenario", "search_schema", "search_fixture", "llm_schema", "llm_fixture"],
+      "properties": {"scenario": {"type": "string", "pattern": "^v[0-9]+$"}, "search_schema": {"type": "string", "pattern": "^v[0-9]+$"}, "search_fixture": {"type": "string", "pattern": "^v[0-9]+$"}, "llm_schema": {"type": "string", "pattern": "^v[0-9]+$"}, "llm_fixture": {"type": "string", "pattern": "^v[0-9]+$"}}
+    },
+    "identity": {
+      "type": "object", "additionalProperties": false, "required": ["requested", "observed"],
+      "properties": {
+        "requested": {"type": "object", "additionalProperties": false, "required": ["provider", "model"], "properties": {"provider": {"type": "string"}, "model": {"type": "string"}}},
+        "observed": {"type": "object", "additionalProperties": false, "required": ["provider", "model"], "properties": {"provider": {"type": "string"}, "model": {"type": "string"}}}
+      }
+    },
+    "images": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["name", "reference", "id", "repo_digest", "source_sha", "built_from_checkout"], "properties": {"name": {"type": "string"}, "reference": {"type": "string"}, "id": {"type": "string", "pattern": "^(unavailable|sha256:[a-f0-9]{64})$"}, "repo_digest": {"type": ["string", "null"], "pattern": "^.+@sha256:[a-f0-9]{64}$"}, "source_sha": {"type": ["string", "null"], "pattern": "^[a-f0-9]{40}$"}, "built_from_checkout": {"type": "boolean"}}}},
+    "bounds": {"type": "object", "additionalProperties": false, "required": ["timeout_seconds", "max_calls", "max_tokens", "cost_ceiling_usd"], "properties": {"timeout_seconds": {"type": "number"}, "max_calls": {"type": "number"}, "max_tokens": {"type": "number"}, "cost_ceiling_usd": {"type": "number"}}},
+    "outcome": {
+      "type": "object", "additionalProperties": false, "required": ["result", "failure_source", "started_at", "finished_at", "test_outcome", "failure_detail"],
+      "properties": {
+        "result": {"enum": ["success", "failure", "advisory_success"]},
+        "failure_source": {"enum": ["none", "authentication", "quota", "twin", "infrastructure", "harness", "provider_drift", "implementation"]},
+        "test_outcome": {"type": "string"}, "failure_detail": {"type": "string"}, "started_at": {"type": "string"}, "finished_at": {"type": "string"}
+      }
+    },
+    "calibration": {
+      "type": "object", "additionalProperties": false,
+      "required": ["schema_version", "outcome", "failure_source", "corpus", "identity", "bounds", "records"],
+      "properties": {
+        "schema_version": {"const": "live-calibration-v2"},
+        "outcome": {"enum": ["success", "failure", "advisory_success"]},
+        "failure_source": {"enum": ["none", "authentication", "quota", "twin", "infrastructure", "harness", "provider_drift"]},
+        "corpus": {
+          "type": "object", "additionalProperties": false, "required": ["id", "digest"],
+          "properties": {"id": {"type": "string", "minLength": 1}, "digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}}
+        },
+        "identity": {
+          "type": "object", "additionalProperties": false, "required": ["requested", "observed"],
+          "properties": {
+            "requested": {"type": "object", "additionalProperties": false, "required": ["provider", "model"], "properties": {"provider": {"type": "string"}, "model": {"type": "string"}}},
+            "observed": {"type": "object", "additionalProperties": false, "required": ["search_provider", "llm_provider", "model"], "properties": {"search_provider": {"type": "string"}, "llm_provider": {"type": "string"}, "model": {"type": "string"}}}
+          }
+        },
+        "bounds": {
+          "type": "object", "additionalProperties": false,
+          "required": ["estimated_max_cost_usd", "estimated_live_provider_cost_usd", "cost_ceiling_usd", "expected_calls"],
+          "properties": {"estimated_max_cost_usd": {"type": "number"}, "estimated_live_provider_cost_usd": {"type": "number"}, "cost_ceiling_usd": {"type": "number"}, "expected_calls": {"type": "integer"}}
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "type": "object", "additionalProperties": false,
+            "required": ["case_id", "kind", "result", "classification"],
+            "properties": {
+              "case_id": {"type": "string"}, "kind": {"enum": ["search", "llm"]},
+              "result": {"enum": ["match", "provider_drift", "authentication", "quota", "twin", "infrastructure", "harness"]},
+              "classification": {"enum": ["match", "provider_drift", "authentication", "quota", "twin", "infrastructure", "harness"]},
+              "provider_fingerprint": {"type": "string", "pattern": "^(unavailable|[a-f0-9]{64})$"},
+              "twin_fingerprint": {"type": "string", "pattern": "^(unavailable|[a-f0-9]{64})$"},
+              "provider_latency_band": {"enum": ["fast", "normal", "slow"]},
+              "twin_latency_band": {"enum": ["fast", "normal", "slow"]}
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {"if": {"properties": {"execution_mode": {"const": "compose"}}}, "then": {"properties": {"images": {"minItems": 15}}, "required": ["images"], "allOf": [{"if": {"properties": {"outcome": {"properties": {"result": {"const": "failure"}}}}}, "then": {}, "else": {"properties": {"images": {"items": {"not": {"properties": {"id": {"const": "unavailable"}}}}}}}}]}},
+    {"if": {"properties": {"execution_mode": {"enum": ["hosted", "live"]}}}, "then": {"properties": {"images": {"items": {"not": {"properties": {"id": {"const": "unavailable"}}}}}}}}
+  ]
+}

--- a/provenance/twin-evidence.schema.json
+++ b/provenance/twin-evidence.schema.json
@@ -14,12 +14,13 @@
       "properties": {"sha": {"type": "string", "pattern": "^[a-f0-9]{40}$"}, "event": {"type": "string", "minLength": 1}, "ref": {"type": "string", "minLength": 1}}
     },
     "selection": {
-       "type": "object", "additionalProperties": false, "required": ["inputs", "twin", "runtime", "tests", "checks"],
+       "type": "object", "additionalProperties": false, "required": ["inputs", "twin", "runtime", "tests", "excluded_tests", "checks"],
       "properties": {
         "inputs": {"type": "array", "items": {"type": "string"}},
         "twin": {"enum": ["search", "llm", "all", "none"]},
         "runtime": {"type": "string"},
-        "tests": {"type": "array", "items": {"enum": ["tests/service/test_twin_contract.py", "tests/service/test_twin_network_isolation.py", "tests/integration/test_twin_failure_injection.py", "tests/service/test_slopsearx_fixture.py", "tests/service/test_searxng_client.py", "tests/service/test_llm_fixture_contract.py", "tests/service/test_llm.py", "tests/service/test_research_adapter_parity.py", "tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable", "tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005", "tests/integration/test_stack.py", "tests/integration/test_critical_journey.py", "tests/integration/", "tests/service/", "mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity", "scripts/live_calibration.py"]}},
+        "tests": {"type": "array", "items": {"enum": ["tests/service/test_twin_contract.py", "tests/service/test_twin_network_isolation.py", "tests/service/test_workflow_contract.py", "tests/integration/test_twin_failure_injection.py", "tests/service/test_slopsearx_fixture.py", "tests/service/test_searxng_client.py", "tests/service/test_llm_fixture_contract.py", "tests/service/test_llm.py", "tests/service/test_research_adapter_parity.py", "tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable", "tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005", "tests/integration/test_stack.py", "tests/integration/test_critical_journey.py", "tests/integration/", "tests/service/", "mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity", "scripts/live_calibration.py"]}},
+        "excluded_tests": {"type": "array", "uniqueItems": true, "items": {"enum": ["tests/service/test_twin_contract.py", "tests/service/test_twin_network_isolation.py", "tests/service/test_workflow_contract.py"]}},
         "checks": {"type": "array", "items": {"enum": ["scenario-version-precheck", "manifest-validation", "fixture-immutability-check"]}}
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ fast-tests = [
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "pytest-xdist>=3.8.0",
+    "pytest-socket>=0.7.0",
     "PyYAML>=6.0",
     "jsonschema>=4.23.0",
     # Service imports exercised by tests/unit and tests/service, excluding ML models.

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -38,9 +38,7 @@ RUNTIME_SERVICES = (
 # Paths whose change affects every service image.
 _CROSS_CUTTING_PATHS = ("docker-compose.yml",)
 _COMMON_PREFIX = "common/"
-_TWIN_PREFIXES = (
-    "llm-svc/",
-    "slopsearx-fixture/",
+_TWIN_SHARED_PREFIXES = (
     "scenarios/",
     "scenario/",
     "tests/scenarios/",
@@ -55,13 +53,6 @@ _TWIN_EXACT_PATHS = frozenset(
         ".github/workflows/docker.yml",
         ".github/workflows/live-calibration.yml",
     }
-)
-_TWIN_CLIENT_SUFFIXES = (
-    "/llm.py",
-    "/searxng_client.py",
-    "/retry.py",
-    "/retry_policy.py",
-    "/caller_policy.py",
 )
 
 
@@ -131,7 +122,7 @@ def twin_test_selection(paths: Iterable[str]) -> str:
     if not relevant:
         return "none"
     if any(
-        path in _TWIN_EXACT_PATHS or path.startswith(_TWIN_PREFIXES[2:])
+        path in _TWIN_EXACT_PATHS or path.startswith(_TWIN_SHARED_PREFIXES)
         for path in relevant
     ):
         return "all"

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -10,6 +10,9 @@ Modes:
 - ``--affected-services``: prints the space-separated list of runtime service
   images that must be rebuilt for a pull request, or ``all`` when the change is
   cross-cutting/unrecognized and the full stack must be rebuilt.
+- ``--requires-twin-contracts``: prints ``true`` when deterministic twin
+  contracts are required.
+- ``--twin-test-selection``: prints ``search``, ``llm``, ``all``, or ``none``.
 """
 
 from __future__ import annotations
@@ -35,6 +38,31 @@ RUNTIME_SERVICES = (
 # Paths whose change affects every service image.
 _CROSS_CUTTING_PATHS = ("docker-compose.yml",)
 _COMMON_PREFIX = "common/"
+_TWIN_PREFIXES = (
+    "llm-svc/",
+    "slopsearx-fixture/",
+    "scenarios/",
+    "scenario/",
+    "tests/scenarios/",
+    "tests/fixtures/",
+    "provenance/",
+    "scripts/twin_",
+    "scripts/live_calibration",
+)
+_TWIN_EXACT_PATHS = frozenset(
+    {
+        "docker-compose.yml",
+        ".github/workflows/docker.yml",
+        ".github/workflows/live-calibration.yml",
+    }
+)
+_TWIN_CLIENT_SUFFIXES = (
+    "/llm.py",
+    "/searxng_client.py",
+    "/retry.py",
+    "/retry_policy.py",
+    "/caller_policy.py",
+)
 
 
 def _is_docs_only(path: str) -> bool:
@@ -94,11 +122,64 @@ def affected_services(paths: Iterable[str]) -> frozenset[str]:
     return frozenset(affected)
 
 
+def twin_test_selection(paths: Iterable[str]) -> str:
+    """Select the narrow twin lane, escalating mixed/unknown changes to all."""
+    path_list = list(paths)
+    if not path_list or any(not path.strip() for path in path_list):
+        return "all"
+    relevant = [path for path in path_list if not _is_docs_only(path)]
+    if not relevant:
+        return "none"
+    if any(
+        path in _TWIN_EXACT_PATHS or path.startswith(_TWIN_PREFIXES[2:])
+        for path in relevant
+    ):
+        return "all"
+    search = any(
+        path.startswith(
+            ("slopsearx-fixture/", "tests/integration/test_slopsearx_fixture.py")
+        )
+        or path.endswith("/searxng_client.py")
+        for path in relevant
+    )
+    llm = any(
+        path.startswith("llm-svc/")
+        or path.endswith("/llm.py")
+        or path
+        in {"tests/service/test_llm_fixture_contract.py", "tests/service/test_llm.py"}
+        for path in relevant
+    )
+    if search and llm:
+        return "all"
+    if search:
+        return "search"
+    if llm:
+        return "llm"
+    return "all"
+
+
+def requires_twin_contracts(paths: Iterable[str]) -> bool:
+    return twin_test_selection(paths) != "none"
+
+
 def main(argv: list[str]) -> int:
     if "--affected-services" in argv:
         args = [a for a in argv if a != "--affected-services"]
         paths = args or sys.stdin.read().splitlines()
         print(" ".join(sorted(affected_services(paths))))
+        return 0
+
+    if "--requires-twin-contracts" in argv or "--twin-test-selection" in argv:
+        args = [
+            a
+            for a in argv
+            if a not in {"--requires-twin-contracts", "--twin-test-selection"}
+        ]
+        paths = args or sys.stdin.read().splitlines()
+        if "--requires-twin-contracts" in argv:
+            print(str(requires_twin_contracts(paths)).lower())
+        else:
+            print(twin_test_selection(paths))
         return 0
 
     paths = argv or sys.stdin.read().splitlines()

--- a/scripts/live_calibration.py
+++ b/scripts/live_calibration.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Run bounded, read-only provider calibration against source-owned twins."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+MAX_CALLS = 6
+REQUEST_TIMEOUT_SECONDS = 20
+MAX_RETRIES = 0
+MAX_TOKENS = 128
+MAX_TOTAL_TOKENS = 512
+COST_CEILING_USD = 1.0
+RESULTS = frozenset({"match", "provider_drift"})
+FAILURE_SOURCES = frozenset(
+    {"authentication", "quota", "twin", "infrastructure", "harness"}
+)
+RequestFn = Callable[[str, str, dict[str, str], dict[str, Any] | None], tuple[int, Any]]
+
+
+def corpus_digest(corpus: list[dict[str, Any]]) -> str:
+    return hashlib.sha256(
+        json.dumps(corpus, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    paths = [root] if root.is_file() else sorted(root.rglob("*"))
+    for path in paths:
+        if path.is_file():
+            digest.update(str(path.relative_to(root.parent)).encode())
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def shape_fingerprint(value: Any) -> str:
+    """Fingerprint recursive JSON types and object keys, never response values."""
+    if isinstance(value, dict):
+        children = ",".join(
+            f"{key}:{shape_fingerprint(value[key])}" for key in sorted(value)
+        )
+        return "{" + children + "}"
+    if isinstance(value, list):
+        return "[" + ",".join(sorted({shape_fingerprint(item) for item in value})) + "]"
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int | float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return type(value).__name__
+
+
+def schema_fingerprint(value: Any) -> str:
+    return hashlib.sha256(shape_fingerprint(value).encode()).hexdigest()
+
+
+def normalize_search_response(body: Any) -> dict[str, Any]:
+    if not isinstance(body, dict):
+        raise ValueError("search response is not an object")
+    web = body.get("web")
+    container: dict[str, Any] = web if isinstance(web, dict) else body
+    results = container.get("results")
+    if not isinstance(results, list):
+        raise ValueError("search results are not a list")
+    normalized = []
+    for result in results:
+        if not isinstance(result, dict):
+            raise ValueError("search result is not an object")
+        description = result.get("description", result.get("content"))
+        if not isinstance(result.get("url"), str) or not isinstance(
+            result.get("title"), str
+        ):
+            raise ValueError("search result identity is invalid")
+        if description is not None and not isinstance(description, str):
+            raise ValueError("search result description is invalid")
+        normalized.append(
+            {"url": result["url"], "title": result["title"], "description": description}
+        )
+    return {"result_count": len(normalized), "results": normalized}
+
+
+def normalize_llm_response(body: Any) -> dict[str, Any]:
+    if not isinstance(body, dict) or not isinstance(body.get("choices"), list):
+        raise ValueError("llm response contract is invalid")
+    choices = []
+    for choice in body["choices"]:
+        if not isinstance(choice, dict) or not isinstance(choice.get("message"), dict):
+            raise ValueError("llm choice contract is invalid")
+        content = choice["message"].get("content")
+        if content is not None and not isinstance(content, str):
+            raise ValueError("llm content contract is invalid")
+        finish_reason = choice.get("finish_reason")
+        if finish_reason is not None and not isinstance(finish_reason, str):
+            raise ValueError("llm finish reason contract is invalid")
+        choices.append(
+            {
+                "message": {"content": content},
+                "finish_reason": finish_reason,
+            }
+        )
+    model = body.get("model")
+    if model is not None and not isinstance(model, str):
+        raise ValueError("llm model contract is invalid")
+    return {"model": model, "choices": choices}
+
+
+def latency_band(seconds: float) -> str:
+    if seconds < 1:
+        return "fast"
+    if seconds < 5:
+        return "normal"
+    return "slow"
+
+
+def classify_failure(status: int | None, *, twin: bool = False) -> str:
+    if twin:
+        return "twin"
+    if status in {401, 403}:
+        return "authentication"
+    if status in {402, 409, 429}:
+        return "quota"
+    if status is None or (500 <= status < 600):
+        return "infrastructure"
+    return "harness"
+
+
+def classify_observation(
+    provider_status: int | None,
+    twin_status: int | None,
+    provider_shape: str | None = None,
+    twin_shape: str | None = None,
+    *,
+    harness_error: bool = False,
+) -> str:
+    if harness_error:
+        return "harness"
+    if provider_status is None:
+        return "infrastructure"
+    if provider_status in {401, 403}:
+        return "authentication"
+    if provider_status in {402, 409, 429}:
+        return "quota"
+    if provider_status >= 500:
+        return "infrastructure"
+    if provider_status >= 400:
+        return "harness"
+    if twin_status is None or twin_status >= 400:
+        return "twin"
+    if provider_status != twin_status or provider_shape != twin_shape:
+        return "provider_drift"
+    return "match"
+
+
+def _request(
+    url: str,
+    method: str,
+    headers: dict[str, str],
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        body = response.read().decode(errors="replace")
+        return response.status, json.loads(body)
+
+
+def _validate_corpus(raw: Any) -> tuple[str, list[dict[str, Any]]]:
+    if not isinstance(raw, dict) or not isinstance(raw.get("id"), str):
+        raise ValueError("corpus must contain a string id")
+    cases = raw.get("cases")
+    if not isinstance(cases, list) or not cases or len(cases) * 2 > MAX_CALLS:
+        raise ValueError("corpus must contain 1-3 cases")
+    for case in cases:
+        if not isinstance(case, dict) or set(case) != {"id", "kind", "input"}:
+            raise ValueError("each case must contain only id, kind, and input")
+        if not isinstance(case["id"], str) or not isinstance(case["kind"], str):
+            raise ValueError("case id and kind must be strings")
+        if (
+            case["kind"] not in {"search", "llm"}
+            or not isinstance(case["input"], str)
+            or not case["input"]
+        ):
+            raise ValueError("case kind/input is invalid")
+    llm_calls = sum(1 for case in cases if case["kind"] == "llm") * 2
+    if llm_calls * MAX_TOKENS > MAX_TOTAL_TOKENS:
+        raise ValueError("calibration corpus exceeds total token bound")
+    return raw["id"], cases
+
+
+def _config() -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "brave_key": os.getenv("BRAVE_API_KEY"),
+        "llm_key": os.getenv("LLM_API_KEY"),
+        "llm_base": os.getenv("LLM_BASE_URL"),
+        "llm_model": os.getenv("LLM_MODEL"),
+        "brave_cost": os.getenv("BRAVE_COST_PER_CALL_USD"),
+        "llm_cost": os.getenv("LLM_COST_PER_1K_TOKENS_USD"),
+        "provider_search": os.getenv("CALIBRATION_PROVIDER_SEARCH_URL"),
+        "twin_search": os.getenv("CALIBRATION_TWIN_SEARCH_URL"),
+        "provider_llm": os.getenv("CALIBRATION_PROVIDER_URL"),
+        "twin_llm": os.getenv("CALIBRATION_TWIN_LLM_URL"),
+    }
+    required = [key for key, value in values.items() if not value]
+    if required:
+        raise ValueError("missing calibration configuration: " + ",".join(required))
+    try:
+        values["brave_cost"] = float(values["brave_cost"])
+        values["llm_cost"] = float(values["llm_cost"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("cost variables must be numeric") from exc
+    if values["brave_cost"] < 0 or values["llm_cost"] < 0:
+        raise ValueError("cost variables must be non-negative")
+    for key in (
+        "llm_base",
+        "provider_search",
+        "twin_search",
+        "provider_llm",
+        "twin_llm",
+    ):
+        if not urllib.parse.urlparse(values[key]).scheme:
+            raise ValueError(f"{key} must be an absolute URL")
+    provider_llm = values["provider_llm"].rstrip("/")
+    if not provider_llm.endswith("/chat/completions"):
+        provider_llm += "/chat/completions"
+    values["provider_llm"] = provider_llm
+    return values
+
+
+def _write_artifact(output: Path, artifact: dict[str, Any]) -> None:
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "calibration.json").write_text(
+        json.dumps(artifact, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def run(
+    output: Path,
+    corpus_path: Path,
+    *,
+    provider_url: str | None = None,
+    twin_url: str | None = None,
+    request_fn: RequestFn | None = None,
+) -> int:
+    started = datetime.now(UTC).isoformat()
+    output.mkdir(parents=True, exist_ok=True)
+    before = {
+        str(path): _tree_digest(Path(path))
+        for path in ("llm-svc", "slopsearx-fixture", "provenance")
+        if Path(path).exists()
+    }
+    artifact: dict[str, Any] = {
+        "schema_version": "live-calibration-v2",
+        "started_at": started,
+        "limits": {
+            "max_calls": MAX_CALLS,
+            "timeout_seconds": REQUEST_TIMEOUT_SECONDS,
+            "max_retries": MAX_RETRIES,
+            "max_tokens": MAX_TOKENS,
+            "max_total_tokens": MAX_TOTAL_TOKENS,
+        },
+        "records": [],
+        "calls": 0,
+        "fixture_tree_digest_before": before,
+    }
+    failure_source: str | None = None
+    try:
+        corpus_id, cases = _validate_corpus(json.loads(corpus_path.read_text()))
+        config = _config()
+        estimate = sum(
+            config["brave_cost"]
+            if case["kind"] == "search"
+            else config["llm_cost"] * MAX_TOKENS / 1000
+            for case in cases
+        )
+        if estimate > COST_CEILING_USD:
+            raise ValueError("configured worst-case estimate exceeds $1")
+        config["provider_llm"] = provider_url or config["provider_llm"]
+        config["twin_llm"] = twin_url or config["twin_llm"]
+        artifact["corpus"] = {"id": corpus_id, "digest": corpus_digest(cases)}
+        artifact["bounds"] = {
+            "estimated_max_cost_usd": estimate,
+            "estimated_live_provider_cost_usd": estimate,
+            "cost_ceiling_usd": COST_CEILING_USD,
+            "expected_calls": len(cases) * 2,
+        }
+        artifact["identity"] = {
+            "requested": {
+                "provider": "brave-search-api+llm",
+                "model": config["llm_model"],
+            },
+            "observed": {
+                "search_provider": "unavailable",
+                "llm_provider": "unavailable",
+                "model": "unavailable",
+            },
+        }
+        call = request_fn or _request
+        for case in cases:
+            record: dict[str, Any] = {"case_id": case["id"], "kind": case["kind"]}
+            observations: dict[
+                str, tuple[int | None, str | None, str | None, bool]
+            ] = {}
+            for target, url in zip(
+                ("provider", "twin"),
+                (
+                    (config["provider_search"], config["twin_search"])
+                    if case["kind"] == "search"
+                    else (config["provider_llm"], config["twin_llm"])
+                ),
+                strict=True,
+            ):
+                artifact["calls"] += 1
+                if artifact["calls"] > MAX_CALLS:
+                    raise ValueError("outbound call bound exceeded")
+                headers = {"Accept": "application/json"}
+                if case["kind"] == "search":
+                    if target == "provider":
+                        headers["X-Subscription-Token"] = config["brave_key"]
+                    endpoint = (
+                        url
+                        + ("&" if "?" in url else "?")
+                        + urllib.parse.urlencode({"q": case["input"], "count": 3})
+                    )
+                    method, payload = "GET", None
+                else:
+                    headers.update(
+                        {
+                            "Content-Type": "application/json",
+                            "Authorization": f"Bearer {config['llm_key']}",
+                        }
+                    )
+                    endpoint = url
+                    payload = {
+                        "model": config["llm_model"],
+                        "messages": [{"role": "user", "content": case["input"]}],
+                        "max_tokens": MAX_TOKENS,
+                    }
+                    method = "POST"
+                started_call = time.monotonic()
+                try:
+                    status, body = call(endpoint, method, headers, payload)
+                    elapsed = time.monotonic() - started_call
+                    if status >= 400:
+                        observations[target] = (status, None, None, False)
+                        record[f"{target}_status"] = status
+                        record[f"{target}_fingerprint"] = "unavailable"
+                        record[f"{target}_latency_band"] = latency_band(elapsed)
+                        record[f"{target}_finished_at"] = datetime.now(UTC).isoformat()
+                        continue
+                    normalized = (
+                        normalize_search_response(body)
+                        if case["kind"] == "search"
+                        else normalize_llm_response(body)
+                    )
+                    fingerprint = schema_fingerprint(normalized)
+                    model = normalized.get("model") if case["kind"] == "llm" else None
+                    observations[target] = (status, fingerprint, model, False)
+                    record[f"{target}_status"] = status
+                    record[f"{target}_fingerprint"] = fingerprint
+                    record[f"{target}_latency_band"] = latency_band(elapsed)
+                    record[f"{target}_finished_at"] = datetime.now(UTC).isoformat()
+                    if target == "provider":
+                        if case["kind"] == "search":
+                            artifact["identity"]["observed"]["search_provider"] = (
+                                "brave-search-api"
+                            )
+                        else:
+                            artifact["identity"]["observed"]["llm_provider"] = (
+                                body.get("provider", "unavailable")
+                                if isinstance(body, dict)
+                                else "unavailable"
+                            )
+                            artifact["identity"]["observed"]["model"] = (
+                                model or "unavailable"
+                            )
+                except urllib.error.HTTPError as exc:
+                    observations[target] = (exc.code, None, None, False)
+                    record[f"{target}_status"] = exc.code
+                    record[f"{target}_fingerprint"] = "unavailable"
+                    elapsed = time.monotonic() - started_call
+                    record[f"{target}_latency_band"] = latency_band(elapsed)
+                    record[f"{target}_finished_at"] = datetime.now(UTC).isoformat()
+                except (OSError, TimeoutError):
+                    observations[target] = (None, None, None, True)
+                    record[f"{target}_status"] = None
+                    record[f"{target}_fingerprint"] = "unavailable"
+                    elapsed = time.monotonic() - started_call
+                    record[f"{target}_latency_band"] = latency_band(elapsed)
+                    record[f"{target}_finished_at"] = datetime.now(UTC).isoformat()
+                except (ValueError, json.JSONDecodeError):
+                    observations[target] = (200, None, None, True)
+                    record[f"{target}_status"] = 200
+                    record[f"{target}_fingerprint"] = "unavailable"
+                    elapsed = time.monotonic() - started_call
+                    record[f"{target}_latency_band"] = latency_band(elapsed)
+                    record[f"{target}_finished_at"] = datetime.now(UTC).isoformat()
+            provider, twin = observations["provider"], observations["twin"]
+            if provider[3]:
+                classification = "harness" if provider[0] == 200 else "infrastructure"
+                failure_source = classification
+            elif twin[3]:
+                classification = "twin"
+                failure_source = classification
+            else:
+                classification = classify_observation(
+                    provider[0], twin[0], provider[1], twin[1]
+                )
+                if classification != "match" and classification != "provider_drift":
+                    failure_source = classification
+                elif classification == "provider_drift" and failure_source is None:
+                    failure_source = "provider_drift"
+            record["result"] = classification
+            record["classification"] = classification
+            artifact["records"].append(record)
+    except (OSError, ValueError, json.JSONDecodeError):
+        failure_source = "harness"
+    after = {
+        str(path): _tree_digest(Path(path))
+        for path in ("llm-svc", "slopsearx-fixture", "provenance")
+        if Path(path).exists()
+    }
+    if after != before:
+        failure_source = "harness"
+    artifact["fixture_tree_digest_after"] = after
+    artifact["finished_at"] = datetime.now(UTC).isoformat()
+    if failure_source in {
+        "authentication",
+        "quota",
+        "twin",
+        "infrastructure",
+        "harness",
+    }:
+        artifact["outcome"] = "failure"
+        artifact["failure_source"] = failure_source
+    elif failure_source == "provider_drift":
+        artifact["outcome"] = "advisory_success"
+        artifact["failure_source"] = "provider_drift"
+    else:
+        artifact["outcome"] = "success"
+        artifact["failure_source"] = "none"
+    _write_artifact(output, artifact)
+    return 0 if artifact["outcome"] != "failure" else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--corpus", type=Path, default=Path("provenance/live-calibration-corpus.json")
+    )
+    parser.add_argument("--calibration-artifact", type=Path)
+    args = parser.parse_args()
+    return run(args.output, args.corpus)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/live_calibration.py
+++ b/scripts/live_calibration.py
@@ -463,7 +463,6 @@ def main() -> int:
     parser.add_argument(
         "--corpus", type=Path, default=Path("provenance/live-calibration-corpus.json")
     )
-    parser.add_argument("--calibration-artifact", type=Path)
     args = parser.parse_args()
     return run(args.output, args.corpus)
 

--- a/scripts/twin_provenance.py
+++ b/scripts/twin_provenance.py
@@ -373,6 +373,114 @@ def _execution_mode() -> str:
     return mode if mode in {"hosted", "compose", "live"} else "hosted"
 
 
+def _valid_calibration_artifact(calibration: object) -> bool:
+    if not isinstance(calibration, dict):
+        return False
+    corpus = calibration.get("corpus")
+    identity = calibration.get("identity")
+    bounds = calibration.get("bounds")
+    limits = calibration.get("limits")
+    records = calibration.get("records")
+    if calibration.get("schema_version") != "live-calibration-v2":
+        return False
+    if calibration.get("outcome") not in {"success", "failure", "advisory_success"}:
+        return False
+    if calibration.get("failure_source") not in {
+        "none",
+        "authentication",
+        "quota",
+        "twin",
+        "infrastructure",
+        "harness",
+        "provider_drift",
+    }:
+        return False
+    if not (
+        isinstance(corpus, dict)
+        and isinstance(corpus.get("id"), str)
+        and corpus["id"]
+        and isinstance(corpus.get("digest"), str)
+        and len(corpus["digest"]) == 64
+        and all(char in "0123456789abcdef" for char in corpus["digest"])
+    ):
+        return False
+    if not isinstance(identity, dict):
+        return False
+    requested = identity.get("requested")
+    observed = identity.get("observed")
+    if not (
+        isinstance(requested, dict)
+        and all(isinstance(requested.get(key), str) for key in ("provider", "model"))
+        and isinstance(observed, dict)
+        and all(
+            isinstance(observed.get(key), str)
+            for key in ("search_provider", "llm_provider", "model")
+        )
+    ):
+        return False
+    if not (
+        isinstance(bounds, dict)
+        and all(
+            isinstance(bounds.get(key), int | float)
+            for key in (
+                "estimated_max_cost_usd",
+                "estimated_live_provider_cost_usd",
+                "cost_ceiling_usd",
+                "expected_calls",
+            )
+        )
+        and isinstance(limits, dict)
+        and all(
+            isinstance(limits.get(key), int | float)
+            for key in (
+                "timeout_seconds",
+                "max_calls",
+                "max_tokens",
+                "max_total_tokens",
+            )
+        )
+    ):
+        return False
+    if not isinstance(records, list):
+        return False
+    classifications = {
+        "match",
+        "provider_drift",
+        "authentication",
+        "quota",
+        "twin",
+        "infrastructure",
+        "harness",
+    }
+    for record in records:
+        if not isinstance(record, dict):
+            return False
+        if not isinstance(record.get("case_id"), str) or not record["case_id"]:
+            return False
+        if record.get("kind") not in {"search", "llm"}:
+            return False
+        if record.get("result") not in classifications:
+            return False
+        if record.get("classification") not in classifications:
+            return False
+        for key in ("provider_fingerprint", "twin_fingerprint"):
+            value = record.get(key)
+            if value is not None and not (
+                value == "unavailable"
+                or (
+                    isinstance(value, str)
+                    and len(value) == 64
+                    and all(char in "0123456789abcdef" for char in value)
+                )
+            ):
+                return False
+        for key in ("provider_latency_band", "twin_latency_band"):
+            value = record.get(key)
+            if value is not None and value not in {"fast", "normal", "slow"}:
+                return False
+    return True
+
+
 def build_manifest(output: Path, inputs: list[str] | None = None) -> dict[str, object]:
     corpus = Path("provenance/twin-corpus.json")
     corpus_data = json.loads(corpus.read_text()) if corpus.exists() else {}
@@ -467,9 +575,7 @@ def build_manifest(output: Path, inputs: list[str] | None = None) -> dict[str, o
     if calibration_artifact:
         try:
             calibration = json.loads(Path(calibration_artifact).read_text())
-            if not isinstance(calibration, dict) or not isinstance(
-                calibration.get("records"), list
-            ):
+            if not _valid_calibration_artifact(calibration):
                 raise ValueError("invalid calibration artifact")
             manifest["calibration"] = {
                 "schema_version": calibration.get("schema_version"),

--- a/scripts/twin_provenance.py
+++ b/scripts/twin_provenance.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Write the versioned, redacted aggregate evidence manifest for twin lanes."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+SCHEMA_VERSION = "twin-evidence-v1"
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_COMPOSE_IMAGES = (
+    "llm-svc",
+    "slopsearx-fixture",
+    "agent-svc-fixture",
+    "slopsearx",
+    "test-site",
+    "tier3-fixture",
+    "scraper-svc",
+    "semantic-svc",
+    "qdrant",
+    "valkey",
+    "browser-svc",
+    "parse-svc",
+    "portal-svc",
+    "mcp-svc",
+    "agent-svc",
+)
+REQUIRED_REPO_DIGEST_IMAGES = {"slopsearx", "qdrant"}
+REQUIRED_CHECKOUT_IMAGES = {
+    "llm-svc",
+    "slopsearx-fixture",
+    "agent-svc-fixture",
+    "test-site",
+    "tier3-fixture",
+}
+ALLOWED_TESTS = {
+    "tests/service/test_twin_contract.py",
+    "tests/service/test_twin_network_isolation.py",
+    "tests/service/test_slopsearx_fixture.py",
+    "tests/service/test_searxng_client.py",
+    "tests/service/test_llm_fixture_contract.py",
+    "tests/service/test_llm.py",
+    "tests/service/test_research_adapter_parity.py",
+    "tests/integration/test_stack.py",
+    "tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable",
+    "tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005",
+    "tests/integration/test_critical_journey.py",
+    "tests/integration/test_twin_failure_injection.py",
+    "tests/integration/",
+    "tests/service/",
+    "mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity",
+    "scripts/live_calibration.py",
+}
+ALLOWED_CHECKS = {
+    "scenario-version-precheck",
+    "manifest-validation",
+    "fixture-immutability-check",
+}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _git(*args: str) -> str:
+    try:
+        return subprocess.check_output(["git", *args], text=True).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+
+
+def _known_repo_path(path: str) -> bool:
+    if not path or Path(path).is_absolute() or ".." in Path(path).parts:
+        return False
+    try:
+        subprocess.check_call(
+            ["git", "ls-files", "--error-unmatch", "--", path],
+            cwd=ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except (OSError, subprocess.CalledProcessError):
+        return Path(path).exists()
+
+
+def _actual_changed_paths(mode: str) -> list[str] | None:
+    if mode == "live":
+        return []
+    base_sha = os.environ.get("TWIN_BASE_SHA", "")
+    if len(base_sha) != 40 or any(char not in "0123456789abcdef" for char in base_sha):
+        return None
+    try:
+        if base_sha == "0" * 40:
+            output = subprocess.check_output(
+                [
+                    "git",
+                    "diff-tree",
+                    "--root",
+                    "--no-commit-id",
+                    "--name-only",
+                    "-r",
+                    "HEAD",
+                ],
+                cwd=ROOT,
+                text=True,
+            )
+        else:
+            output = subprocess.check_output(
+                ["git", "diff", "--name-only", base_sha, "HEAD"],
+                cwd=ROOT,
+                text=True,
+            )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return sorted(line for line in output.splitlines() if line)
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _image_records(execution_mode: str) -> list[dict[str, object]]:
+    if execution_mode in {"hosted", "live"} and not os.environ.get(
+        "TWIN_RECORD_IMAGES"
+    ):
+        return []
+    records = []
+    references = {
+        name: os.environ.get(
+            f"TWIN_IMAGE_{name.upper().replace('-', '_')}",
+            "ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d"
+            if name == "slopsearx"
+            else name,
+        )
+        for name in REQUIRED_COMPOSE_IMAGES
+    }
+    source_sha = _git("rev-parse", "HEAD")
+    built_services = set(
+        filter(None, os.environ.get("TWIN_BUILT_FROM_CHECKOUT", "").split(","))
+    )
+    for name, default_reference in references.items():
+        reference = os.environ.get(
+            f"TWIN_IMAGE_{name.upper().replace('-', '_')}", default_reference
+        )
+        image_id = "unavailable"
+        repo_digest = None
+        try:
+            service_id = subprocess.check_output(
+                ["docker", "compose", "images", "-q", name], text=True
+            ).strip()
+            if service_id:
+                reference = service_id
+            image_id = subprocess.check_output(
+                ["docker", "image", "inspect", "--format", "{{.Id}}", reference],
+                text=True,
+            ).strip()
+            digests = subprocess.check_output(
+                [
+                    "docker",
+                    "image",
+                    "inspect",
+                    "--format",
+                    "{{json .RepoDigests}}",
+                    reference,
+                ],
+                text=True,
+            ).strip()
+            parsed = json.loads(digests)
+            repo_digest = parsed[0] if parsed else None
+        except (
+            OSError,
+            subprocess.CalledProcessError,
+            json.JSONDecodeError,
+            IndexError,
+        ):
+            pass
+        records.append(
+            {
+                "name": name,
+                "reference": reference,
+                "id": image_id,
+                "repo_digest": repo_digest,
+                "source_sha": source_sha if name in built_services else None,
+                "built_from_checkout": name in built_services,
+            }
+        )
+    return records
+
+
+def _fixture_versions() -> dict[str, str]:
+    versions = {
+        "scenario": "v0",
+        "search_schema": "v0",
+        "search_fixture": "v0",
+        "llm_schema": "v0",
+        "llm_fixture": "v0",
+    }
+
+    def constants(path: Path) -> dict[str, str]:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            return {}
+        found: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AnnAssign | ast.Assign):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            if not any(isinstance(target, ast.Name) for target in targets):
+                continue
+            if isinstance(node.value, ast.Constant) and isinstance(
+                node.value.value, str
+            ):
+                for target in targets:
+                    if isinstance(target, ast.Name) and target.id in {
+                        "SCHEMA_VERSION",
+                        "FIXTURE_VERSION",
+                    }:
+                        found[target.id] = node.value.value
+        return found
+
+    llm = constants(ROOT / "llm-svc/llm_svc/app.py")
+    search = constants(ROOT / "slopsearx-fixture/slopsearx_fixture/app.py")
+    versions.update(
+        {
+            "llm_schema": llm.get("SCHEMA_VERSION", "unavailable"),
+            "llm_fixture": llm.get("FIXTURE_VERSION", "unavailable"),
+            "search_schema": search.get("SCHEMA_VERSION", "unavailable"),
+            "search_fixture": search.get("FIXTURE_VERSION", "unavailable"),
+            "scenario": search.get("SCHEMA_VERSION", "unavailable"),
+        }
+    )
+    return versions
+
+
+TEST_SELECTIONS = {
+    "search": [
+        "tests/service/test_slopsearx_fixture.py",
+        "tests/service/test_searxng_client.py",
+    ],
+    "llm": [
+        "tests/service/test_llm_fixture_contract.py",
+        "tests/service/test_llm.py",
+    ],
+    "all": [
+        "tests/service/test_llm_fixture_contract.py",
+        "tests/service/test_slopsearx_fixture.py",
+        "tests/service/test_research_adapter_parity.py",
+        "tests/service/test_searxng_client.py",
+    ],
+    "none": [],
+}
+
+
+def _selected_tests(selection: str) -> list[str]:
+    explicit = os.environ.get("TWIN_TESTS")
+    if explicit:
+        try:
+            parsed = json.loads(explicit)
+        except json.JSONDecodeError:
+            parsed = []
+        if isinstance(parsed, list) and all(isinstance(item, str) for item in parsed):
+            return parsed
+    selected = (
+        parsed
+        if explicit
+        and isinstance(parsed, list)
+        and all(isinstance(item, str) for item in parsed)
+        else TEST_SELECTIONS.get(selection, [])
+    )
+    return list(
+        dict.fromkeys(
+            [
+                *selected,
+                "tests/service/test_twin_contract.py",
+                "tests/service/test_twin_network_isolation.py",
+            ]
+        )
+    )
+
+
+def _selected_checks() -> list[str]:
+    raw = os.environ.get("TWIN_CHECKS", "scenario-version-precheck,manifest-validation")
+    return list(dict.fromkeys(item for item in raw.split(",") if item))
+
+
+def _expected_hosted_tests(selection: str) -> list[str]:
+    return list(
+        dict.fromkeys(
+            [
+                *TEST_SELECTIONS.get(selection, []),
+                "tests/service/test_twin_contract.py",
+                "tests/service/test_twin_network_isolation.py",
+            ]
+        )
+    )
+
+
+def _selection_error(
+    mode: str, selection: str, tests: list[str], checks: list[str]
+) -> str | None:
+    if selection not in TEST_SELECTIONS:
+        return "unknown twin selection"
+    if any(test not in ALLOWED_TESTS for test in tests):
+        return "unknown selected test"
+    if any(check not in ALLOWED_CHECKS for check in checks):
+        return "unknown selected check"
+    if mode == "hosted" and tests != _expected_hosted_tests(selection):
+        return "hosted test selection does not match classifier selection"
+    if mode == "compose":
+        required = {
+            "tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable",
+            "tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005",
+            "tests/integration/test_critical_journey.py",
+            "tests/integration/",
+            "tests/service/",
+            "tests/integration/test_twin_failure_injection.py",
+            "mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity",
+        }
+        if not required.issubset(tests):
+            return "compose test selection is incomplete"
+    if mode == "live" and tests != ["scripts/live_calibration.py"]:
+        return "live test selection is not the calibration harness"
+    required_checks = {"scenario-version-precheck", "manifest-validation"}
+    if not required_checks.issubset(checks):
+        return "required evidence checks are missing"
+    if mode == "live" and "fixture-immutability-check" not in checks:
+        return "live fixture immutability check is missing"
+    return None
+
+
+def _execution_mode() -> str:
+    mode = os.environ.get("TWIN_EXECUTION_MODE", "hosted")
+    return mode if mode in {"hosted", "compose", "live"} else "hosted"
+
+
+def build_manifest(output: Path, inputs: list[str] | None = None) -> dict[str, object]:
+    corpus = Path("provenance/twin-corpus.json")
+    corpus_data = json.loads(corpus.read_text()) if corpus.exists() else {}
+    started = os.environ.get("TWIN_STARTED_AT", _now())
+    requested_result = os.environ.get("TWIN_RESULT", "success")
+    result = (
+        requested_result
+        if requested_result in {"success", "failure", "advisory_success"}
+        else "failure"
+    )
+    requested_source = os.environ.get("TWIN_FAILURE_SOURCE", "harness")
+    source = (
+        requested_source
+        if requested_source
+        in {
+            "none",
+            "authentication",
+            "quota",
+            "twin",
+            "infrastructure",
+            "harness",
+            "provider_drift",
+            "implementation",
+        }
+        else "harness"
+    )
+    if result == "success":
+        source = "none"
+    mode = _execution_mode()
+    selected_tests = _selected_tests(os.environ.get("TWIN_SELECTION", "all"))
+    selected_checks = _selected_checks()
+    selection_error = _selection_error(
+        mode,
+        os.environ.get("TWIN_SELECTION", "all"),
+        selected_tests,
+        selected_checks,
+    )
+    if selection_error:
+        result = "failure"
+        source = "harness"
+    manifest: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "execution_mode": mode,
+        "commit": {
+            "sha": _git("rev-parse", "HEAD"),
+            "event": os.environ.get("GITHUB_EVENT_NAME", "local"),
+            "ref": os.environ.get("GITHUB_REF", "local"),
+        },
+        "selection": {
+            "inputs": inputs or [],
+            "twin": os.environ.get("TWIN_SELECTION", "all"),
+            "runtime": os.environ.get("RUNTIME_SELECTION", "unknown"),
+            "tests": selected_tests,
+            "checks": selected_checks,
+        },
+        "corpus": {
+            "id": corpus_data.get("id", "unavailable"),
+            "digest": _digest(corpus) if corpus.exists() else "unavailable",
+        },
+        "versions": _fixture_versions(),
+        "identity": {
+            "requested": {
+                "provider": os.environ.get("LLM_PROVIDER", "fixture"),
+                "model": os.environ.get("LLM_MODEL", "fixture-model"),
+            },
+            "observed": {
+                "provider": os.environ.get("OBSERVED_PROVIDER", "unavailable"),
+                "model": os.environ.get("OBSERVED_MODEL", "unavailable"),
+            },
+        },
+        "images": _image_records(mode),
+        "bounds": {
+            "timeout_seconds": int(os.environ.get("TWIN_TIMEOUT_SECONDS", "300")),
+            "max_calls": int(os.environ.get("TWIN_MAX_CALLS", "0")),
+            "max_tokens": int(os.environ.get("TWIN_MAX_TOKENS", "0")),
+            "cost_ceiling_usd": float(os.environ.get("TWIN_COST_CEILING_USD", "0")),
+        },
+        "outcome": {
+            "result": result,
+            "failure_source": source,
+            "test_outcome": os.environ.get("TWIN_TEST_OUTCOME", "unavailable"),
+            "failure_detail": selection_error
+            or os.environ.get("TWIN_FAILURE_DETAIL", "unavailable"),
+            "started_at": started,
+            "finished_at": _now(),
+        },
+    }
+    calibration_artifact = os.environ.get("TWIN_CALIBRATION_ARTIFACT")
+    if calibration_artifact:
+        try:
+            calibration = json.loads(Path(calibration_artifact).read_text())
+            if not isinstance(calibration, dict) or not isinstance(
+                calibration.get("records"), list
+            ):
+                raise ValueError("invalid calibration artifact")
+            manifest["calibration"] = {
+                "schema_version": calibration.get("schema_version"),
+                "outcome": calibration.get("outcome", "failure"),
+                "failure_source": calibration.get("failure_source", "harness"),
+                "corpus": calibration.get("corpus", {}),
+                "identity": calibration.get("identity", {}),
+                "bounds": calibration.get("bounds", {}),
+                "records": [
+                    {
+                        key: record.get(key)
+                        for key in record
+                        if key.endswith(("_fingerprint", "_latency_band"))
+                        or key in {"case_id", "kind", "result", "classification"}
+                    }
+                    for record in calibration["records"]
+                    if isinstance(record, dict)
+                ],
+            }
+            calibration_corpus = calibration.get("corpus")
+            if isinstance(calibration_corpus, dict):
+                manifest["corpus"] = calibration_corpus
+            calibration_bounds = calibration.get("bounds")
+            calibration_limits = calibration.get("limits")
+            if isinstance(calibration_bounds, dict) and isinstance(
+                calibration_limits, dict
+            ):
+                manifest["bounds"] = {
+                    "timeout_seconds": calibration_limits.get("timeout_seconds", 0),
+                    "max_calls": calibration_limits.get("max_calls", 0),
+                    "max_tokens": calibration_limits.get(
+                        "max_total_tokens", calibration_limits.get("max_tokens", 0)
+                    ),
+                    "cost_ceiling_usd": calibration_bounds.get("cost_ceiling_usd", 0),
+                }
+            calibration_identity = calibration.get("identity")
+            if isinstance(calibration_identity, dict):
+                requested = calibration_identity.get("requested", {})
+                observed = calibration_identity.get("observed", {})
+                if isinstance(requested, dict) and isinstance(observed, dict):
+                    observed_providers = [
+                        observed.get("search_provider"),
+                        observed.get("llm_provider"),
+                    ]
+                    manifest["identity"] = {
+                        "requested": {
+                            "provider": str(requested.get("provider", "unavailable")),
+                            "model": str(requested.get("model", "unavailable")),
+                        },
+                        "observed": {
+                            "provider": "+".join(
+                                str(provider)
+                                for provider in observed_providers
+                                if provider and provider != "unavailable"
+                            )
+                            or "unavailable",
+                            "model": str(observed.get("model", "unavailable")),
+                        },
+                    }
+            calibration_outcome = calibration.get("outcome")
+            calibration_source = calibration.get("failure_source")
+            if calibration_outcome in {"success", "failure", "advisory_success"}:
+                manifest["outcome"] = {
+                    **cast(dict[str, object], manifest["outcome"]),
+                    "result": calibration_outcome,
+                    "failure_source": calibration_source
+                    if calibration_source
+                    in {
+                        "none",
+                        "authentication",
+                        "quota",
+                        "twin",
+                        "infrastructure",
+                        "harness",
+                        "provider_drift",
+                    }
+                    else "harness",
+                }
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            os.environ["TWIN_CALIBRATION_INVALID"] = "1"
+            manifest["calibration"] = {
+                "schema_version": "live-calibration-v2",
+                "outcome": "failure",
+                "failure_source": "harness",
+                "corpus": {"id": "unavailable", "digest": "0" * 64},
+                "identity": {
+                    "requested": {"provider": "unavailable", "model": "unavailable"},
+                    "observed": {
+                        "search_provider": "unavailable",
+                        "llm_provider": "unavailable",
+                        "model": "unavailable",
+                    },
+                },
+                "bounds": {
+                    "estimated_max_cost_usd": 0,
+                    "estimated_live_provider_cost_usd": 0,
+                    "cost_ceiling_usd": 0,
+                    "expected_calls": 0,
+                },
+                "records": [],
+            }
+            manifest["outcome"] = {
+                **cast(dict[str, object], manifest["outcome"]),
+                "result": "failure",
+                "failure_source": "harness",
+                "failure_detail": "missing or invalid calibration artifact",
+            }
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "twin-evidence.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--changed-paths-json", default="[]")
+    parser.add_argument("--calibration-artifact", type=Path)
+    args = parser.parse_args()
+    if args.calibration_artifact:
+        os.environ["TWIN_CALIBRATION_ARTIFACT"] = str(args.calibration_artifact)
+    invalid = False
+    try:
+        paths = json.loads(args.changed_paths_json)
+        if not isinstance(paths, list) or not all(
+            isinstance(path, str) for path in paths
+        ):
+            raise ValueError
+    except (json.JSONDecodeError, ValueError):
+        paths = []
+        invalid = True
+        os.environ["TWIN_RESULT"] = "failure"
+        os.environ["TWIN_FAILURE_SOURCE"] = "harness"
+    invalid_paths = [path for path in paths if not _known_repo_path(path)]
+    if invalid_paths:
+        invalid = True
+        os.environ["TWIN_RESULT"] = "failure"
+        os.environ["TWIN_FAILURE_SOURCE"] = "harness"
+        os.environ["TWIN_FAILURE_DETAIL"] = "invalid changed paths"
+    actual_paths = _actual_changed_paths(_execution_mode())
+    if actual_paths is None or sorted(paths) != actual_paths:
+        invalid = True
+        os.environ["TWIN_RESULT"] = "failure"
+        os.environ["TWIN_FAILURE_SOURCE"] = "harness"
+        os.environ["TWIN_FAILURE_DETAIL"] = (
+            "changed paths do not match checked-out event diff"
+        )
+    manifest = build_manifest(args.output, paths)
+    if cast(dict[str, object], manifest["outcome"])["result"] == "failure":
+        invalid = True
+    if (
+        os.environ.get("TWIN_EXECUTION_MODE") == "compose"
+        and os.environ.get("TWIN_REQUIRE_IMAGES") == "1"
+    ):
+        images = cast(list[dict[str, object]], manifest["images"])
+        missing = [
+            str(record["name"])
+            for record in images
+            if record["id"] == "unavailable"
+            or (
+                record["name"] in REQUIRED_REPO_DIGEST_IMAGES
+                and not record["repo_digest"]
+            )
+        ]
+        checkout_sha = _git("rev-parse", "HEAD")
+        missing.extend(
+            str(record["name"])
+            for record in images
+            if record["name"] in REQUIRED_CHECKOUT_IMAGES
+            and (
+                not record["built_from_checkout"]
+                or record["source_sha"] != checkout_sha
+            )
+        )
+        missing = sorted(set(missing))
+        if missing:
+            invalid = True
+            manifest["outcome"] = {
+                **cast(dict[str, object], manifest["outcome"]),
+                "result": "failure",
+                "failure_source": "infrastructure",
+                "failure_detail": "required images unavailable: " + ",".join(missing),
+            }
+            (args.output / "twin-evidence.json").write_text(
+                json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+            )
+    if args.calibration_artifact and (
+        not Path(args.calibration_artifact).is_file()
+        or os.environ.get("TWIN_CALIBRATION_INVALID") == "1"
+    ):
+        invalid = True
+    return 1 if invalid else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/twin_provenance.py
+++ b/scripts/twin_provenance.py
@@ -43,6 +43,7 @@ REQUIRED_CHECKOUT_IMAGES = {
 ALLOWED_TESTS = {
     "tests/service/test_twin_contract.py",
     "tests/service/test_twin_network_isolation.py",
+    "tests/service/test_workflow_contract.py",
     "tests/service/test_slopsearx_fixture.py",
     "tests/service/test_searxng_client.py",
     "tests/service/test_llm_fixture_contract.py",
@@ -282,6 +283,7 @@ def _selected_tests(selection: str) -> list[str]:
                 *selected,
                 "tests/service/test_twin_contract.py",
                 "tests/service/test_twin_network_isolation.py",
+                "tests/service/test_workflow_contract.py",
             ]
         )
     )
@@ -292,6 +294,19 @@ def _selected_checks() -> list[str]:
     return list(dict.fromkeys(item for item in raw.split(",") if item))
 
 
+def _excluded_tests() -> list[str]:
+    raw = os.environ.get("TWIN_EXCLUDED_TESTS", "[]")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return ["invalid"]
+    if not isinstance(parsed, list) or not all(
+        isinstance(item, str) for item in parsed
+    ):
+        return ["invalid"]
+    return list(dict.fromkeys(parsed))
+
+
 def _expected_hosted_tests(selection: str) -> list[str]:
     return list(
         dict.fromkeys(
@@ -299,22 +314,31 @@ def _expected_hosted_tests(selection: str) -> list[str]:
                 *TEST_SELECTIONS.get(selection, []),
                 "tests/service/test_twin_contract.py",
                 "tests/service/test_twin_network_isolation.py",
+                "tests/service/test_workflow_contract.py",
             ]
         )
     )
 
 
 def _selection_error(
-    mode: str, selection: str, tests: list[str], checks: list[str]
+    mode: str,
+    selection: str,
+    tests: list[str],
+    excluded_tests: list[str],
+    checks: list[str],
 ) -> str | None:
     if selection not in TEST_SELECTIONS:
         return "unknown twin selection"
     if any(test not in ALLOWED_TESTS for test in tests):
         return "unknown selected test"
+    if any(test not in ALLOWED_TESTS for test in excluded_tests):
+        return "unknown excluded test"
     if any(check not in ALLOWED_CHECKS for check in checks):
         return "unknown selected check"
     if mode == "hosted" and tests != _expected_hosted_tests(selection):
         return "hosted test selection does not match classifier selection"
+    if mode in {"hosted", "live"} and excluded_tests:
+        return f"{mode} test selection cannot exclude tests"
     if mode == "compose":
         required = {
             "tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable",
@@ -327,6 +351,13 @@ def _selection_error(
         }
         if not required.issubset(tests):
             return "compose test selection is incomplete"
+        expected_exclusions = {
+            "tests/service/test_twin_contract.py",
+            "tests/service/test_twin_network_isolation.py",
+            "tests/service/test_workflow_contract.py",
+        }
+        if set(excluded_tests) != expected_exclusions:
+            return "compose host-only exclusions are incomplete"
     if mode == "live" and tests != ["scripts/live_calibration.py"]:
         return "live test selection is not the calibration harness"
     required_checks = {"scenario-version-precheck", "manifest-validation"}
@@ -372,11 +403,13 @@ def build_manifest(output: Path, inputs: list[str] | None = None) -> dict[str, o
         source = "none"
     mode = _execution_mode()
     selected_tests = _selected_tests(os.environ.get("TWIN_SELECTION", "all"))
+    excluded_tests = _excluded_tests()
     selected_checks = _selected_checks()
     selection_error = _selection_error(
         mode,
         os.environ.get("TWIN_SELECTION", "all"),
         selected_tests,
+        excluded_tests,
         selected_checks,
     )
     if selection_error:
@@ -395,6 +428,7 @@ def build_manifest(output: Path, inputs: list[str] | None = None) -> dict[str, o
             "twin": os.environ.get("TWIN_SELECTION", "all"),
             "runtime": os.environ.get("RUNTIME_SELECTION", "unknown"),
             "tests": selected_tests,
+            "excluded_tests": excluded_tests,
             "checks": selected_checks,
         },
         "corpus": {

--- a/slopsearx-fixture/Dockerfile
+++ b/slopsearx-fixture/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a
 WORKDIR /app
 COPY slopsearx-fixture/pyproject.toml .
 RUN pip install --no-cache-dir -e .

--- a/slopsearx-fixture/slopsearx_fixture/app.py
+++ b/slopsearx-fixture/slopsearx_fixture/app.py
@@ -78,8 +78,10 @@ class FixtureState:
         """Return the ordinal for a non-sensitive scenario/query partition."""
         partition = hashlib.sha256(query.encode("utf-8")).hexdigest()[:16]
         key = (scenario, partition, run_id)
-        ordinal = self.scenario_requests.get(key, 0) + 1
+        ordinal = self.scenario_requests.pop(key, 0) + 1
         self.scenario_requests[key] = ordinal
+        while len(self.scenario_requests) > MAX_LEDGER:
+            del self.scenario_requests[next(iter(self.scenario_requests))]
         return ordinal
 
     def record(

--- a/slopsearx-fixture/slopsearx_fixture/app.py
+++ b/slopsearx-fixture/slopsearx_fixture/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
+import re
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -14,7 +15,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 SCHEMA_VERSION: Literal["v1"] = "v1"
 MAX_DELAY_MS = 2_000
+MAX_LEDGER = 200
 FIXTURE_SITE_BASE_URL = os.getenv("FIXTURE_SITE_BASE_URL", "http://test-site:8000")
+FIXTURE_VERSION = "v1"
+RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 SCENARIOS = {
     "healthy",
     "zero-results",
@@ -64,12 +68,16 @@ class FixtureState:
     default_scenario: str = "healthy"
     ledger: list[dict[str, object]] = field(default_factory=list)
     request_number: int = 0
-    scenario_requests: dict[tuple[str, str], int] = field(default_factory=dict)
+    scenario_requests: dict[tuple[str, str, str | None], int] = field(
+        default_factory=dict
+    )
 
-    def next_scenario_request(self, scenario: str, query: str) -> int:
+    def next_scenario_request(
+        self, scenario: str, query: str, run_id: str | None
+    ) -> int:
         """Return the ordinal for a non-sensitive scenario/query partition."""
         partition = hashlib.sha256(query.encode("utf-8")).hexdigest()[:16]
-        key = (scenario, partition)
+        key = (scenario, partition, run_id)
         ordinal = self.scenario_requests.get(key, 0) + 1
         self.scenario_requests[key] = ordinal
         return ordinal
@@ -83,6 +91,7 @@ class FixtureState:
         categories: str,
         page: int,
         result_count: int,
+        run_id: str | None,
     ) -> None:
         self.request_number += 1
         self.ledger.append(
@@ -95,8 +104,11 @@ class FixtureState:
                 "categories": categories,
                 "page": page,
                 "result_count": result_count,
+                "fixture_version": FIXTURE_VERSION,
+                "run_id": run_id,
             }
         )
+        del self.ledger[:-MAX_LEDGER]
 
 
 def _result(index: int, engine: str = "brave") -> SearchResult:
@@ -123,8 +135,37 @@ def create_app(*, default_scenario: str = "healthy") -> FastAPI:
         }
 
     @app.get("/ledger")
-    async def ledger() -> dict[str, object]:
-        return {"schema_version": SCHEMA_VERSION, "entries": state.ledger}
+    async def ledger(run_id: str | None = Query(default=None)) -> dict[str, object]:
+        if run_id is not None and not RUN_ID_PATTERN.fullmatch(run_id):
+            raise HTTPException(status_code=400, detail="invalid run_id")
+        entries = (
+            state.ledger
+            if run_id is None
+            else [entry for entry in state.ledger if entry.get("run_id") == run_id]
+        )
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "fixture_version": FIXTURE_VERSION,
+            "entries": entries,
+        }
+
+    @app.post("/ledger/reset")
+    async def reset_ledger(run_id: str | None = Query(default=None)) -> dict[str, str]:
+        if run_id is not None and not RUN_ID_PATTERN.fullmatch(run_id):
+            raise HTTPException(status_code=400, detail="invalid run_id")
+        if run_id is None:
+            state.ledger.clear()
+            state.scenario_requests.clear()
+        else:
+            state.ledger[:] = [
+                entry for entry in state.ledger if entry.get("run_id") != run_id
+            ]
+            state.scenario_requests = {
+                key: value
+                for key, value in state.scenario_requests.items()
+                if key[2] != run_id
+            }
+        return {"status": "ok"}
 
     @app.get("/search")
     async def search(
@@ -138,6 +179,7 @@ def create_app(*, default_scenario: str = "healthy") -> FastAPI:
         scenario_version: str = Query(default=SCHEMA_VERSION),
         limit: int = Query(default=10, ge=0, le=50),
         delay_ms: int = Query(default=0, ge=0, le=MAX_DELAY_MS),
+        run_id: str | None = Query(default=None, pattern=r"^[A-Za-z0-9._-]{1,64}$"),
     ) -> Response:
         del request, format, language
         if scenario_version != SCHEMA_VERSION:
@@ -148,7 +190,7 @@ def create_app(*, default_scenario: str = "healthy") -> FastAPI:
         selected = scenario or state.default_scenario
         if selected not in SCENARIOS:
             raise HTTPException(status_code=400, detail=f"Unknown scenario: {selected}")
-        scenario_request = state.next_scenario_request(selected, q)
+        scenario_request = state.next_scenario_request(selected, q, run_id)
         effective_delay = (
             delay_ms
             if selected not in {"delayed", "timeout"}
@@ -240,6 +282,7 @@ def create_app(*, default_scenario: str = "healthy") -> FastAPI:
             categories=categories,
             page=pageno,
             result_count=result_count,
+            run_id=run_id,
         )
         return payload
 

--- a/tests/integration/test_twin_failure_injection.py
+++ b/tests/integration/test_twin_failure_injection.py
@@ -1,0 +1,88 @@
+"""Failure taxonomy checks against the deployed Compose fixture services."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+from agent.exceptions import ProviderOutputError, RetryableRateLimitError
+from agent.llm import LLMClient
+from agent.searxng_client import SearXNGClient
+
+RUN_ID = os.environ.get("TWIN_RUN_ID", "compose-failure-injection")
+SEARCH_URL = os.environ.get("SEARCH_BASE_URL", "http://slopsearx-fixture:8080")
+LLM_URL = os.environ.get("LLM_BASE_URL", "http://llm-svc:8011/v1")
+
+
+def _llm(scenario: str) -> LLMClient:
+    base_url = LLM_URL.split("?", 1)[0].rstrip("/")
+    return LLMClient(
+        f"{base_url}/scenarios/{scenario}?run_id={RUN_ID}",
+        model="fixture-model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_deployed_search_rate_limit_has_retry_metadata():
+    client = SearXNGClient(SEARCH_URL)
+    try:
+        with pytest.raises(RetryableRateLimitError) as raised:
+            await client.search(
+                "failure", scenario="rate-limit-retry-after", raise_on_rate_limit=True
+            )
+        assert raised.value.retry_after_seconds == 2
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_deployed_search_malformed_response_degrades_without_crash():
+    client = SearXNGClient(SEARCH_URL)
+    try:
+        results, health = await client.search("failure", scenario="malformed-json")
+        assert results == []
+        assert "failed" in health.detail.lower()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_deployed_search_timeout_is_classified():
+    client = SearXNGClient(SEARCH_URL)
+    await client._client.aclose()
+    client._client = httpx.AsyncClient(timeout=0.01)
+    try:
+        results, health = await client.search("failure", scenario="delayed")
+        assert results == []
+        assert "timed out" in health.detail.lower()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_deployed_llm_failures_are_typed():
+    for scenario, error in (
+        ("rate-limit", RetryableRateLimitError),
+        ("malformed-json", ProviderOutputError),
+        ("refusal", ProviderOutputError),
+        ("truncated", ProviderOutputError),
+        ("server-error", ProviderOutputError),
+    ):
+        client = _llm(scenario)
+        try:
+            with pytest.raises(error):
+                await client.generate("system", "failure")
+        finally:
+            await client.close()
+
+
+@pytest.mark.asyncio
+async def test_deployed_llm_timeout_is_typed_transport_error():
+    client = _llm("timeout")
+    client._client.timeout = httpx.Timeout(0.05)
+    try:
+        with pytest.raises(ProviderOutputError, match="transport failed"):
+            await client.generate("system", "failure")
+    finally:
+        await client.close()

--- a/tests/integration/test_twin_failure_injection.py
+++ b/tests/integration/test_twin_failure_injection.py
@@ -11,7 +11,7 @@ from agent.llm import LLMClient
 from agent.searxng_client import SearXNGClient
 
 RUN_ID = os.environ.get("TWIN_RUN_ID", "compose-failure-injection")
-SEARCH_URL = os.environ.get("SEARCH_BASE_URL", "http://slopsearx-fixture:8080")
+SEARCH_URL = os.environ.get("SEARCH_FIXTURE_BASE_URL", "http://slopsearx-fixture:8080")
 LLM_URL = os.environ.get("LLM_BASE_URL", "http://llm-svc:8011/v1")
 
 

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import subprocess
 import sys
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -179,6 +180,54 @@ class CiChangeClassificationTests(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result.stdout, "false\n")
+
+    def test_twin_selection_table(self) -> None:
+        cases = [
+            (["llm-svc/llm_svc/app.py"], True, "llm"),
+            (["slopsearx-fixture/slopsearx_fixture/app.py"], True, "search"),
+            (["agent-svc/agent/searxng_client.py"], True, "search"),
+            (["docs/ci.md"], False, "none"),
+            (["docs/ci.md", "docker-compose.yml"], True, "all"),
+            (["unknown/path"], True, "all"),
+            ([], True, "all"),
+            ([""], True, "all"),
+        ]
+        for paths, expected_bool, expected_selection in cases:
+            with self.subTest(paths=paths):
+                self.assertEqual(MODULE.requires_twin_contracts(paths), expected_bool)
+                self.assertEqual(MODULE.twin_test_selection(paths), expected_selection)
+
+    def test_changed_path_shell_block_is_valid_and_keeps_zero_sha_else(self) -> None:
+        workflow = WORKFLOW.read_text()
+        block = workflow.split('if [ "${{ github.event_name }}"', 1)[1]
+        block = (
+            'if [ "${{ github.event_name }}"'
+            + block.split("\n\n  twin-contracts:", 1)[0]
+        )
+        block = textwrap.dedent(block).replace("${{", "${PLACEHOLDER_")
+        block = block.replace("}}", "}")
+        result = subprocess.run(
+            ["bash", "-n"], input=block, text=True, capture_output=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("git diff-tree --root", block)
+        self.assertIn(
+            'if [ "$base" = "0000000000000000000000000000000000000000" ]; then', block
+        )
+        self.assertIn(
+            'else\n              changed_paths=$(git diff --name-only "$base" "$head")',
+            block,
+        )
+
+    def test_embedded_llm_probe_python_compiles_and_run_id_is_propagated(self) -> None:
+        workflow = WORKFLOW.read_text()
+        marker = 'docker compose exec -T agent-svc python3 -c "\n'
+        probe = workflow.split(marker, 1)[1].split('\n           "', 1)[0]
+        compile(textwrap.dedent(probe), "docker.yml LLM probe", "exec")
+        compose = (ROOT / "docker-compose.yml").read_text()
+        self.assertGreaterEqual(compose.count("TWIN_RUN_ID=${TWIN_RUN_ID:-}"), 2)
+        self.assertIn("run_id=${TWIN_RUN_ID:-}", compose)
+        self.assertIn("run_id=${{ github.run_id }}-${{ github.run_attempt }}", workflow)
 
 
 class RuntimeGateWorkflowContractTests(unittest.TestCase):
@@ -548,7 +597,7 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
             "- name: Fail when required runtime validation fails", self.runtime_gate
         )
         self.assertIn("needs.integration-tests.result != 'success'", self.runtime_gate)
-        self.assertEqual(self.runtime_gate.count("exit 1"), 2)
+        self.assertEqual(self.runtime_gate.count("exit 1"), 3)
 
 
 class FastTestsWorkflowContractTests(unittest.TestCase):

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 import textwrap
 import unittest
 from pathlib import Path
+
+import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 CLASSIFIER = ROOT / "scripts" / "classify_ci_changes.py"
@@ -221,9 +224,17 @@ class CiChangeClassificationTests(unittest.TestCase):
 
     def test_embedded_llm_probe_python_compiles_and_run_id_is_propagated(self) -> None:
         workflow = WORKFLOW.read_text()
-        marker = 'docker compose exec -T agent-svc python3 -c "\n'
-        probe = workflow.split(marker, 1)[1].split('\n           "', 1)[0]
-        compile(textwrap.dedent(probe), "docker.yml LLM probe", "exec")
+        parsed = yaml.safe_load(workflow)
+        integration = parsed["jobs"]["integration-tests"]["steps"]
+        run = next(
+            step["run"]
+            for step in integration
+            if step.get("name") == "Verify LLM fixture contract and agent routing"
+        )
+        probes = re.findall(r'python3 -c "\n(.*?)\n"', run, flags=re.DOTALL)
+        self.assertEqual(len(probes), 2)
+        for index, probe in enumerate(probes):
+            compile(probe, f"docker.yml LLM probe {index}", "exec")
         compose = (ROOT / "docker-compose.yml").read_text()
         self.assertGreaterEqual(compose.count("TWIN_RUN_ID=${TWIN_RUN_ID:-}"), 2)
         self.assertIn("run_id=${TWIN_RUN_ID:-}", compose)

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -236,8 +236,11 @@ class CiChangeClassificationTests(unittest.TestCase):
         for index, probe in enumerate(probes):
             compile(probe, f"docker.yml LLM probe {index}", "exec")
         compose = (ROOT / "docker-compose.yml").read_text()
-        self.assertGreaterEqual(compose.count("TWIN_RUN_ID=${TWIN_RUN_ID:-}"), 2)
-        self.assertIn("run_id=${TWIN_RUN_ID:-}", compose)
+        self.assertIn("TWIN_RUN_ID=${TWIN_RUN_ID:-local}", compose)
+        self.assertIn("run_id=${TWIN_RUN_ID:-local}", compose)
+        self.assertNotIn(
+            "LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-}", compose
+        )
         self.assertIn("run_id=${{ github.run_id }}-${{ github.run_attempt }}", workflow)
 
 

--- a/tests/service/test_slopsearx_fixture.py
+++ b/tests/service/test_slopsearx_fixture.py
@@ -16,10 +16,25 @@ import uvicorn
 sys.path.insert(0, str(Path(__file__).parents[2] / "slopsearx-fixture"))
 
 from slopsearx_fixture.app import (
+    MAX_LEDGER,
     SCHEMA_VERSION,
+    FixtureState,
     SearchResponse,
     create_app,
 )
+
+
+def test_scenario_request_partitions_are_hard_bounded():
+    state = FixtureState()
+    for index in range(MAX_LEDGER + 5):
+        state.next_scenario_request("healthy", f"query-{index}", "run-a")
+    assert len(state.scenario_requests) == MAX_LEDGER
+    newest_key = next(reversed(state.scenario_requests))
+    assert newest_key[2] == "run-a"
+    assert (
+        state.next_scenario_request("healthy", f"query-{MAX_LEDGER + 4}", "run-a") == 2
+    )
+    assert len(state.scenario_requests) == MAX_LEDGER
 
 
 @pytest_asyncio.fixture

--- a/tests/service/test_slopsearx_fixture.py
+++ b/tests/service/test_slopsearx_fixture.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import socket
 import sys
 from pathlib import Path
@@ -224,6 +225,82 @@ async def test_pagination_delay_and_category_ledger_are_bounded_and_private(
         await timeout_client.close()
     finally:
         await _stop_tcp_fixture(base_url, server_task, server)
+
+
+@pytest.mark.asyncio
+async def test_ledger_is_versioned_run_scoped_and_resettable():
+    from httpx import ASGITransport, AsyncClient
+
+    direct = AsyncClient(
+        transport=ASGITransport(app=create_app()), base_url="http://fixture"
+    )
+    await direct.get("/search", params={"q": "private", "run_id": "run-a"})
+    await direct.get("/search", params={"q": "other", "run_id": "run-b"})
+    ledger = (await direct.get("/ledger", params={"run_id": "run-a"})).json()
+    assert ledger["fixture_version"] == "v1"
+    assert {entry["run_id"] for entry in ledger["entries"]} == {"run-a"}
+    assert "private" not in json.dumps(ledger)
+    assert (await direct.post("/ledger/reset", params={"run_id": "run-a"})).json() == {
+        "status": "ok"
+    }
+    assert (await direct.get("/ledger", params={"run_id": "run-a"})).json()[
+        "entries"
+    ] == []
+    await direct.aclose()
+
+
+@pytest.mark.asyncio
+async def test_ledger_is_hard_bounded_and_run_reset_removes_quota_state():
+    from httpx import ASGITransport, AsyncClient
+
+    direct = AsyncClient(
+        transport=ASGITransport(app=create_app()), base_url="http://fixture"
+    )
+    for index in range(205):
+        response = await direct.get(
+            "/search", params={"q": f"query-{index}", "run_id": "run-a"}
+        )
+        assert response.status_code == 200
+    entries = (await direct.get("/ledger")).json()["entries"]
+    assert len(entries) == 200
+    assert entries[0]["request_id"] == 6
+    await direct.get(
+        "/search",
+        params={"scenario": "quota-exhaustion", "q": "same", "run_id": "run-a"},
+    )
+    assert (
+        await direct.get(
+            "/search",
+            params={"scenario": "quota-exhaustion", "q": "same", "run_id": "run-b"},
+        )
+    ).status_code == 200
+    await direct.post("/ledger/reset", params={"run_id": "run-a"})
+    assert (await direct.get("/ledger", params={"run_id": "run-a"})).json()[
+        "entries"
+    ] == []
+    assert (
+        await direct.get(
+            "/search",
+            params={"scenario": "quota-exhaustion", "q": "same", "run_id": "run-a"},
+        )
+    ).status_code == 200
+    await direct.aclose()
+
+
+@pytest.mark.asyncio
+async def test_run_reset_isolates_quota_counters_and_ledger():
+    from httpx import ASGITransport, AsyncClient
+
+    direct = AsyncClient(
+        transport=ASGITransport(app=create_app()), base_url="http://fixture"
+    )
+    params = {"scenario": "quota-exhaustion", "q": "same", "run_id": "run-a"}
+    assert (await direct.get("/search", params=params)).status_code == 200
+    assert (await direct.get("/search", params=params)).status_code == 429
+    await direct.post("/ledger/reset", params={"run_id": "run-a"})
+    assert (await direct.get("/search", params=params)).status_code == 200
+    assert (await direct.get("/ledger", params={"run_id": "run-a"})).json()["entries"]
+    await direct.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/service/test_twin_contract.py
+++ b/tests/service/test_twin_contract.py
@@ -20,6 +20,7 @@ def _isolate_twin_environment(monkeypatch):
         "TWIN_CALIBRATION_ARTIFACT",
         "TWIN_CHECKS",
         "TWIN_EXECUTION_MODE",
+        "TWIN_EXCLUDED_TESTS",
         "TWIN_FAILURE_DETAIL",
         "TWIN_FAILURE_SOURCE",
         "TWIN_RECORD_IMAGES",
@@ -182,6 +183,16 @@ def test_compose_exact_images_validate_as_success(tmp_path, monkeypatch):
                 "tests/service/",
                 "tests/integration/test_twin_failure_injection.py",
                 "mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity",
+            ]
+        ),
+    )
+    monkeypatch.setenv(
+        "TWIN_EXCLUDED_TESTS",
+        json.dumps(
+            [
+                "tests/service/test_twin_contract.py",
+                "tests/service/test_twin_network_isolation.py",
+                "tests/service/test_workflow_contract.py",
             ]
         ),
     )

--- a/tests/service/test_twin_contract.py
+++ b/tests/service/test_twin_contract.py
@@ -1,0 +1,687 @@
+"""Docker-free contracts for classifier, provenance, and calibration bounds."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import validate
+
+ROOT = Path(__file__).parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_twin_environment(monkeypatch):
+    for name in (
+        "TWIN_BASE_SHA",
+        "TWIN_BUILT_FROM_CHECKOUT",
+        "TWIN_CALIBRATION_ARTIFACT",
+        "TWIN_CHECKS",
+        "TWIN_EXECUTION_MODE",
+        "TWIN_FAILURE_DETAIL",
+        "TWIN_FAILURE_SOURCE",
+        "TWIN_RECORD_IMAGES",
+        "TWIN_REQUIRE_IMAGES",
+        "TWIN_RESULT",
+        "TWIN_SELECTION",
+        "TWIN_TESTS",
+        "TWIN_TEST_OUTCOME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_twin_selection_is_conservative_and_docs_only_is_negative():
+    classifier = _load("classifier", ROOT / "scripts/classify_ci_changes.py")
+    assert classifier.requires_twin_contracts(["llm-svc/llm_svc/app.py"])
+    assert classifier.requires_twin_contracts(["agent-svc/agent/llm.py"])
+    assert classifier.requires_twin_contracts(["docker-compose.yml"])
+    assert classifier.requires_twin_contracts(["unknown/new-policy.toml"])
+    assert classifier.requires_twin_contracts([])
+    assert not classifier.requires_twin_contracts(["docs/ci.md"])
+
+
+def test_provenance_manifest_matches_versioned_schema(tmp_path):
+    provenance = _load("provenance", ROOT / "scripts/twin_provenance.py")
+    manifest = provenance.build_manifest(tmp_path, ["llm-svc/llm_svc/app.py"])
+    schema = json.loads((ROOT / "provenance/twin-evidence.schema.json").read_text())
+    validate(manifest, schema)
+    assert manifest["schema_version"] == schema["properties"]["schema_version"]["const"]
+    assert manifest["selection"]["inputs"] == ["llm-svc/llm_svc/app.py"]
+    assert manifest["selection"]["tests"]
+    assert manifest["versions"]["llm_schema"] == "v1"
+    assert "prompt" not in json.dumps(manifest)
+
+
+def test_invalid_provenance_paths_write_strict_failure_manifest(tmp_path, monkeypatch):
+    provenance = _load("invalid_provenance", ROOT / "scripts/twin_provenance.py")
+    monkeypatch.setenv("TWIN_RESULT", "success")
+    output = tmp_path / "invalid"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "twin_provenance",
+            "--output",
+            str(output),
+            "--changed-paths-json",
+            "not-json",
+        ],
+    )
+    assert provenance.main() == 1
+    manifest = json.loads((output / "twin-evidence.json").read_text())
+    schema = json.loads((ROOT / "provenance/twin-evidence.schema.json").read_text())
+    validate(manifest, schema)
+    assert manifest["outcome"]["result"] == "failure"
+    assert manifest["outcome"]["failure_source"] == "harness"
+
+
+def test_hosted_manifest_rejects_selection_test_mismatch(tmp_path, monkeypatch):
+    provenance = _load("mismatch_provenance", ROOT / "scripts/twin_provenance.py")
+    monkeypatch.setenv("TWIN_EXECUTION_MODE", "hosted")
+    monkeypatch.setenv("TWIN_BASE_SHA", provenance._git("rev-parse", "HEAD"))
+    monkeypatch.setenv("TWIN_SELECTION", "search")
+    monkeypatch.setenv("TWIN_TESTS", json.dumps(["tests/service/test_llm.py"]))
+    monkeypatch.setattr(
+        "sys.argv",
+        ["twin_provenance", "--output", str(tmp_path), "--changed-paths-json", "[]"],
+    )
+    assert provenance.main() == 1
+    manifest = json.loads((tmp_path / "twin-evidence.json").read_text())
+    assert manifest["outcome"]["result"] == "failure"
+    assert manifest["outcome"]["failure_source"] == "harness"
+    assert "does not match" in manifest["outcome"]["failure_detail"]
+
+
+def test_hosted_manifest_rejects_incomplete_changed_path_evidence(
+    tmp_path, monkeypatch
+):
+    provenance = _load("path_mismatch_provenance", ROOT / "scripts/twin_provenance.py")
+    monkeypatch.setenv("TWIN_EXECUTION_MODE", "hosted")
+    monkeypatch.setenv("TWIN_SELECTION", "all")
+    monkeypatch.setenv("TWIN_BASE_SHA", provenance._git("rev-parse", "HEAD"))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "twin_provenance",
+            "--output",
+            str(tmp_path),
+            "--changed-paths-json",
+            json.dumps(["README.md"]),
+        ],
+    )
+    assert provenance.main() == 1
+    manifest = json.loads((tmp_path / "twin-evidence.json").read_text())
+    assert manifest["outcome"]["result"] == "failure"
+    assert manifest["outcome"]["failure_source"] == "harness"
+    assert manifest["outcome"]["failure_detail"] == (
+        "changed paths do not match checked-out event diff"
+    )
+
+
+def test_compose_unavailable_images_are_failure_not_acceptance(tmp_path, monkeypatch):
+    provenance = _load("compose_provenance", ROOT / "scripts/twin_provenance.py")
+    monkeypatch.setenv("TWIN_EXECUTION_MODE", "compose")
+    monkeypatch.setenv("TWIN_BASE_SHA", provenance._git("rev-parse", "HEAD"))
+    monkeypatch.setenv("TWIN_REQUIRE_IMAGES", "1")
+    monkeypatch.setenv("TWIN_RECORD_IMAGES", "1")
+    monkeypatch.setattr(
+        provenance,
+        "_image_records",
+        lambda mode: [
+            {
+                "name": name,
+                "reference": name,
+                "id": "unavailable",
+                "repo_digest": None,
+                "source_sha": "0" * 40,
+                "built_from_checkout": False,
+            }
+            for name in provenance.REQUIRED_COMPOSE_IMAGES
+        ],
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["twin_provenance", "--output", str(tmp_path), "--changed-paths-json", "[]"],
+    )
+    assert provenance.main() == 1
+    manifest = json.loads((tmp_path / "twin-evidence.json").read_text())
+    schema = json.loads((ROOT / "provenance/twin-evidence.schema.json").read_text())
+    validate(manifest, schema)
+    assert manifest["outcome"]["failure_source"] == "infrastructure"
+
+
+def test_compose_exact_images_validate_as_success(tmp_path, monkeypatch):
+    provenance = _load(
+        "compose_success_provenance", ROOT / "scripts/twin_provenance.py"
+    )
+    checkout_sha = provenance._git("rev-parse", "HEAD")
+    monkeypatch.setenv("TWIN_EXECUTION_MODE", "compose")
+    monkeypatch.setenv("TWIN_BASE_SHA", provenance._git("rev-parse", "HEAD"))
+    monkeypatch.setenv("TWIN_REQUIRE_IMAGES", "1")
+    monkeypatch.setenv("TWIN_RECORD_IMAGES", "1")
+    monkeypatch.setenv(
+        "TWIN_BUILT_FROM_CHECKOUT", ",".join(provenance.REQUIRED_CHECKOUT_IMAGES)
+    )
+    monkeypatch.setenv(
+        "TWIN_TESTS",
+        json.dumps(
+            [
+                "tests/integration/test_stack.py::test_cross_endpoint_compact_citations_resolvable",
+                "tests/integration/test_stack.py::test_cross_plan_agent_structured_output_val_cross_005",
+                "tests/integration/test_critical_journey.py",
+                "tests/integration/",
+                "tests/service/",
+                "tests/integration/test_twin_failure_injection.py",
+                "mcp-svc/tests/test_integration.py::TestHostHeaderTransportSecurity",
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        provenance,
+        "_image_records",
+        lambda mode: [
+            {
+                "name": name,
+                "reference": name,
+                "id": "sha256:" + "1" * 64,
+                "repo_digest": (
+                    f"example/{name}@sha256:" + "2" * 64
+                    if name in provenance.REQUIRED_REPO_DIGEST_IMAGES
+                    else None
+                ),
+                "source_sha": (
+                    checkout_sha
+                    if name in provenance.REQUIRED_CHECKOUT_IMAGES
+                    else None
+                ),
+                "built_from_checkout": name in provenance.REQUIRED_CHECKOUT_IMAGES,
+            }
+            for name in provenance.REQUIRED_COMPOSE_IMAGES
+        ],
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        ["twin_provenance", "--output", str(tmp_path), "--changed-paths-json", "[]"],
+    )
+    assert provenance.main() == 0
+    manifest = json.loads((tmp_path / "twin-evidence.json").read_text())
+    validate(
+        manifest,
+        json.loads((ROOT / "provenance/twin-evidence.schema.json").read_text()),
+    )
+    assert manifest["execution_mode"] == "compose"
+    assert len(manifest["images"]) == len(provenance.REQUIRED_COMPOSE_IMAGES)
+    assert manifest["outcome"]["result"] == "success"
+
+
+def test_live_calibration_projects_into_strict_aggregate_manifest(
+    tmp_path, monkeypatch
+):
+    provenance = _load("live_provenance", ROOT / "scripts/twin_provenance.py")
+    calibration = {
+        "schema_version": "live-calibration-v2",
+        "outcome": "advisory_success",
+        "failure_source": "provider_drift",
+        "corpus": {"id": "live-v2", "digest": "3" * 64},
+        "identity": {
+            "requested": {"provider": "brave-search-api+llm", "model": "model-a"},
+            "observed": {
+                "search_provider": "brave-search-api",
+                "llm_provider": "vendor-a",
+                "model": "model-a",
+            },
+        },
+        "limits": {
+            "timeout_seconds": 20,
+            "max_calls": 6,
+            "max_tokens": 128,
+            "max_total_tokens": 512,
+        },
+        "bounds": {
+            "estimated_max_cost_usd": 0.1,
+            "estimated_live_provider_cost_usd": 0.1,
+            "cost_ceiling_usd": 1.0,
+            "expected_calls": 4,
+        },
+        "records": [
+            {
+                "case_id": "s",
+                "kind": "search",
+                "result": "provider_drift",
+                "classification": "provider_drift",
+                "provider_fingerprint": "4" * 64,
+                "twin_fingerprint": "5" * 64,
+                "provider_latency_band": "fast",
+                "twin_latency_band": "fast",
+            }
+        ],
+    }
+    calibration_path = tmp_path / "calibration.json"
+    calibration_path.write_text(json.dumps(calibration))
+    output = tmp_path / "aggregate"
+    monkeypatch.setenv("TWIN_EXECUTION_MODE", "live")
+    monkeypatch.setenv("TWIN_SELECTION", "all")
+    monkeypatch.setenv("TWIN_TESTS", json.dumps(["scripts/live_calibration.py"]))
+    monkeypatch.setenv(
+        "TWIN_CHECKS",
+        "scenario-version-precheck,manifest-validation,fixture-immutability-check",
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "twin_provenance",
+            "--output",
+            str(output),
+            "--calibration-artifact",
+            str(calibration_path),
+        ],
+    )
+    assert provenance.main() == 0
+    manifest = json.loads((output / "twin-evidence.json").read_text())
+    validate(
+        manifest,
+        json.loads((ROOT / "provenance/twin-evidence.schema.json").read_text()),
+    )
+    assert manifest["outcome"]["result"] == "advisory_success"
+    assert manifest["outcome"]["failure_source"] == "provider_drift"
+    assert manifest["corpus"] == calibration["corpus"]
+    assert manifest["selection"]["tests"] == ["scripts/live_calibration.py"]
+    assert manifest["identity"]["observed"]["provider"] == ("brave-search-api+vendor-a")
+
+
+def test_missing_live_calibration_writes_valid_failure_manifest(tmp_path, monkeypatch):
+    provenance = _load("missing_live_provenance", ROOT / "scripts/twin_provenance.py")
+    output = tmp_path / "aggregate"
+    monkeypatch.setenv("TWIN_EXECUTION_MODE", "live")
+    monkeypatch.setenv("TWIN_SELECTION", "all")
+    monkeypatch.setenv("TWIN_TESTS", json.dumps(["scripts/live_calibration.py"]))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "twin_provenance",
+            "--output",
+            str(output),
+            "--calibration-artifact",
+            str(tmp_path / "missing.json"),
+        ],
+    )
+    assert provenance.main() == 1
+    manifest = json.loads((output / "twin-evidence.json").read_text())
+    validate(
+        manifest,
+        json.loads((ROOT / "provenance/twin-evidence.schema.json").read_text()),
+    )
+    assert manifest["outcome"]["result"] == "failure"
+    assert manifest["outcome"]["failure_source"] == "harness"
+
+
+def test_calibration_failure_taxonomy_and_bounds():
+    calibration = _load("calibration", ROOT / "scripts/live_calibration.py")
+    assert calibration.classify_failure(401) == "authentication"
+    assert calibration.classify_failure(429) == "quota"
+    assert calibration.classify_failure(None) == "infrastructure"
+    assert (
+        calibration.classify_observation(200, 200, "{a:string}", "{a:string}")
+        == "match"
+    )
+    assert (
+        calibration.classify_observation(200, 200, "{a:string}", "{b:string}")
+        == "provider_drift"
+    )
+    assert calibration.classify_observation(200, 500) == "twin"
+    assert calibration.classify_observation(500, 200) == "infrastructure"
+    assert calibration.classify_observation(401, 200) == "authentication"
+    assert calibration.classify_observation(429, 200) == "quota"
+    assert calibration.classify_observation(None, 200) == "infrastructure"
+    assert calibration.classify_observation(200, 200, harness_error=True) == "harness"
+    assert calibration.MAX_CALLS <= 6
+    assert calibration.REQUEST_TIMEOUT_SECONDS <= 20
+    assert calibration.MAX_RETRIES == 0
+    assert calibration.MAX_TOKENS <= 128
+    assert calibration.COST_CEILING_USD <= 1
+
+
+def test_malformed_twin_response_is_twin_failure(tmp_path, monkeypatch):
+    calibration = _load(
+        "malformed_twin_calibration", ROOT / "scripts/live_calibration.py"
+    )
+    _set_calibration_env(monkeypatch)
+    corpus = tmp_path / "corpus.json"
+    _write_calibration_corpus(corpus)
+
+    def request(url, method, headers, payload):
+        if "twin" in url:
+            return 200, {"malformed": True}
+        return 200, {"results": [{"url": "u", "title": "t", "description": "d"}]}
+
+    assert calibration.run(tmp_path / "out", corpus, request_fn=request) == 1
+    artifact = json.loads((tmp_path / "out/calibration.json").read_text())
+    assert artifact["records"][0]["result"] == "twin"
+    assert artifact["failure_source"] == "twin"
+
+
+def test_calibration_synthetic_outcomes_are_sanitized_and_bounded(
+    tmp_path, monkeypatch
+):
+    calibration = _load("calibration_run", ROOT / "scripts/live_calibration.py")
+    for key, value in {
+        "BRAVE_API_KEY": "brave-secret",
+        "LLM_API_KEY": "llm-secret",
+        "LLM_BASE_URL": "https://provider.test/v1",
+        "LLM_MODEL": "model-a",
+        "BRAVE_COST_PER_CALL_USD": "0.01",
+        "LLM_COST_PER_1K_TOKENS_USD": "0.01",
+        "CALIBRATION_PROVIDER_SEARCH_URL": "https://provider.test/search",
+        "CALIBRATION_TWIN_SEARCH_URL": "http://twin/search",
+        "CALIBRATION_PROVIDER_URL": "https://provider.test/v1/chat/completions",
+        "CALIBRATION_TWIN_LLM_URL": "http://twin/v1/chat/completions",
+    }.items():
+        monkeypatch.setenv(key, value)
+    corpus = tmp_path / "corpus.json"
+    corpus.write_text(
+        json.dumps(
+            {
+                "id": "synthetic",
+                "cases": [
+                    {"id": "s", "kind": "search", "input": "private query"},
+                    {"id": "l", "kind": "llm", "input": "private prompt"},
+                ],
+            }
+        )
+    )
+    outcomes = {
+        "search": (200, {"results": [{"url": "u", "title": "x", "content": "c"}]}),
+        "llm": (200, {"model": "model-a", "choices": []}),
+    }
+
+    def fake(url, method, headers, payload):
+        kind = "search" if "search" in url else "llm"
+        if "X-Subscription-Token" in headers:
+            assert headers["X-Subscription-Token"] == "brave-secret"
+        if kind == "llm":
+            assert headers["Authorization"] == "Bearer llm-secret"
+            assert payload["max_tokens"] == 128
+        return outcomes[kind]
+
+    assert calibration.run(tmp_path / "out", corpus, request_fn=fake) == 0
+    artifact = json.loads((tmp_path / "out/calibration.json").read_text())
+    assert [record["case_id"] for record in artifact["records"]] == ["s", "l"]
+    assert "private" not in json.dumps(artifact)
+    assert artifact["calls"] == 4
+
+    def status(status):
+        return lambda url, method, headers, payload: (status, {"error": "x"})
+
+    for status_code, expected in [
+        (401, "authentication"),
+        (429, "quota"),
+        (503, "infrastructure"),
+    ]:
+        artifact_dir = tmp_path / f"out-{status_code}"
+        assert (
+            calibration.run(artifact_dir, corpus, request_fn=status(status_code)) == 1
+        )
+        record = json.loads((artifact_dir / "calibration.json").read_text())["records"][
+            0
+        ]
+        assert record["result"] == expected
+        assert (
+            json.loads((artifact_dir / "calibration.json").read_text())[
+                "failure_source"
+            ]
+            == expected
+        )
+
+    for exception, expected in [
+        (TimeoutError(), "infrastructure"),
+        (ValueError("bad response"), "harness"),
+    ]:
+        artifact_dir = tmp_path / f"out-{expected}"
+
+        def failing_request(*args, error=exception):
+            raise error
+
+        assert calibration.run(artifact_dir, corpus, request_fn=failing_request) == 1
+        record = json.loads((artifact_dir / "calibration.json").read_text())["records"][
+            0
+        ]
+        assert record["result"] == expected
+
+
+def test_normalized_contracts_and_success_aggregation(tmp_path, monkeypatch):
+    calibration = _load("normalized_calibration", ROOT / "scripts/live_calibration.py")
+    for key, value in {
+        "BRAVE_API_KEY": "key",
+        "LLM_API_KEY": "key",
+        "LLM_BASE_URL": "https://provider.test/v1",
+        "LLM_MODEL": "requested",
+        "BRAVE_COST_PER_CALL_USD": "0",
+        "LLM_COST_PER_1K_TOKENS_USD": "0",
+        "CALIBRATION_PROVIDER_SEARCH_URL": "https://provider.test/search",
+        "CALIBRATION_TWIN_SEARCH_URL": "http://twin/search",
+        "CALIBRATION_PROVIDER_URL": "https://provider.test/chat",
+        "CALIBRATION_TWIN_LLM_URL": "http://twin/chat",
+    }.items():
+        monkeypatch.setenv(key, value)
+    corpus = tmp_path / "corpus.json"
+    corpus.write_text(
+        json.dumps(
+            {
+                "id": "c",
+                "cases": [{"id": "s", "kind": "search", "input": "secret query"}],
+            }
+        )
+    )
+
+    def request(url, method, headers, payload):
+        if "search" in url:
+            if "provider.test" in url:
+                return 200, {
+                    "web": {"results": [{"url": "u", "title": "t", "description": "d"}]}
+                }
+            return 200, {
+                "results": [{"url": "u", "title": "t", "content": "d", "engine": "x"}]
+            }
+        return 200, {
+            "model": "observed",
+            "choices": [
+                {"message": {"content": "secret response"}, "finish_reason": "stop"}
+            ],
+        }
+
+    assert calibration.run(tmp_path / "out", corpus, request_fn=request) == 0
+    artifact = json.loads((tmp_path / "out/calibration.json").read_text())
+    assert artifact["outcome"] == "success"
+    assert artifact["failure_source"] == "none"
+    assert (
+        artifact["records"][0]["provider_fingerprint"]
+        == artifact["records"][0]["twin_fingerprint"]
+    )
+    assert artifact["records"][0]["provider_latency_band"] in {"fast", "normal", "slow"}
+    assert "secret" not in json.dumps(artifact)
+
+
+def _set_calibration_env(monkeypatch, *, brave_cost="0.01", llm_cost="0.01"):
+    for key, value in {
+        "BRAVE_API_KEY": "brave-secret",
+        "LLM_API_KEY": "llm-secret",
+        "LLM_BASE_URL": "https://provider.test/v1",
+        "LLM_MODEL": "model-a",
+        "BRAVE_COST_PER_CALL_USD": brave_cost,
+        "LLM_COST_PER_1K_TOKENS_USD": llm_cost,
+        "CALIBRATION_PROVIDER_SEARCH_URL": "https://provider.test/search",
+        "CALIBRATION_TWIN_SEARCH_URL": "http://twin/search",
+        "CALIBRATION_PROVIDER_URL": "https://provider.test/chat",
+        "CALIBRATION_TWIN_LLM_URL": "http://twin/chat",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+
+def _write_calibration_corpus(path, *, include_llm=False):
+    cases = [{"id": "s", "kind": "search", "input": "private query"}]
+    if include_llm:
+        cases.append({"id": "l", "kind": "llm", "input": "private prompt"})
+    path.write_text(json.dumps({"id": "synthetic", "cases": cases}))
+
+
+def test_calibration_divergence_is_advisory_and_preserves_fixtures(
+    tmp_path, monkeypatch
+):
+    calibration = _load("divergence_calibration", ROOT / "scripts/live_calibration.py")
+    _set_calibration_env(monkeypatch)
+    corpus = tmp_path / "corpus.json"
+    _write_calibration_corpus(corpus)
+
+    def request(url, method, headers, payload):
+        if "provider.test" in url:
+            return 200, {
+                "web": {"results": [{"url": "u", "title": "t", "description": None}]}
+            }
+        return 200, {"results": [{"url": "u", "title": "t", "content": "d"}]}
+
+    assert calibration.run(tmp_path / "out", corpus, request_fn=request) == 0
+    artifact = json.loads((tmp_path / "out/calibration.json").read_text())
+    assert artifact["outcome"] == "advisory_success"
+    assert artifact["failure_source"] == "provider_drift"
+    assert artifact["records"][0]["result"] == "provider_drift"
+    assert (
+        artifact["fixture_tree_digest_before"] == artifact["fixture_tree_digest_after"]
+    )
+
+
+def test_calibration_twin_failure_is_nonzero(tmp_path, monkeypatch):
+    calibration = _load(
+        "twin_failure_calibration", ROOT / "scripts/live_calibration.py"
+    )
+    _set_calibration_env(monkeypatch)
+    corpus = tmp_path / "corpus.json"
+    _write_calibration_corpus(corpus)
+
+    def request(url, method, headers, payload):
+        if "twin" in url:
+            return 503, {"error": "fixture unavailable"}
+        return 200, {
+            "web": {"results": [{"url": "u", "title": "t", "description": "d"}]}
+        }
+
+    assert calibration.run(tmp_path / "out", corpus, request_fn=request) == 1
+    artifact = json.loads((tmp_path / "out/calibration.json").read_text())
+    assert artifact["outcome"] == "failure"
+    assert artifact["failure_source"] == "twin"
+
+
+def test_calibration_config_corpus_and_cost_fail_closed(tmp_path, monkeypatch):
+    calibration = _load("fail_closed_calibration", ROOT / "scripts/live_calibration.py")
+    corpus = tmp_path / "corpus.json"
+    _write_calibration_corpus(corpus)
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    assert (
+        calibration.run(
+            tmp_path / "missing", corpus, request_fn=lambda *args: (200, {})
+        )
+        == 1
+    )
+    missing = json.loads((tmp_path / "missing/calibration.json").read_text())
+    assert missing["outcome"] == "failure"
+    assert missing["failure_source"] == "harness"
+
+    _set_calibration_env(monkeypatch, brave_cost="2.0")
+    assert (
+        calibration.run(tmp_path / "cost", corpus, request_fn=lambda *args: (200, {}))
+        == 1
+    )
+    cost = json.loads((tmp_path / "cost/calibration.json").read_text())
+    assert cost["outcome"] == "failure"
+    assert cost["failure_source"] == "harness"
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"id": "bad", "cases": []}))
+    assert (
+        calibration.run(
+            tmp_path / "corpus", invalid, request_fn=lambda *args: (200, {})
+        )
+        == 1
+    )
+    assert (
+        json.loads((tmp_path / "corpus/calibration.json").read_text())["failure_source"]
+        == "harness"
+    )
+
+    token_corpus = tmp_path / "token-corpus.json"
+    token_corpus.write_text(
+        json.dumps(
+            {
+                "id": "too-many-tokens",
+                "cases": [
+                    {"id": f"l{index}", "kind": "llm", "input": "bounded"}
+                    for index in range(3)
+                ],
+            }
+        )
+    )
+    _set_calibration_env(monkeypatch)
+    assert (
+        calibration.run(
+            tmp_path / "tokens", token_corpus, request_fn=lambda *args: (200, {})
+        )
+        == 1
+    )
+    assert (
+        json.loads((tmp_path / "tokens/calibration.json").read_text())["failure_source"]
+        == "harness"
+    )
+
+
+def test_calibration_artifact_has_bounded_fingerprints_latency_and_identity(
+    tmp_path, monkeypatch
+):
+    calibration = _load("identity_calibration", ROOT / "scripts/live_calibration.py")
+    _set_calibration_env(monkeypatch)
+    corpus = tmp_path / "corpus.json"
+    _write_calibration_corpus(corpus, include_llm=True)
+
+    def request(url, method, headers, payload):
+        if "search" in url:
+            if "provider.test" in url:
+                return 200, {
+                    "web": {"results": [{"url": "u", "title": "t", "description": "d"}]}
+                }
+            return 200, {"results": [{"url": "u", "title": "t", "content": "d"}]}
+        return 200, {
+            "provider": "vendor-a",
+            "model": "model-a",
+            "choices": [
+                {"message": {"content": "private response"}, "finish_reason": "stop"}
+            ],
+        }
+
+    assert calibration.run(tmp_path / "out", corpus, request_fn=request) == 0
+    artifact = json.loads((tmp_path / "out/calibration.json").read_text())
+    assert artifact["calls"] == 4 <= calibration.MAX_CALLS
+    assert artifact["limits"]["max_tokens"] <= 128
+    assert artifact["limits"]["max_total_tokens"] <= 512
+    assert artifact["bounds"]["estimated_live_provider_cost_usd"] <= 1
+    assert artifact["identity"]["observed"] == {
+        "search_provider": "brave-search-api",
+        "llm_provider": "vendor-a",
+        "model": "model-a",
+    }
+    for record in artifact["records"]:
+        for target in ("provider", "twin"):
+            assert len(record[f"{target}_fingerprint"]) == 64
+            assert record[f"{target}_latency_band"] in {"fast", "normal", "slow"}
+    serialized = json.dumps(artifact)
+    assert "private query" not in serialized
+    assert "private prompt" not in serialized
+    assert "private response" not in serialized
+    assert "brave-secret" not in serialized
+    assert "llm-secret" not in serialized

--- a/tests/service/test_twin_contract.py
+++ b/tests/service/test_twin_contract.py
@@ -335,6 +335,83 @@ def test_missing_live_calibration_writes_valid_failure_manifest(tmp_path, monkey
     assert manifest["outcome"]["failure_source"] == "harness"
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "schema_version": "live-calibration-v2",
+            "outcome": "failure",
+            "failure_source": "harness",
+            "records": [],
+        },
+        {
+            "schema_version": "live-calibration-v2",
+            "outcome": "success",
+            "failure_source": "none",
+            "corpus": {"id": "live-v2", "digest": "1" * 64},
+            "identity": {
+                "requested": {"provider": "provider", "model": "model"},
+                "observed": {
+                    "search_provider": "search",
+                    "llm_provider": "llm",
+                    "model": "model",
+                },
+            },
+            "bounds": {
+                "estimated_max_cost_usd": 0.1,
+                "estimated_live_provider_cost_usd": 0.1,
+                "cost_ceiling_usd": 1.0,
+                "expected_calls": 2,
+            },
+            "limits": {
+                "timeout_seconds": 20,
+                "max_calls": 6,
+                "max_tokens": 128,
+                "max_total_tokens": 512,
+            },
+            "records": [{}],
+        },
+    ],
+)
+def test_incomplete_live_calibration_writes_valid_failure_manifest(
+    tmp_path, monkeypatch, payload
+):
+    provenance = _load(
+        "incomplete_live_provenance", ROOT / "scripts/twin_provenance.py"
+    )
+    artifact = tmp_path / "incomplete.json"
+    artifact.write_text(json.dumps(payload))
+    output = tmp_path / "aggregate"
+    monkeypatch.setenv("TWIN_EXECUTION_MODE", "live")
+    monkeypatch.setenv("TWIN_SELECTION", "all")
+    monkeypatch.setenv("TWIN_TESTS", json.dumps(["scripts/live_calibration.py"]))
+    monkeypatch.setenv(
+        "TWIN_CHECKS",
+        "scenario-version-precheck,manifest-validation,fixture-immutability-check",
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "twin_provenance",
+            "--output",
+            str(output),
+            "--calibration-artifact",
+            str(artifact),
+        ],
+    )
+    assert provenance.main() == 1
+    manifest = json.loads((output / "twin-evidence.json").read_text())
+    validate(
+        manifest,
+        json.loads((ROOT / "provenance/twin-evidence.schema.json").read_text()),
+    )
+    assert manifest["outcome"]["result"] == "failure"
+    assert manifest["outcome"]["failure_source"] == "harness"
+    assert manifest["outcome"]["failure_detail"] == (
+        "missing or invalid calibration artifact"
+    )
+
+
 def test_calibration_failure_taxonomy_and_bounds():
     calibration = _load("calibration", ROOT / "scripts/live_calibration.py")
     assert calibration.classify_failure(401) == "authentication"

--- a/tests/service/test_twin_network_isolation.py
+++ b/tests/service/test_twin_network_isolation.py
@@ -6,7 +6,6 @@ import os
 import socket
 
 import pytest
-from pytest_socket import SocketConnectBlockedError
 
 
 def test_hosted_socket_guard_blocks_non_loopback():
@@ -14,5 +13,7 @@ def test_hosted_socket_guard_blocks_non_loopback():
         return
     with socket.socket() as sock:
         sock.settimeout(0.01)
-        with pytest.raises(SocketConnectBlockedError):
+        with pytest.raises(RuntimeError) as raised:
             sock.connect(("192.0.2.1", 9))
+    assert type(raised.value).__module__ == "pytest_socket"
+    assert type(raised.value).__name__ == "SocketConnectBlockedError"

--- a/tests/service/test_twin_network_isolation.py
+++ b/tests/service/test_twin_network_isolation.py
@@ -1,0 +1,18 @@
+"""The hosted twin lane must reject non-loopback sockets."""
+
+from __future__ import annotations
+
+import os
+import socket
+
+import pytest
+from pytest_socket import SocketConnectBlockedError
+
+
+def test_hosted_socket_guard_blocks_non_loopback():
+    if os.environ.get("TWIN_SOCKET_GUARD") != "1":
+        return
+    with socket.socket() as sock:
+        sock.settimeout(0.01)
+        with pytest.raises(SocketConnectBlockedError):
+            sock.connect(("192.0.2.1", 9))

--- a/tests/service/test_workflow_contract.py
+++ b/tests/service/test_workflow_contract.py
@@ -108,7 +108,9 @@ def test_compose_run_id_and_failure_provenance_are_unambiguous():
     docker = yaml.safe_load(workflow)
     assert "${LLM_BASE_URL:-http://llm-svc:8011/v1?run_id=${" not in compose
     assert "LLM_BASE_URL=${LLM_BASE_URL:-http://llm-svc:8011/v1}" in compose
-    assert "LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-}" in compose
+    assert "TWIN_RUN_ID=${TWIN_RUN_ID:-local}" in compose
+    assert "LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-local}" in compose
+    assert "LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-}" not in compose
     compose_evidence = workflow.split(
         "- name: Write Compose twin evidence manifest", 1
     )[1]

--- a/tests/service/test_workflow_contract.py
+++ b/tests/service/test_workflow_contract.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import yaml
+
 
 def test_docker_workflow_captures_and_uploads_sanitized_fixture_diagnostics():
     workflow = (Path(__file__).parents[2] / ".github/workflows/docker.yml").read_text()
@@ -10,3 +12,118 @@ def test_docker_workflow_captures_and_uploads_sanitized_fixture_diagnostics():
     assert "Upload LLM fixture diagnostics" in workflow
     assert '"prompt"' not in workflow
     assert '"context"' not in workflow
+
+
+def test_hosted_twin_lane_is_bounded_hermetic_and_secret_free():
+    workflow = (Path(__file__).parents[2] / ".github/workflows/docker.yml").read_text()
+    hosted = workflow.split("  twin-contracts:\n", 1)[1].split(
+        "\n  build-and-push:", 1
+    )[0]
+    assert "runs-on: ubuntu-latest" in hosted
+    assert "timeout-minutes: 5" in hosted
+    assert "permissions:\n      contents: read" in hosted
+    assert "HTTP_PROXY: http://127.0.0.1:9" in hosted
+    assert "NO_PROXY: localhost,127.0.0.1,::1" in hosted
+    assert "${{ secrets." not in hosted
+    assert "actions/upload-artifact" in hosted
+    assert "twin-evidence.json" in hosted
+    assert "scenario" in hosted and "parity" in hosted
+
+
+def test_runtime_gate_depends_on_hosted_twin_without_renaming_required_check():
+    workflow = (Path(__file__).parents[2] / ".github/workflows/docker.yml").read_text()
+    runtime = workflow.split("  runtime-gate:\n", 1)[1]
+    assert "name: Runtime Gate" in runtime
+    assert "needs: [changes, twin-contracts, integration-tests]" in runtime
+    assert "Fail when required twin validation fails" in runtime
+
+
+def test_calibration_is_trusted_only_and_does_not_rewrite_fixtures():
+    workflow = (
+        Path(__file__).parents[2] / ".github/workflows/live-calibration.yml"
+    ).read_text()
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "pull_request" not in workflow
+    assert "pull_request_target" not in workflow
+    assert "github.repository == 'groktopus/groktocrawl'" in workflow
+    assert "github.ref == 'refs/heads/main'" in workflow
+    assert "persist-credentials: false" in workflow
+    assert "environment: live-calibration" in workflow
+    assert "git diff --exit-code -- llm-svc slopsearx-fixture provenance" in workflow
+    assert "BRAVE_API_KEY" in workflow and "LLM_API_KEY" in workflow
+
+
+def test_required_twin_images_are_immutable():
+    root = Path(__file__).parents[2]
+    compose = (root / "docker-compose.yml").read_text()
+    assert (
+        compose.count(
+            "ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d"
+        )
+        == 2
+    )
+    assert "slopsearx:latest" not in compose
+    for dockerfile in (
+        root / "llm-svc/Dockerfile",
+        root / "slopsearx-fixture/Dockerfile",
+    ):
+        assert (
+            "python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a"
+            in dockerfile.read_text()
+        )
+
+
+def test_workflows_have_structured_trusted_and_hosted_contracts():
+    root = Path(__file__).parents[2]
+    live = yaml.safe_load((root / ".github/workflows/live-calibration.yml").read_text())
+    docker = yaml.safe_load((root / ".github/workflows/docker.yml").read_text())
+    assert set(live["jobs"]) == {"calibrate"}
+    assert live["jobs"]["calibrate"]["timeout-minutes"] == 10
+    triggers = live.get("on", live.get(True))
+    assert "schedule" in triggers and "workflow_dispatch" in triggers
+    assert "pull_request" not in triggers
+    assert live["jobs"]["calibrate"]["if"] == (
+        "github.repository == 'groktopus/groktocrawl' && github.ref == 'refs/heads/main'"
+    )
+    assert docker["jobs"]["twin-contracts"]["runs-on"] == "ubuntu-latest"
+    assert docker["jobs"]["integration-tests"]["runs-on"] == [
+        "self-hosted",
+        "groktopus",
+        "docker",
+    ]
+    assert "secrets." not in repr(docker["jobs"]["twin-contracts"])
+    twin_run = repr(docker["jobs"]["twin-contracts"])
+    assert (
+        "setup-uv" in twin_run
+        and "uv sync --locked --no-dev --group fast-tests" in twin_run
+    )
+    assert "twin-out" in twin_run and "junitxml" in twin_run
+
+
+def test_compose_run_id_and_failure_provenance_are_unambiguous():
+    root = Path(__file__).parents[2]
+    compose = (root / "docker-compose.yml").read_text()
+    workflow = (root / ".github/workflows/docker.yml").read_text()
+    assert "${LLM_BASE_URL:-http://llm-svc:8011/v1?run_id=${" not in compose
+    assert "LLM_BASE_URL=${LLM_BASE_URL:-http://llm-svc:8011/v1}" in compose
+    assert "LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-}" in compose
+    compose_evidence = workflow.split(
+        "- name: Write Compose twin evidence manifest", 1
+    )[1]
+    assert (
+        "TWIN_FAILURE_SOURCE: ${{ job.status == 'success' && 'none' || 'implementation' }}"
+        in compose_evidence
+    )
+    assert "TWIN_TEST_OUTCOME: ${{ job.status }}" in compose_evidence
+    assert "uv run --no-sync python scripts/twin_provenance.py" in compose_evidence
+    assert (
+        "TWIN_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}"
+        in compose_evidence
+    )
+    assert (
+        "TWIN_BUILT_FROM_CHECKOUT: llm-svc,slopsearx-fixture,agent-svc-fixture,test-site,tier3-fixture"
+        in compose_evidence
+    )
+    assert "tests/integration/test_twin_failure_injection.py" in compose_evidence
+    assert "tests/service/test_twin_failure_injection.py" not in compose_evidence

--- a/tests/service/test_workflow_contract.py
+++ b/tests/service/test_workflow_contract.py
@@ -105,6 +105,7 @@ def test_compose_run_id_and_failure_provenance_are_unambiguous():
     root = Path(__file__).parents[2]
     compose = (root / "docker-compose.yml").read_text()
     workflow = (root / ".github/workflows/docker.yml").read_text()
+    docker = yaml.safe_load(workflow)
     assert "${LLM_BASE_URL:-http://llm-svc:8011/v1?run_id=${" not in compose
     assert "LLM_BASE_URL=${LLM_BASE_URL:-http://llm-svc:8011/v1}" in compose
     assert "LLM_BASE_URL=http://llm-svc:8011/v1?run_id=${TWIN_RUN_ID:-}" in compose
@@ -127,3 +128,11 @@ def test_compose_run_id_and_failure_provenance_are_unambiguous():
     )
     assert "tests/integration/test_twin_failure_injection.py" in compose_evidence
     assert "tests/service/test_twin_failure_injection.py" not in compose_evidence
+    for host_only in (
+        "tests/service/test_twin_contract.py",
+        "tests/service/test_twin_network_isolation.py",
+        "tests/service/test_workflow_contract.py",
+    ):
+        assert f"--ignore=/app/{host_only}" in workflow
+        assert host_only in compose_evidence
+        assert host_only in repr(docker["jobs"]["twin-contracts"])

--- a/tests/unit/test_slopsearx_mcp_compose.py
+++ b/tests/unit/test_slopsearx_mcp_compose.py
@@ -43,7 +43,9 @@ def test_direct_slopsearx_mcp_is_opt_in_and_uses_shared_wiring():
     service = COMPOSE["services"]["slopsearx-mcp"]
     environment = _environment(service)
 
-    assert service["image"] == "ghcr.io/magnus919/slopsearx:latest"
+    assert service["image"] == (
+        "ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d"
+    )
     # Gated behind a profile so a no-config `docker compose up` does not start
     # the companion; it runs only when the `mcp` profile is enabled.
     assert service["profiles"] == ["mcp"]
@@ -91,7 +93,7 @@ def test_direct_slopsearx_mcp_grants_default_on_and_allow_opt_out():
     )
 
     assert {_resolve(environment[name], {}) for name in grant_names} == {"1"}
-    disabled: dict[str, str] = {name: "0" for name in grant_names}  # noqa: C420
+    disabled: dict[str, str] = dict.fromkeys(grant_names, "0")
     assert {_resolve(environment[name], disabled) for name in grant_names} == {"0"}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -844,6 +844,7 @@ fast-tests = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-socket" },
     { name = "pytest-xdist" },
     { name = "python-docx" },
     { name = "python-multipart" },
@@ -898,6 +899,7 @@ fast-tests = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-docx", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -2066,6 +2068,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-socket"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/ce/4ef7b049852c95a8727b4a7e6496f762df1ac0b47bc0320d10293f5e95ec/pytest_socket-0.8.1.tar.gz", hash = "sha256:2f57787914ad2e1308d09ce141b95c3e55741fbb4fb7b7556593a6b063e0c9c7", size = 17313, upload-time = "2026-08-19T15:16:25.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/ef/ab507f117b3d19b54e3c9c632a99c28c3b284562ec6e02e274581d530d92/pytest_socket-0.8.1-py3-none-any.whl", hash = "sha256:f9846bed1dcd96eed459e5e14795bbaf96715cf4e827891fe70773817ecb8ed4", size = 8751, upload-time = "2026-08-19T15:16:24.426Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds explicit dependency-twin CI tiers without introducing a second orchestration system:

- a hosted, credential-free `Twin Contracts` lane for deterministic search and LLM contracts;
- run-scoped twin evidence in the existing self-hosted Compose integration lane;
- a separate trusted scheduled/manual live-calibration workflow that treats provider divergence as advisory evidence and never rewrites fixtures.

The change also pins required twin images, records exact provenance, and extends conservative change classification so fork PRs receive hosted contract coverage without access to secrets or self-hosted runners.

Closes #571.

## Trust and authority boundaries

- Hosted PR twin tests reference no provider secrets and deny non-loopback HTTP(S) egress during test execution.
- Fork pull requests cannot select the self-hosted Compose lane or live calibration.
- Live calibration runs only on canonical protected `main`, with `contents: read`, checkout credentials disabled, bounded calls/time/tokens/configured cost estimate, and artifact-only output.
- Provider divergence is advisory success. Authentication, quota, twin, infrastructure, and harness failures remain distinct failed outcomes.
- Live evidence cannot update deterministic fixture or scenario sources.

## Provenance

The versioned aggregate manifest records:

- checked-out commit, event, and ref;
- exact changed paths and selected twin test files;
- corpus ID and digest;
- actual source-derived search/LLM schema and fixture versions;
- requested and observed provider/model identity;
- exact local image IDs and RepoDigests when available;
- timeout/call/token/cost bounds;
- result, test outcome, and failure source.

## Verification

- [x] Strict provenance/workflow/classifier suite: 72 passed + 27 subtests.
- [x] Hosted `all` lane under pytest-socket: 58 selected contracts + 18 provenance/isolation contracts passed.
- [x] Full Docker-free unit/service suite: 1,658 passed.
- [x] Changed-file Ruff and formatting passed.
- [x] Mypy passed for new/changed Python surfaces.
- [x] Lockfile and documentation inventory passed.
- [x] All workflow YAML parsed.
- [x] Changed-path shell syntax and embedded Python probe contracts passed.
- [x] Candidate tracked/untracked Gitleaks stream found no leaks.
- [x] Independent frozen-candidate review passed.
- [ ] Self-hosted Docker Integration Tests and Runtime Gate pass at exact PR head.

## AI assistance

Implemented with OpenCode under Jasper’s orchestration. Jasper independently audited and remediated calibration semantics, workflow syntax, run isolation, provenance failure handling, normalized fingerprints, aggregate outcomes, identity preservation, and missing run-level tests before submission.

Submitted by Jasper (AI agent on behalf of Magnus Hedemark).
