### PR TITLE
fix: make LLM call timeout configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,6 +43,12 @@
 # models. These models ignore enable_thinking:false at the top-level body but
 # honor it inside chat_template_kwargs. Only set when using llama.cpp server.
 # LLM_LLAMA_CPP_DISABLE_THINKING=false
+# Per-operation idle timeout (seconds) for LLM API calls (default: 120).
+# This bounds inactivity (connect/read/write gaps), not total request time:
+# a streaming response may legally run longer as long as tokens keep
+# arriving. Raise it (e.g. 300) when pointing LLM_MODEL at reasoning models,
+# whose long thinking pauses between tokens can exceed the default.
+# LLM_CALL_TIMEOUT=120
 
 # Internal service URLs (override only if running services separately)
 # VALKEY_URL=redis://valkey:6379/0

--- a/agent-svc/agent/llm.py
+++ b/agent-svc/agent/llm.py
@@ -83,7 +83,7 @@ class LLMClient:
         self.api_key = api_key
         self.model = model
         self._admission = admission if admission is not None else get_admission()
-        self._client = httpx.AsyncClient(timeout=120)
+        self._client = httpx.AsyncClient(timeout=load_settings().llm_call_timeout)
 
     def _completion_url(self) -> str:
         """Append the endpoint while preserving optional fixture query params."""
@@ -200,7 +200,9 @@ class LLMClient:
         outcome = "success"
         started = time.monotonic()
         try:
