### PR TITLE
fix(compose): delegate slopsearx-mcp grant defaults to upstream secure policy

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -267,18 +267,18 @@
 # SLOPSEARX_MCP_AUTH_TOKEN=
 # SLOPSEARX_MCP_PORT=8007
 #
-# Specialist grants default to enabled. Set any one to 0 to remove that group
-# of direct SlopSearX MCP tools; grants neither create provider credentials nor
-# enable search providers that lack their required configuration.
+# Specialist grants are DISABLED by default (secure-by-default, inherited from
+# the SlopSearX image). Opt in per group; grants neither create provider
+# credentials nor enable search providers that lack their required
+# configuration.
 # MCP_GRANT_JOBS=1
 # MCP_GRANT_SCIENCE=1
 # MCP_GRANT_RESEARCH=1
 # MCP_GRANT_SECURITY=1
 # MCP_TARGETED_SENSITIVE_ALLOWED=1
 #
-# Safe opt-out examples:
-# MCP_GRANT_SECURITY=0
-# MCP_TARGETED_SENSITIVE_ALLOWED=0
+# Targeted sensitive engines (hibp, dehashed) stay unreachable unless
+# MCP_TARGETED_SENSITIVE_ALLOWED=1; leave it unset unless you need them.
 
 # CLI rate-limit retry policy (ADR-0053). Read directly by the `groktocrawl`
 # CLI for `answer`, `agent`, and `crawl` requests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,15 @@ services:
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8000
       - MCP_AUTH_TOKEN=${SLOPSEARX_MCP_AUTH_TOKEN:-}
-      - MCP_GRANT_JOBS=${MCP_GRANT_JOBS:-1}
-      - MCP_GRANT_SCIENCE=${MCP_GRANT_SCIENCE:-1}
-      - MCP_GRANT_RESEARCH=${MCP_GRANT_RESEARCH:-1}
-      - MCP_GRANT_SECURITY=${MCP_GRANT_SECURITY:-1}
-      - MCP_TARGETED_SENSITIVE_ALLOWED=${MCP_TARGETED_SENSITIVE_ALLOWED:-1}
+      # Grants delegate defaults to the SlopSearX image, which is secure by
+      # default: specialist grants and targeted sensitive-engine access stay
+      # off until explicitly enabled. Set values in .env to opt in, e.g.
+      # MCP_GRANT_SECURITY=1. An empty value means "no override" upstream.
+      - MCP_GRANT_JOBS=${MCP_GRANT_JOBS:-}
+      - MCP_GRANT_SCIENCE=${MCP_GRANT_SCIENCE:-}
+      - MCP_GRANT_RESEARCH=${MCP_GRANT_RESEARCH:-}
+      - MCP_GRANT_SECURITY=${MCP_GRANT_SECURITY:-}
+      - MCP_TARGETED_SENSITIVE_ALLOWED=${MCP_TARGETED_SENSITIVE_ALLOWED:-}
     depends_on:
       valkey:
         condition: service_healthy

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -40,12 +40,14 @@ port is `SLOPSEARX_MCP_PORT` (default `8007`). The companion shares the normal
 Brave credential and Valkey service wiring, but no grant creates credentials or
 bypasses HTTP MCP authentication.
 
-All grants default to `1`: `MCP_GRANT_JOBS` controls jobs tools,
+All grants default to disabled (secure-by-default, inherited from the
+SlopSearX image): `MCP_GRANT_JOBS` enables jobs tools,
 `MCP_GRANT_SCIENCE` science tools, `MCP_GRANT_RESEARCH` research tools,
 `MCP_GRANT_SECURITY` security tools, and