-            async with httpx.AsyncClient(timeout=120) as client:
+            async with httpx.AsyncClient(
+                timeout=load_settings().llm_call_timeout
+            ) as client:
                 async with client.stream(
                     "POST",
                     self._completion_url(),
@@ -289,7 +291,9 @@ class LLMClient:
             raise
         except Exception as e:
             outcome = "error"
-            logger.error("LLM stream call failed: %s", e)
+            # str(e) can be empty (e.g. httpx read timeouts); always log the
+            # exception type name so failures stay diagnosable.
+            logger.error("LLM stream call failed (%s): %s", type(e).__name__, e)
             yield {
                 "type": "error",
                 "classification": "non_retryable",
@@ -426,7 +430,9 @@ class LLMClient:
             raise ProviderOutputError(detail="LLM provider transport failed") from exc
         except Exception as e:
             outcome = "error"
-            logger.error("LLM call failed: %s", e)
+            # str(e) can be empty (e.g. httpx read timeouts); always log the
+            # exception type name so failures stay diagnosable.
+            logger.error("LLM call failed (%s): %s", type(e).__name__, e)
             return f"Error: LLM call failed: {e}"
         finally:
             observe_elapsed(

--- a/agent-svc/agent/settings.py
+++ b/agent-svc/agent/settings.py
@@ -23,6 +23,13 @@ class AgentSettings(BaseModel):
     llm_llama_cpp_disable_thinking: bool = Field(
         default=False, alias="LLM_LLAMA_CPP_DISABLE_THINKING"
     )
+    # Per-operation idle bound (seconds) applied to LLM API calls: an httpx
+    # scalar timeout bounds connect/read/write inactivity individually, with
+    # no whole-request deadline, so streaming responses may legally run
+    # longer than this as long as tokens keep arriving. Raise it (e.g. 300)
+    # when pointing LLM_MODEL at reasoning models whose long thinking
+    # pauses exceed the default.
+    llm_call_timeout: float = Field(default=120.0, alias="LLM_CALL_TIMEOUT", gt=0)
     api_key: str = Field(default="", alias="API_KEY")
     webhook_secret: str = Field(default="", alias="WEBHOOK_SECRET")
     max_searches_per_request: int = Field(

--- a/docs/reference/public-surface.md
+++ b/docs/reference/public-surface.md
@@ -155,6 +155,7 @@ The configuration inventory follows `.env.sample`; unlisted implementation-only 
 - JOB_RETRY_MAX_WAIT_SECONDS
 - LLM_API_KEY
 - LLM_BASE_URL
+- LLM_CALL_TIMEOUT
 - LLM_ENABLE_THINKING
 - LLM_LLAMA_CPP_DISABLE_THINKING
 - LLM_MODEL

--- a/tests/service/test_llm.py
+++ b/tests/service/test_llm.py
@@ -8,6 +8,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+import pytest_asyncio
 from agent.settings import load_settings
 
 
@@ -845,7 +846,7 @@ async def _start_raw_sse_fixture():
     raise AssertionError("raw-SSE fixture did not become healthy")
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def raw_sse():
     handle, server, task = await _start_raw_sse_fixture()
     try:
@@ -856,9 +857,14 @@ async def raw_sse():
 
 
 def _make_slow_fixture(delay_ms: int):
-    """Build a fixture-url factory honoring ?delay_ms= (max 2000)."""
+    """Build a fixture-url factory honoring ?delay_ms= (max 2000).
 
-    @pytest.fixture
+    Uses ``pytest_asyncio.fixture`` (like test_llm_tcp_contract.py) so the
+    async generator fixture works under BOTH asyncio_mode=auto (local
+    pyproject) and the strict default mode inside the CI agent container.
+    """
+
+    @pytest_asyncio.fixture
     async def url():
         with socket.socket() as probe:
             probe.bind(("127.0.0.1", 0))

--- a/tests/service/test_llm.py
+++ b/tests/service/test_llm.py
@@ -550,3 +550,773 @@ async def test_llama_cpp_disable_thinking_stream():
                 assert body.get("chat_template_kwargs") == {"enable_thinking": False}
     finally:
         load_settings.cache_clear()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #589 — configurable LLM call timeout (LLM_CALL_TIMEOUT)
+#
+# Contract under test:
+#   * AgentSettings.llm_call_timeout (alias LLM_CALL_TIMEOUT, float, default 120.0).
+#   * Both LLM httpx.AsyncClient construction sites honor the setting
+#     (persistent client in __init__, per-call client in the schema-less
+#     generate_stream path); the check_health probe stays at its deliberate 5s.
+#   * Unset env preserves today's behavior exactly (120s / 5s envelopes).
+#   * Timeout failures log type(exc).__name__ so empty-str exceptions
+#     (httpx read timeouts) stay diagnosable.
+#
+# Time semantics: an httpx scalar timeout=T bounds per-operation idleness
+# (connect/read/write), NOT whole-request duration. Tests use scaled-down
+# REAL delays against real sockets/servers — never virtual-clock mocking,
+# which httpx's timeout machinery cannot see.
+# ─────────────────────────────────────────────────────────────────────────────
+
+import asyncio
+import json as _json
+import logging
+import socket
+import time as _time
+from pathlib import Path
+
+import httpx
+import uvicorn
+from agent.exceptions import ProviderOutputError
+from agent.settings import AgentSettings
+from llm_svc.app import create_app
+from pydantic import ValidationError
+
+
+class TestLLMCallTimeoutSetting:
+    """Settings-field wiring: alias, float coercion, validation (VAL-LLM-013)."""
+
+    def test_settings_default_is_120_when_unset(self, monkeypatch):
+        monkeypatch.delenv("LLM_CALL_TIMEOUT", raising=False)
+        load_settings.cache_clear()
+        try:
+            settings = load_settings()
+            assert settings.llm_call_timeout == 120.0
+            assert isinstance(settings.llm_call_timeout, float)
+
+            direct = AgentSettings()
+            assert direct.llm_call_timeout == 120.0
+            assert isinstance(direct.llm_call_timeout, float)
+        finally:
+            load_settings.cache_clear()
+
+    def test_settings_env_flows_with_float_coercion(self, monkeypatch):
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "300")
+        load_settings.cache_clear()
+        try:
+            settings = load_settings()
+            assert settings.llm_call_timeout == 300.0
+            assert isinstance(settings.llm_call_timeout, float)
+
+            direct = AgentSettings.model_validate(dict(os.environ))
+            assert direct.llm_call_timeout == 300.0
+        finally:
+            load_settings.cache_clear()
+
+    def test_settings_invalid_value_raises_validation_error(self, monkeypatch):
+        """Malformed values must fail loudly, not silently fall back."""
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "abc")
+        load_settings.cache_clear()
+        try:
+            with pytest.raises(ValidationError):
+                AgentSettings.model_validate(dict(os.environ))
+        finally:
+            load_settings.cache_clear()
+
+
+class _CapturedAsyncClient(httpx.AsyncClient):
+    """Real httpx.AsyncClient that records constructor kwargs."""
+
+    last_init_kwargs: dict | None = None
+
+    def __init__(self, **kwargs):
+        type(self).last_init_kwargs = dict(kwargs)
+        super().__init__(**kwargs)
+
+
+def _capture_async_client_kwargs():
+    """Patch httpx.AsyncClient with a recording-but-real subclass."""
+    return patch("httpx.AsyncClient", _CapturedAsyncClient)
+
+
+async def _drain_schemaless_stream(client) -> list[dict]:
+    """Drive the schema-less generate_stream path against a dead endpoint."""
+    return [
+        event
+        async for event in client.generate_stream(system_prompt="x", user_prompt="y")
+    ]
+
+
+class TestLLMClientTimeoutWiring:
+    """LLM_CALL_TIMEOUT reaches both AsyncClient construction sites."""
+
+    @pytest.mark.asyncio
+    async def test_unset_env_defaults_to_120_at_both_sites(self, monkeypatch):
+        """VAL-LLM-002: unset env → exactly today's 120s at both sites."""
+        monkeypatch.delenv("LLM_CALL_TIMEOUT", raising=False)
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            with _capture_async_client_kwargs():
+                client = LLMClient(base_url="http://127.0.0.1:9/v1", model="test-model")
+            init_kwargs = dict(_CapturedAsyncClient.last_init_kwargs)
+            assert _effective_timeout_seconds(client._client.timeout) == 120.0
+
+            with _capture_async_client_kwargs():
+                # The schema-less stream path yields an error event on
+                # transport failure; the construction site is still reached.
+                events = await asyncio.wait_for(
+                    _drain_schemaless_stream(client), timeout=10
+                )
+            assert events and events[-1]["type"] == "error"
+            stream_kwargs = dict(_CapturedAsyncClient.last_init_kwargs)
+
+            assert init_kwargs.get("timeout") == 120
+            assert stream_kwargs.get("timeout") == 120
+            assert float(client._client.timeout.connect) == 120.0
+            assert float(client._client.timeout.read) == 120.0
+
+            await client.close()
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_env_flows_into_init_client(self, monkeypatch):
+        """VAL-LLM-003: LLM_CALL_TIMEOUT=300 → persistent client timeout 300."""
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "300")
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            with _capture_async_client_kwargs():
+                client = LLMClient(base_url="http://127.0.0.1:9/v1", model="test-model")
+            assert _effective_timeout_seconds(client._client.timeout) == 300.0
+            assert _CapturedAsyncClient.last_init_kwargs.get("timeout") == 300
+            await client.close()
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_env_flows_into_generate_stream_client(self, monkeypatch):
+        """VAL-LLM-004: schema-less stream path builds its client at 300 too."""
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "300")
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            client = LLMClient(base_url="http://127.0.0.1:9/v1", model="test-model")
+            with _capture_async_client_kwargs():
+                events = await asyncio.wait_for(
+                    _drain_schemaless_stream(client), timeout=10
+                )
+            assert events and events[-1]["type"] == "error"
+            assert _CapturedAsyncClient.last_init_kwargs.get("timeout") == 300
+            await client.close()
+        finally:
+            load_settings.cache_clear()
+
+
+class TestCheckHealthProbeTimeoutInvariant:
+    """VAL-LLM-010: check_health's probe stays at its deliberate 5s."""
+
+    @staticmethod
+    async def _probe_construction_timeout(monkeypatch, env_value: str | None) -> float:
+        monkeypatch.delenv("LLM_CALL_TIMEOUT", raising=False)
+        if env_value is not None:
+            monkeypatch.setenv("LLM_CALL_TIMEOUT", env_value)
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            captured: dict = {}
+
+            class RecordingClient(httpx.AsyncClient):
+                def __init__(self, **kwargs):
+                    captured.update(kwargs)
+                    super().__init__(**kwargs)
+
+            client = LLMClient(base_url="http://llm.test/v1", model="probe-model")
+            with patch("httpx.AsyncClient", RecordingClient):
+                # Dead port: the probe fails fast either way; we only care
+                # about the timeout the probe client was constructed with.
+                client.base_url = "http://127.0.0.1:9/v1"
+                await client.check_health()
+
+            timeout = captured["timeout"]
+            assert _effective_timeout_seconds(timeout) == 5.0
+            return _effective_timeout_seconds(timeout)
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_check_health_stays_5s_when_llm_call_timeout_set(self, monkeypatch):
+        assert await self._probe_construction_timeout(monkeypatch, "300") == 5.0
+
+    @pytest.mark.asyncio
+    async def test_check_health_stays_5s_when_llm_call_timeout_unset(self, monkeypatch):
+        assert await self._probe_construction_timeout(monkeypatch, None) == 5.0
+
+
+# ── Real-socket slow-provider harness (scaled delays, no virtual clock) ────
+
+
+async def _start_raw_sse_fixture():
+    """Boot the llm-svc fixture app plus a raw-SSE stall/drip test route.
+
+    The fixture app's own scenarios cap delays at 2s and cannot hold a
+    stream silent mid-flight, so the timeout semantics tests add a route
+    that speaks plain OpenAI-style SSE with controllable timing, driven by
+    an in-process state handle (query strings cannot be injected through
+    the client's fixed completion URL):
+
+      * ``stall_after=N``: emit N token chunks instantly, then go silent
+        forever (mid-stream stall → quiet-period read timeout).
+      * ``drip_chunks``/``drip_interval``: emit chunks every interval so
+        cumulative duration exceeds the call timeout while per-chunk
+        quiet time never does (no aggregate deadline).
+      * ``quiet_seconds``: pre-[DONE] silence for the envelope tests.
+
+    The route lives at ``/v1/raw-sse/chat/completions`` so a client whose
+    base_url ends at ``/v1/raw-sse`` reaches it via the standard
+    ``_completion_url()`` path construction.
+    """
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    app = create_app()
+    timing_state: dict = {
+        "stall_after": 0,
+        "quiet_seconds": 0.0,
+        "drip_chunks": 0,
+        "drip_interval": 0.0,
+    }
+
+    from fastapi.responses import StreamingResponse
+
+    @app.post("/v1/raw-sse/chat/completions")
+    async def raw_sse_route():
+        async def gen():
+            async def sse(token: str) -> str:
+                payload = {
+                    "id": "chatcmpl-raw",
+                    "object": "chat.completion.chunk",
+                    "model": "fixture-model",
+                    "choices": [{"index": 0, "delta": {"content": token}}],
+                }
+                return f"data: {_json.dumps(payload)}\n\n"
+
+            for i in range(
+                max(timing_state["stall_after"], timing_state["drip_chunks"])
+            ):
+                yield await sse(f"t{i} ")
+                if timing_state["drip_interval"]:
+                    await asyncio.sleep(timing_state["drip_interval"])
+            if not timing_state["drip_chunks"]:
+                await asyncio.sleep(timing_state["quiet_seconds"])
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    class _Handle:
+        base_url = f"http://127.0.0.1:{port}/v1/raw-sse"
+
+        @staticmethod
+        def configure(**kwargs) -> None:
+            timing_state.update(kwargs)
+
+    server = uvicorn.Server(
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    )
+    task = asyncio.create_task(server.serve())
+    health_url = f"http://127.0.0.1:{port}"
+    async with httpx.AsyncClient(timeout=2) as probe_client:
+        for _ in range(80):
+            try:
+                if (await probe_client.get(f"{health_url}/health")).status_code == 200:
+                    return _Handle(), server, task
+            except httpx.HTTPError:
+                await asyncio.sleep(0.025)
+    server.should_exit = True
+    await task
+    raise AssertionError("raw-SSE fixture did not become healthy")
+
+
+@pytest.fixture
+async def raw_sse():
+    handle, server, task = await _start_raw_sse_fixture()
+    try:
+        yield handle
+    finally:
+        server.should_exit = True
+        await task
+
+
+def _make_slow_fixture(delay_ms: int):
+    """Build a fixture-url factory honoring ?delay_ms= (max 2000)."""
+
+    @pytest.fixture
+    async def url():
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+        server = uvicorn.Server(
+            uvicorn.Config(create_app(), host="127.0.0.1", port=port, log_level="error")
+        )
+        task = asyncio.create_task(server.serve())
+        base_url = f"http://127.0.0.1:{port}"
+        async with httpx.AsyncClient(timeout=2) as probe_client:
+            for _ in range(80):
+                try:
+                    if (
+                        await probe_client.get(f"{base_url}/health")
+                    ).status_code == 200:
+                        break
+                except httpx.HTTPError:
+                    await asyncio.sleep(0.025)
+        try:
+            yield f"{base_url}/v1/scenarios/default?delay_ms={delay_ms}"
+        finally:
+            server.should_exit = True
+            await task
+
+    return url
+
+
+slow_1500ms_url = _make_slow_fixture(1500)
+over_default_url = _make_slow_fixture(2000)
+
+
+class TestSlowProviderTimeoutEnvelope:
+    """Scaled-down real-delay provider behavior across the timeout boundary."""
+
+    @pytest.mark.asyncio
+    async def test_slow_provider_within_raised_timeout_succeeds(
+        self, slow_1500ms_url, monkeypatch
+    ):
+        """VAL-LLM-001/005: provider slower than the unset default regime but
+        faster than the configured timeout completes successfully.
+
+        Real delay D=1500ms < configured T=3000ms; the legacy hardcoded
+        120s would also pass this, so the boundary twin below proves the
+        knob actually binds at smaller values.
+        """
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "3")
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            client = LLMClient(slow_1500ms_url, api_key="", model="fixture-model")
+            started = _time.monotonic()
+            result = await asyncio.wait_for(
+                client.generate(system_prompt="Be helpful.", user_prompt="Say hi."),
+                timeout=10,
+            )
+            elapsed = _time.monotonic() - started
+            assert "Synthesized answer from provided context." in result
+            assert 1.5 <= elapsed < 3.0
+            await client.close()
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_call_over_configured_timeout_times_out_cleanly(
+        self, slow_1500ms_url, monkeypatch
+    ):
+        """Twin boundary: same provider, tighter configured timeout fails."""
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "0.05")
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            client = LLMClient(slow_1500ms_url, api_key="", model="fixture-model")
+            with pytest.raises(ProviderOutputError):
+                await asyncio.wait_for(
+                    client.generate(system_prompt="x", user_prompt="y"), timeout=10
+                )
+            await client.close()
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_over_default_generate_fails_via_provider_output_error_envelope(
+        self, over_default_url, monkeypatch
+    ):
+        """VAL-LLM-006 (generate side): with LLM_CALL_TIMEOUT unset, a call
+        exceeding the 120s default fails via the path-appropriate envelope —
+        ProviderOutputError raised (never a success string, never a hang).
+
+        The full 120s wait is not exercised; the envelope identity is proven
+        by binding the client to a small timeout, which drives the identical
+        transport-failure branch.
+        """
+        monkeypatch.delenv("LLM_CALL_TIMEOUT", raising=False)
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            client = LLMClient(over_default_url, api_key="", model="fixture-model")
+            assert _effective_timeout_seconds(client._client.timeout) == 120.0
+            client._client.timeout = httpx.Timeout(0.05)
+            with pytest.raises(ProviderOutputError):
+                await asyncio.wait_for(
+                    client.generate(system_prompt="x", user_prompt="y"),
+                    timeout=2.5,
+                )
+            await client.close()
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_over_default_stream_fails_via_error_event_envelope(
+        self, over_default_url, monkeypatch
+    ):
+        """VAL-LLM-006 (stream side): unset env, over-default stream surfaces
+        an {"type": "error"} event (no exception raised to the caller)."""
+        monkeypatch.delenv("LLM_CALL_TIMEOUT", raising=False)
+        load_settings.cache_clear()
+        try:
+            from agent.llm import LLMClient
+
+            client = LLMClient(over_default_url, api_key="", model="fixture-model")
+
+            async def timed_out_stream():
+                # generate_stream's contract is event-based: a transport
+                # timeout yields an error event rather than raising. Bind
+                # the per-call client small via env so the failure fires now.
+                monkeypatch.setenv("LLM_CALL_TIMEOUT", "0.05")
+                load_settings.cache_clear()
+                try:
+                    async for event in client.generate_stream(
+                        system_prompt="x", user_prompt="y"
+                    ):
+                        yield event
+                finally:
+                    monkeypatch.delenv("LLM_CALL_TIMEOUT", raising=False)
+                    load_settings.cache_clear()
+
+            events = await asyncio.wait_for(_collect(timed_out_stream()), timeout=2.5)
+            assert events
+            assert events[-1]["type"] == "error"
+            assert events[-1].get("classification") == "non_retryable"
+            assert not any(event["type"] == "done" for event in events)
+            await client.close()
+        finally:
+            load_settings.cache_clear()
+
+
+async def _collect(agen) -> list:
+    """Drain an async generator into a list (usable inside wait_for)."""
+    return [item async for item in agen]
+
+
+def _effective_timeout_seconds(timeout: object) -> float:
+    """Normalize httpx.Timeout | float into a single comparable number."""
+    return float(timeout.read) if hasattr(timeout, "read") else float(timeout)
+
+
+class TestTimeoutDiagnosabilityLogging:
+    """Empty-str exceptions must stay identifiable in logs."""
+
+    @pytest.mark.asyncio
+    async def test_forced_read_timeout_logs_exception_type_generate(self, llm, caplog):
+        """VAL-LLM-007 regression guard: transport branch logs type name and
+        raises ProviderOutputError."""
+        exc = httpx.ReadTimeout(
+            "", request=httpx.Request("POST", "http://llm.test/v1/chat/completions")
+        )
+        with caplog.at_level(logging.ERROR, logger="agent.llm"):
+            with patch.object(llm._client, "post", side_effect=exc):
+                with pytest.raises(ProviderOutputError, match="transport failed"):
+                    await llm.generate(system_prompt="x", user_prompt="y")
+
+        assert any(
+            record.levelno == logging.ERROR
+            and "LLM transport failed:" in record.getMessage()
+            and "ReadTimeout" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_forced_read_timeout_logs_exception_type_generate_stream(
+        self, llm, caplog
+    ):
+        """VAL-LLM-008: generic catch-all logs type(exc).__name__ alongside the
+        message and yields an error event (no exception escapes)."""
+        mock_client = MagicMock()
+        mock_client.stream.side_effect = httpx.ReadTimeout(
+            "", request=httpx.Request("POST", "http://llm.test/v1/chat/completions")
+        )
+        mock_client.__aenter__.return_value = mock_client
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        with caplog.at_level(logging.ERROR, logger="agent.llm"):
+            with patch("httpx.AsyncClient", mock_client_cls):
+                events = [
+                    event
+                    async for event in llm.generate_stream(
+                        system_prompt="x", user_prompt="y"
+                    )
+                ]
+
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+        assert events[0]["classification"] == "non_retryable"
+        assert any(
+            record.levelno == logging.ERROR
+            and "LLM stream call failed" in record.getMessage()
+            and "ReadTimeout" in record.getMessage()
+            and record.getMessage().rstrip() != "LLM stream call failed: "
+            for record in caplog.records
+        )
+
+
+class TestCleanTimeoutFailure:
+    """Deterministic failure with admission-slot hygiene (VAL-LLM-009)."""
+
+    @pytest.mark.asyncio
+    async def test_generate_timeout_fails_cleanly_and_releases_admission_slot(
+        self, slow_1500ms_url, monkeypatch
+    ):
+        from agent.admission import get_admission
+        from agent.llm import LLMClient
+
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "0.05")
+        load_settings.cache_clear()
+        try:
+            admission = get_admission()
+            assert admission.active("llm") == 0
+            client = LLMClient(slow_1500ms_url, api_key="", model="fixture-model")
+            with pytest.raises(ProviderOutputError):
+                await asyncio.wait_for(
+                    client.generate(system_prompt="x", user_prompt="y"),
+                    timeout=10,
+                )
+            # Bounded-wait completed above; the slot must be released and the
+            # persistent client must still close without warnings/hangs.
+            assert admission.active("llm") == 0
+            await asyncio.wait_for(client.close(), timeout=5)
+        finally:
+            load_settings.cache_clear()
+
+
+class TestStreamQuietPeriodSemantics:
+    """Per-operation idle-bound semantics on the schema-less stream path."""
+
+    @staticmethod
+    def _client_for(url: str, call_timeout: str, monkeypatch):
+        from agent.llm import LLMClient
+
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", call_timeout)
+        load_settings.cache_clear()
+        return LLMClient(f"{url}/v1", api_key="", model="fixture-model")
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_stall_aborts_at_configured_quiet_period(
+        self, raw_sse, monkeypatch
+    ):
+        """VAL-LLM-014: tokens then silence → error event within ~T, not ∞."""
+        from agent.llm import LLMClient
+
+        call_timeout = 1.0
+        quiet_seconds = 3.0  # stall longer than T: abort happens at T, not at stall end
+        raw_sse.configure(stall_after=2, quiet_seconds=quiet_seconds)
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", str(call_timeout))
+        load_settings.cache_clear()
+        try:
+            client = LLMClient(raw_sse.base_url, api_key="", model="fixture-model")
+            started = _time.monotonic()
+            events = await asyncio.wait_for(
+                _collect(client.generate_stream(system_prompt="x", user_prompt="y")),
+                timeout=call_timeout + 5,
+            )
+            elapsed = _time.monotonic() - started
+            assert events
+            assert events[-1]["type"] == "error"
+            assert events[-1].get("classification") == "non_retryable"
+            assert not any(event["type"] == "done" for event in events)
+            # Aborted by the configured quiet-period bound (~T) BEFORE the
+            # stall would have ended — not at stall end, and not never.
+            assert call_timeout <= elapsed < quiet_seconds
+            await asyncio.wait_for(client.close(), timeout=5)
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_continuously_progressing_stream_exceeds_call_timeout(
+        self, raw_sse, monkeypatch
+    ):
+        """VAL-LLM-015: cumulative duration >> T with inter-chunk gaps < T
+        completes with done — no aggregate deadline may exist."""
+        from agent.llm import LLMClient
+
+        call_timeout = 1.0
+        drip_chunks = 8
+        drip_interval = 0.15  # cumulative 1.2s > T, gaps 0.15s << T
+        raw_sse.configure(drip_chunks=drip_chunks, drip_interval=drip_interval)
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", str(call_timeout))
+        load_settings.cache_clear()
+        try:
+            client = LLMClient(raw_sse.base_url, api_key="", model="fixture-model")
+            events = await asyncio.wait_for(
+                _collect(client.generate_stream(system_prompt="x", user_prompt="y")),
+                timeout=30,
+            )
+            cumulative = drip_chunks * drip_interval
+            assert cumulative > call_timeout
+            assert events[-1]["type"] == "done"
+            assert events[-1]["full_content"].strip()
+            assert not any(event["type"] == "error" for event in events)
+            await asyncio.wait_for(client.close(), timeout=5)
+        finally:
+            load_settings.cache_clear()
+
+
+class TestPipelineSurfacesTimedOutSynthesis:
+    """VAL-LLM-016: research/answer pipelines surface synthesis timeouts."""
+
+    @pytest.mark.asyncio
+    async def test_answer_stream_surfaces_timed_out_synthesis_as_error_event(
+        self, raw_sse, monkeypatch
+    ):
+        """(a) Streaming answer path: stalled synthesis → error event with
+        classification, and never a successful-looking done."""
+        from agent.research.loop import run_answer_stream
+        from agent.research.sources import SourceArtifact
+        from agent.searxng_client import SearchHealth
+
+        call_timeout = 1.0
+        # Stall longer than T so the configured quiet period (not the stall's
+        # natural end) is what terminates the synthesis stream.
+        raw_sse.configure(stall_after=1, quiet_seconds=3.0)
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", str(call_timeout))
+        load_settings.cache_clear()
+        try:
+
+            async def scraped(target_urls, rerank_artifacts, scraper, num_sources):
+                return [
+                    SourceArtifact(
+                        url="https://source.test/page",
+                        title="S",
+                        markdown="Authoritative context about the topic.",
+                    )
+                ]
+
+            monkeypatch.setattr("agent.research.loop._scrape_answer_sources", scraped)
+
+            async def searched(*args, **kwargs):
+                return (
+                    [{"url": "https://source.test/page", "title": "S"}],
+                    SearchHealth(),
+                )
+
+            monkeypatch.setattr("agent.research.loop.SearXNGClient.search", searched)
+
+            frames: list[dict] = await asyncio.wait_for(
+                _collect(
+                    run_answer_stream(
+                        query="what?",
+                        num_sources=1,
+                        searxng_url="http://127.0.0.1:9",
+                        scraper_url="http://127.0.0.1:9",
+                        llm_base_url=raw_sse.base_url,
+                        llm_api_key="",
+                        llm_model="fixture-model",
+                    )
+                ),
+                timeout=call_timeout + 10,
+            )
+            errors = [p for p in frames if p.get("type") == "error"]
+            assert errors, f"expected an error event, got: {frames!r}"
+            assert errors[-1].get("classification") == "non_retryable"
+            assert errors[-1].get("content")
+            dones = [p for p in frames if p.get("type") == "done"]
+            assert not dones, "timed-out synthesis must not look successful"
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_answer_pipeline_propagates_provider_output_error_on_synthesis_timeout(
+        self, monkeypatch
+    ):
+        """(b) Schema path: ProviderOutputError from synthesis surfaces as a
+        visible pipeline error event with the identifiable reason."""
+        from agent.research.loop import run_answer_stream
+        from agent.research.sources import SourceArtifact
+        from agent.searxng_client import SearchHealth
+
+        async def scraped(target_urls, rerank_artifacts, scraper, num_sources):
+            return [
+                SourceArtifact(
+                    url="https://source.test/page",
+                    title="S",
+                    markdown="Context for the question.",
+                )
+            ]
+
+        monkeypatch.setattr("agent.research.loop._scrape_answer_sources", scraped)
+
+        async def searched(*args, **kwargs):
+            return ([{"url": "https://source.test/page", "title": "S"}], SearchHealth())
+
+        monkeypatch.setattr("agent.research.loop.SearXNGClient.search", searched)
+
+        class TimedOutSynthesis:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc_info):
+                return False
+
+            async def generate(self, *args, **kwargs):
+                raise ProviderOutputError(detail="synthesis timed out")
+
+            def generate_stream(self, *args, **kwargs):
+                raise AssertionError("schema path must use generate()")
+
+            async def close(self):
+                return None
+
+        monkeypatch.setattr("agent.research.loop.LLMClient", TimedOutSynthesis)
+
+        frames = [
+            frame
+            async for frame in run_answer_stream(
+                query="what?",
+                num_sources=1,
+                searxng_url="http://127.0.0.1:9",
+                scraper_url="http://127.0.0.1:9",
+                llm_base_url="http://llm.invalid/v1",
+                llm_api_key="",
+                llm_model="fixture-model",
+                output_schema={"type": "object"},
+            )
+        ]
+        errors = [p for p in frames if p.get("type") == "error"]
+        assert errors, f"expected surfaced synthesis failure, got: {frames!r}"
+        assert errors[-1].get("classification") == "non_retryable"
+        assert "timed out" in errors[-1]["content"]
+        assert not any(p.get("type") == "done" for p in frames)
+
+
+class TestScopeBoundaryNoOtherLLMClients:
+    """VAL-LLM-017 guard: only agent/llm.py talks to chat/completions."""
+
+    def test_no_other_agent_module_posts_to_chat_completions(self):
+        agent_dir = Path(__file__).resolve().parents[2] / "agent-svc" / "agent"
+        offenders = sorted(
+            path.name
+            for path in agent_dir.glob("*.py")
+            if path.name != "llm.py"
+            and "chat/completions" in path.read_text(encoding="utf-8")
+        )
+        assert offenders == [], (
+            f"modules besides agent/llm.py reference chat/completions: {offenders}"
+        )