-`MCP_TARGETED_SENSITIVE_ALLOWED` targeted sensitive-engine selection. Disable
-only the capability group you do not want, for example
-`MCP_GRANT_SECURITY=0` or `MCP_TARGETED_SENSITIVE_ALLOWED=0` in `.env`.
+`MCP_TARGETED_SENSITIVE_ALLOWED` targeted sensitive-engine selection
+(`hibp`, `dehashed`). Opt in per capability group in `.env`, for example
+`MCP_GRANT_SECURITY=1`; leave `MCP_TARGETED_SENSITIVE_ALLOWED` unset unless
+sensitive-engine queries are explicitly wanted.
 
 The service healthcheck sends a bounded, authenticated MCP `initialize`
 request to its local Streamable HTTP endpoint. It verifies MCP protocol

--- a/tests/unit/test_slopsearx_mcp_compose.py
+++ b/tests/unit/test_slopsearx_mcp_compose.py
@@ -82,7 +82,7 @@ def test_direct_slopsearx_mcp_refuses_to_start_without_token():
     assert "exec python -m slopsearx.mcp" in script
 
 
-def test_direct_slopsearx_mcp_grants_default_on_and_allow_opt_out():
+def test_direct_slopsearx_mcp_grants_delegate_defaults_upstream():
     environment = _environment(COMPOSE["services"]["slopsearx-mcp"])
     grant_names = (
         "MCP_GRANT_JOBS",
@@ -92,7 +92,12 @@ def test_direct_slopsearx_mcp_grants_default_on_and_allow_opt_out():
         "MCP_TARGETED_SENSITIVE_ALLOWED",
     )
 
-    assert {_resolve(environment[name], {}) for name in grant_names} == {"1"}
+    # Compose expresses no default: an unset grant interpolates to an empty
+    # value, which the SlopSearX image parses as "no override", leaving its
+    # secure-by-default policy (all grants off) in force.
+    assert {_resolve(environment[name], {}) for name in grant_names} == {""}
+    enabled: dict[str, str] = dict.fromkeys(grant_names, "1")
+    assert {_resolve(environment[name], enabled) for name in grant_names} == {"1"}
     disabled: dict[str, str] = dict.fromkeys(grant_names, "0")
     assert {_resolve(environment[name], disabled) for name in grant_names} == {"0"}
 


### PR DESCRIPTION
Fixes #578. Context: magnus919/SlopSearX#197.

## Problem

`slopsearx-mcp` passed all five grant variables with default-on fallbacks (`${MCP_GRANT_*:-1}`, `${MCP_TARGETED_SENSITIVE_ALLOWED:-1}`). Any deployment enabling the `mcp` profile without an explicit `.env` silently granted every specialist tool **and** targeted sensitive-engine access (`hibp`, `dehashed`) — overriding SlopSearX's secure-by-default posture instead of inheriting it.

## Change

- `docker-compose.yml`: grant fallbacks `:1` → `` `:-` `` (empty). The image parses an unset grant as "no override", leaving upstream's secure defaults (all grants off, pinned by `TestMCPPolicy::test_defaults_are_secure`) in force. Explicit `1`/`0` in `.env` pass through unchanged.
- `.env.sample` + `docs/guides/deployment.md`: documented as opt-in, sensitive engines called out as leave-unset-unless-needed.
- `tests/unit/test_slopsearx_mcp_compose.py`: contract test rewritten — unset → empty (no default opinion), explicit `1`/`0` still pass through.

## Verification

- `uv run --no-sync pytest tests/unit/test_slopsearx_mcp_compose.py`: **5/5 passed** at commit 45b1492.
- Full `tests/unit/ tests/service/` under CI-matching flags: 1406 passed; the 8 collection-error modules fail identically on **clean HEAD** in this macOS environment (missing service deps) — pre-existing, unrelated to this diff.
- pre-commit (ruff, ruff format, yaml, gitleaks, …): all passed at commit time.

## Deployment impact

hal2000's production stack sets these variables explicitly (specialist grants on, `MCP_TARGETED_SENSITIVE_ALLOWED=0`) and is unaffected. Fresh profile-enabled deployments now start with zero grants until opted in — that is the intended behavior change.