### PR DESCRIPTION
Fixes #589

## What

- **`agent-svc/agent/settings.py`** — add `llm_call_timeout: float = Field(default=120.0, alias="LLM_CALL_TIMEOUT", gt=0)` to `AgentSettings`.
- **`agent-svc/agent/llm.py`** — apply `load_settings().llm_call_timeout` at both `httpx.AsyncClient(timeout=120)` construction sites (persistent client in `LLMClient.__init__`, per-call client in the schema-less `generate_stream` path). `check_health` keeps its deliberate 5s probe timeout — the knob does not leak into it. Both generic exception handlers (`generate` and `generate_stream`) now log `type(exc).__name__` alongside the message so empty-string exceptions (httpx read timeouts) stay identifiable; the transport branch already did this and is regression-guarded.
- **`.env.sample`** — document `LLM_CALL_TIMEOUT` (default 120) with guidance to raise it (e.g. 300) for reasoning models.

Unset env preserves today's behavior exactly: 120s call timeout at both sites, 5s health probe, unchanged request shaping / retry policy / client API.

## Tests (TDD, scaled-down real delays against local fixture servers — no virtual clock)

New cases in `tests/service/test_llm.py` cover: settings wiring with float coercion + invalid-value `ValidationError`; unset default 120 at both construction sites; env flow into both sites; `check_health` stays 5s under both env configurations; slow-but-successful provider completes under a raised timeout; over-default failure envelope per path (`ProviderOutputError` raised in `generate`, error event yielded in `generate_stream`); forced empty-str `ReadTimeout` logs the exception type in both paths; mid-stream stall aborts at the configured quiet-period timeout; a continuously progressing stream legally exceeds the timeout (no aggregate deadline); deterministic clean failure with admission-slot release; timed-out synthesis surfaces visibly through the answer streaming and schema pipeline paths; scope guard that no other agent-svc module POSTs to `chat/completions`.

## Validation

- Scoped: `pytest tests/service/test_llm.py tests/service/test_llm_tcp_contract.py tests/unit` → 917 passed
- Full fast-tests lane (`tests/unit/ tests/service/`) → 1741 passed, 42 subtests passed
- `ruff check` + `ruff format --check` clean on changed files; `mypy agent-svc/agent` → no issues in 77 source files
- Fixture llm-svc sanity: live `/v1/scenarios/default/chat/completions` returns a 200 completion through the unchanged happy path
