### PR TITLE
fix: propagate vector-search failures in find-similar (#588)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -77,6 +77,10 @@
 # ── Vector Index (Phase 2 semantic search) ───────────────────────
 # Maximum documents in the persistent vector index (default: 250000)
 # VECTOR_INDEX_MAX_DOCS=250000
+# Client-side timeout (seconds) for blocking Qdrant HTTP calls. Defaults to
+# QDRANT_QUERY_TIMEOUT so the server-side query wrapper stays the binding
+# bound; raise it if a slow-but-healthy index times out at the client first.
+# QDRANT_CLIENT_TIMEOUT=10
 
 # ── Content-Based Near-Duplicate Detection (Phase 3) ─────────────
 # Cosine similarity threshold for near-duplicate detection (default: 0.95)

--- a/agent-svc/agent/exceptions.py
+++ b/agent-svc/agent/exceptions.py
@@ -76,6 +76,20 @@ class SearchError(GroktoCrawlError):
     detail = "Search failed"
 
 
+class SemanticError(GroktoCrawlError):
+    """The semantic-svc vector backend failed or is unreachable.
+
+    Raised when a dependent call into semantic-svc (e.g. the find-similar
+    vector search) fails at the transport or HTTP level, so the failure
+    surfaces as a structured 502 instead of being masked as an empty
+    success result (issue #588).
+    """
+
+    status_code = 502
+    error_code = "SEMANTIC_SERVICE_ERROR"
+    detail = "Semantic service error"
+
+
 class ConflictError(GroktoCrawlError):
     status_code = 409
     error_code = "CONFLICT"

--- a/agent-svc/agent/research/similar.py
+++ b/agent-svc/agent/research/similar.py
@@ -5,6 +5,7 @@ import math
 
 import httpx
 
+from ..exceptions import SemanticError
 from ..scraper_client import ScraperClient
 from ..searxng_client import SearXNGClient
 
@@ -75,19 +76,19 @@ async def _run_find_similar_qdrant(
         try:
             vector_results = await semantic.search_vector(query_text, limit=limit)
         except httpx.HTTPError as e:
-            # Vector index unavailable or slow (503, timeout, connection
-            # error). Degrade gracefully to no similar results rather than
-            # surfacing a 500 to the caller.
+            # Vector index unavailable or slow (503, 500, timeout, connection
+            # error). Surface a structured 502 instead of masking the backend
+            # failure as an empty success result (issue #588).
             response = getattr(e, "response", None)
             status = (
                 getattr(response, "status_code", None) if response is not None else None
             )
             detail = f" (HTTP {status})" if status else f" ({type(e).__name__})"
-            logger.warning(
-                "find_similar: semantic vector search failed%s; returning no results",
+            logger.error(
+                "find_similar: semantic vector search failed%s",
                 detail,
             )
-            return []
+            raise SemanticError(f"Semantic vector search failed{detail}") from e
 
         return [
             {

--- a/docs/reference/public-surface.md
+++ b/docs/reference/public-surface.md
@@ -170,6 +170,7 @@ The configuration inventory follows `.env.sample`; unlisted implementation-only 
 - MCP_TARGETED_SENSITIVE_ALLOWED
 - NEAR_DUP_MODE
 - NEAR_DUP_THRESHOLD
+- QDRANT_CLIENT_TIMEOUT
 - QDRANT_URL
 - PARSE_MAX_SIZE_MB
 - QA_MAX_BOILERPLATE_RATIO

--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -174,6 +174,15 @@ COLLECTION_NAME = "groktocrawl_pages"
 MAX_DOCS = int(os.getenv("VECTOR_INDEX_MAX_DOCS", "250000"))
 QDRANT_URL = os.getenv("QDRANT_URL", "http://qdrant:6333")
 QDRANT_QUERY_TIMEOUT = float(os.getenv("QDRANT_QUERY_TIMEOUT", "10"))
+# Client-side timeout for the blocking Qdrant HTTP calls. Defaults to
+# QDRANT_QUERY_TIMEOUT so the asyncio.wait_for wrapper in router_search
+# stays the binding bound — a lower hardcoded client timeout (the old 5s)
+# would fire first and make slow-but-healthy indexes unreachable (issue #588).
+# Rounded up to an int because qdrant-client types its timeout as int and
+# ceil()s fractional values itself.
+QDRANT_CLIENT_TIMEOUT = int(
+    float(os.getenv("QDRANT_CLIENT_TIMEOUT", str(QDRANT_QUERY_TIMEOUT)))
+)
 
 # ── Migration state (in-memory, lost on restart) ──────────────────
 # For restart-surviving state, store in Valkey or a known Qdrant point.
@@ -264,7 +273,7 @@ def _is_qdrant_ready() -> bool:
     client = _qdrant
     temporary_client = client is None
     if temporary_client:
-        client = QdrantClient(url=QDRANT_URL, timeout=5)
+        client = QdrantClient(url=QDRANT_URL, timeout=QDRANT_CLIENT_TIMEOUT)
     assert client is not None
     try:
         client.get_collections()
@@ -294,7 +303,7 @@ async def _ensure_qdrant() -> QdrantClient:
     """Lazy-init Qdrant client and collection with named vector support."""
     global _qdrant, _qdrant_ready
     if _qdrant is None:
-        _qdrant = QdrantClient(url=QDRANT_URL)
+        _qdrant = QdrantClient(url=QDRANT_URL, timeout=QDRANT_CLIENT_TIMEOUT)
     if not _qdrant_ready:
         try:
             collections = _qdrant.get_collections()

--- a/semantic-svc/app.py
+++ b/semantic-svc/app.py
@@ -31,6 +31,7 @@ import contextlib
 import datetime
 import hashlib
 import logging
+import math
 import os
 import time
 from contextlib import asynccontextmanager
@@ -178,9 +179,9 @@ QDRANT_QUERY_TIMEOUT = float(os.getenv("QDRANT_QUERY_TIMEOUT", "10"))
 # QDRANT_QUERY_TIMEOUT so the asyncio.wait_for wrapper in router_search
 # stays the binding bound — a lower hardcoded client timeout (the old 5s)
 # would fire first and make slow-but-healthy indexes unreachable (issue #588).
-# Rounded up to an int because qdrant-client types its timeout as int and
-# ceil()s fractional values itself.
-QDRANT_CLIENT_TIMEOUT = int(
+# Rounded UP (ceil) to satisfy qdrant-client's int-typed timeout without ever
+# landing below the fractional wrapper timeout (int() truncation would).
+QDRANT_CLIENT_TIMEOUT = math.ceil(
     float(os.getenv("QDRANT_CLIENT_TIMEOUT", str(QDRANT_QUERY_TIMEOUT)))
 )
 

--- a/tests/service/test_find_similar_cli.py
+++ b/tests/service/test_find_similar_cli.py
@@ -1,0 +1,98 @@
+"""CLI tests for find-similar backend-failure vs. clean-empty behavior.
+
+Covers issue #588's user-facing contract: when the API answers non-200
+(vector backend down), ``groktocrawl find-similar`` must exit non-zero
+with a structured error — never print "No similar pages found". A true
+empty result (HTTP 200, ``data: []``) keeps the legacy exit-0 behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.service.test_cli import _cli_ns
+
+
+def _make_client(api_error):
+    client = MagicMock()
+    client.dry_run = False
+    client.find_similar.side_effect = api_error
+    return client
+
+
+def _make_args():
+    args = MagicMock()
+    args.url = "https://example.com/herbs"
+    args.limit = 10
+    args.search_mode = "qdrant"
+    return args
+
+
+class TestFindSimilarBackendFailure:
+    def test_backend_error_exits_non_zero_with_stderr_message(self, capsys):
+        """Non-200 answer → SystemExit(1), error on stderr, no empty-success."""
+        api_error = _cli_ns["ApiError"](
+            "API error (502): semantic-svc vector search failed",
+            status_code=502,
+            body={
+                "success": False,
+                "error": "semantic-svc vector search failed",
+                "error_code": "SEMANTIC_SERVICE_ERROR",
+            },
+        )
+        cmd_find_similar = _cli_ns["cmd_find_similar"]
+        client = _make_client(api_error)
+
+        with pytest.raises(SystemExit) as exit_info:
+            cmd_find_similar(client, _make_args())
+
+        assert exit_info.value.code != 0
+        captured = capsys.readouterr()
+        assert "API error (502)" in captured.err
+        assert "No similar pages found" not in captured.out + captured.err
+
+    def test_backend_error_json_mode_emits_structured_body_on_stdout(self, capsys):
+        """--json mode: die() dumps the response body carrying the error code."""
+        original_json = _cli_ns["JSON_OUTPUT"]
+        _cli_ns["JSON_OUTPUT"] = True
+        try:
+            api_error = _cli_ns["ApiError"](
+                "API error (502): semantic-svc vector search failed",
+                status_code=502,
+                body={
+                    "success": False,
+                    "error": "semantic-svc vector search failed",
+                    "error_code": "SEMANTIC_SERVICE_ERROR",
+                },
+            )
+            cmd_find_similar = _cli_ns["cmd_find_similar"]
+            with pytest.raises(SystemExit) as exit_info:
+                cmd_find_similar(_make_client(api_error), _make_args())
+        finally:
+            _cli_ns["JSON_OUTPUT"] = original_json
+
+        assert exit_info.value.code != 0
+        out = capsys.readouterr().out
+        body = json.loads(out.strip())
+        assert body["error_code"] == "SEMANTIC_SERVICE_ERROR"
+        assert body["success"] is False
+
+
+class TestFindSimilarCleanEmpty:
+    def test_empty_data_prints_no_similar_pages_and_exits_zero(self, capsys):
+        """200 + data:[] → 'No similar pages found for <url>' and no raise."""
+        client = MagicMock()
+        client.dry_run = False
+        client.find_similar.return_value = {"success": True, "data": []}
+
+        cmd_find_similar = _cli_ns["cmd_find_similar"]
+        # cmd_find_similar returns normally on a clean-empty payload: any
+        # SystemExit (non-zero error path) would fail this test.
+        cmd_find_similar(client, _make_args())
+
+        captured = capsys.readouterr()
+        assert "No similar pages found for https://example.com/herbs" in captured.out
+        assert captured.err == ""

--- a/tests/service/test_find_similar_route.py
+++ b/tests/service/test_find_similar_route.py
@@ -1,0 +1,200 @@
+"""Route-level tests for find-similar error propagation (issue #588).
+
+Exercises the real route wiring — ``agent.routes.router`` with the real
+``groktocrawl_error_handler`` registered for ``GroktoCrawlError``, the same
+minimal harness used by ``tests/service/test_rate_limit_contract.py`` — to
+prove that a raised :class:`SemanticError` renders as HTTP 502 with the
+standard ``ErrorResponse`` body and never as a success-shaped payload.
+
+Also pins the healthy-path contracts: a successful vector search still
+returns mapped results, a genuinely empty index still yields
+``success:true, data:[]``, and the OpenAPI success schema for
+``POST /v2/find-similar`` is unchanged.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agent.app import groktocrawl_error_handler
+from agent.exceptions import GroktoCrawlError, SemanticError
+from agent.routes import router
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app() -> FastAPI:
+    """Minimal real harness mirroring create_app's error-handler wiring."""
+    app = FastAPI()
+    app.state.rate_limiter = MagicMock()
+    app.state.job_store = MagicMock()
+    app.state.max_searches_per_request = 5
+    app.state.task_tracker = MagicMock()
+    app.state.llm_base_url = "http://llm.test/v1"
+    app.state.llm_api_key = ""
+    app.state.llm_model = "test-model"
+    app.state.searxng_url = "http://searxng.test"
+    app.state.scraper_url = "http://scraper.test"
+    app.state.semantic_url = "http://semantic.test"
+    app.state.research_memory = MagicMock()
+    app.add_exception_handler(GroktoCrawlError, groktocrawl_error_handler)
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client():
+    return TestClient(_build_app())
+
+
+def _patched_research(search_vector):
+    """Patch the research-layer SemanticClient used by run_find_similar."""
+
+    class _FakeSemantic:
+        def __init__(self, base_url=""):
+            pass
+
+        async def search_vector(self, query, limit=5):
+            return await search_vector(query, limit)
+
+        async def embed(self, texts):
+            return [[0.0] * 3 for _ in texts]
+
+        async def close(self):
+            pass
+
+    class _FakeScraper:
+        def __init__(self, base_url=""):
+            pass
+
+        async def scrape(self, url):
+            return {
+                "success": True,
+                "data": {"markdown": "# Herbs", "metadata": {"title": "Herbs"}},
+            }
+
+        async def close(self):
+            pass
+
+    class _FakeSearx:
+        def __init__(self, base_url=""):
+            pass
+
+        async def search(self, query, limit=5):
+            return [], {}
+
+        async def close(self):
+            pass
+
+    return (
+        patch("agent.research.similar.ScraperClient", _FakeScraper),
+        patch("agent.semantic_client.SemanticClient", _FakeSemantic),
+        patch("agent.research.similar.SearXNGClient", _FakeSearx),
+    )
+
+
+class TestFindSimilarSemanticErrorContract:
+    def test_semantic_error_renders_502_with_standard_error_body(self, client):
+        """A raised SemanticError surfaces as 502 + ErrorResponse shape."""
+        patches = _patched_research(
+            AsyncMock(side_effect=SemanticError("semantic-svc vector search failed"))
+        )
+        with patches[0], patches[1], patches[2]:
+            resp = client.post(
+                "/v2/find-similar",
+                json={"url": "https://example.com/herbs"},
+            )
+
+        assert resp.status_code == 502
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error"] == "semantic-svc vector search failed"
+        assert body["error_code"] == "SEMANTIC_SERVICE_ERROR"
+        # No success-model keys may leak into the error body.
+        for key in ("query_url", "search_mode", "latency_ms", "data"):
+            assert key not in body
+
+    def test_semantic_error_propagates_through_route_without_local_handling(
+        self, client
+    ):
+        """The route has no local try/except; the handler does the rendering.
+
+        A GroktoCrawlError raised inside run_find_similar must reach the
+        registered handler unchanged (status/error_code preserved).
+        """
+        err = SemanticError("upstream down")
+        patches = _patched_research(AsyncMock(side_effect=err))
+        with patches[0], patches[1], patches[2]:
+            resp = client.post(
+                "/v2/find-similar",
+                json={"url": "https://example.com/herbs", "limit": 3},
+            )
+
+        assert resp.status_code == err.status_code == 502
+        assert resp.json()["error_code"] == "SEMANTIC_SERVICE_ERROR"
+
+
+class TestFindSimilarHealthyContracts:
+    def test_success_still_returns_mapped_results(self, client):
+        """A healthy vector search keeps returning mapped results."""
+
+        async def _ok(query, limit):
+            assert limit == 10  # FindSimilarRequest default
+            return [
+                {"url": "https://a.com", "title": "A", "content": "c" * 250},
+                {"url": "https://b.com", "title": "B"},
+            ]
+
+        patches = _patched_research(_ok)
+        with patches[0], patches[1], patches[2]:
+            resp = client.post(
+                "/v2/find-similar",
+                json={"url": "https://example.com/herbs"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["query_url"] == "https://example.com/herbs"
+        assert body["search_mode"] == "qdrant"
+        assert isinstance(body["latency_ms"], float)
+        assert len(body["data"]) == 2
+        first, second = body["data"]
+        assert first["url"] == "https://a.com"
+        assert first["description"] == "c" * 200  # truncated at 200 chars
+        assert second["description"] == ""  # no content key -> empty
+
+    def test_genuinely_empty_index_returns_success_with_empty_data(self, client):
+        """A clean empty result is success, never an error (issue #588)."""
+
+        async def _empty(query, limit):
+            return []
+
+        patches = _patched_research(_empty)
+        with patches[0], patches[1], patches[2]:
+            resp = client.post(
+                "/v2/find-similar",
+                json={"url": "https://example.com/unindexed"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"] == []
+        assert "error_code" not in body
+
+
+class TestFindSimilarOpenApiSchema:
+    def test_openapi_success_schema_is_find_similar_response(self):
+        """No schema drift: success response stays FindSimilarResponse."""
+        spec = _build_app().openapi()
+        operation = spec["paths"]["/v2/find-similar"]["post"]
+        declared = {
+            int(code): models for code, models in operation["responses"].items()
+        }
+        assert 200 in declared
+        success_ref = declared[200]["content"]["application/json"]["schema"][
+            "$ref"
+        ].split("/")[-1]
+        assert success_ref == "FindSimilarResponse"

--- a/tests/unit/test_find_similar_degradation.py
+++ b/tests/unit/test_find_similar_degradation.py
@@ -1,9 +1,15 @@
-"""Tests for graceful degradation of the find-similar qdrant path.
+"""Tests for error propagation in the find-similar qdrant path.
 
 Covers ``agent-svc/agent/research/similar.py:_run_find_similar_qdrant``:
 when semantic-svc fails for the vector search (503 index unavailable,
-timeout on a slow backend, or connection error), find-similar should
-degrade to an empty result instead of letting the error escape as a 500.
+500 internal error, timeout on a slow backend, or connection error),
+find-similar MUST raise the typed ``SemanticError`` (HTTP 502,
+``SEMANTIC_SERVICE_ERROR``) instead of masking the failure as an empty
+success result (issue #588).
+
+The scrape-stage short-circuit is preserved: a failed scrape of the
+query URL still degrades to ``[]`` without ever calling the semantic
+service.
 """
 
 from __future__ import annotations
@@ -12,6 +18,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from agent.exceptions import GroktoCrawlError, SemanticError
 from agent.research.similar import _run_find_similar_qdrant
 
 
@@ -35,9 +42,11 @@ class _FakeScraper:
 class _FakeSemantic:
     def __init__(self, search_vector):
         self._search_vector = search_vector
+        self.search_vector_calls: list[tuple[str, int]] = []
         self.closed = False
 
     async def search_vector(self, query, limit=5):
+        self.search_vector_calls.append((query, limit))
         return await self._search_vector(query, limit)
 
     async def close(self):
@@ -50,64 +59,110 @@ def _mock_http_status_error(status: int) -> httpx.HTTPStatusError:
     return httpx.HTTPStatusError("error", request=request, response=response)
 
 
-@pytest.mark.asyncio
-async def test_qdrant_503_returns_empty_results():
-    """A 503 from semantic-svc degrades to no similar results, not a 500."""
-    semantic = _FakeSemantic(AsyncMock(side_effect=_mock_http_status_error(503)))
-
+async def _run(scraper=None, semantic=None):
+    """Invoke _run_find_similar_qdrant with patched clients."""
     with (
-        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
+        patch(
+            "agent.research.similar.ScraperClient",
+            return_value=scraper or _FakeScraper(),
+        ),
         patch("agent.semantic_client.SemanticClient", return_value=semantic),
     ):
-        results = await _run_find_similar_qdrant(
+        return await _run_find_similar_qdrant(
             url="https://example.com/herbs",
             limit=5,
             scraper_url="http://scraper-svc:8001",
             semantic_url="http://semantic-svc:8003",
         )
 
-    assert results == []
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [503, 500])
+async def test_qdrant_http_status_error_raises_semantic_error(status):
+    """An upstream HTTP error status from semantic-svc raises SemanticError."""
+    semantic = _FakeSemantic(AsyncMock(side_effect=_mock_http_status_error(status)))
+
+    with pytest.raises(SemanticError) as exc_info:
+        await _run(semantic=semantic)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.error_code == "SEMANTIC_SERVICE_ERROR"
+    # The detail identifies the upstream HTTP condition.
+    assert str(status) in exc_info.value.detail
 
 
 @pytest.mark.asyncio
-async def test_qdrant_http_error_returns_empty():
-    """A 500 from semantic-svc degrades to no similar results, not a 500."""
-    semantic = _FakeSemantic(AsyncMock(side_effect=_mock_http_status_error(500)))
-
-    with (
-        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
-        patch("agent.semantic_client.SemanticClient", return_value=semantic),
-    ):
-        results = await _run_find_similar_qdrant(
-            url="https://example.com/herbs",
-            limit=5,
-            scraper_url="http://scraper-svc:8001",
-            semantic_url="http://semantic-svc:8003",
-        )
-
-    assert results == []
-
-
-@pytest.mark.asyncio
-async def test_qdrant_timeout_returns_empty():
-    """A timeout (slow backend) degrades to no similar results, not a 500."""
+async def test_qdrant_timeout_raises_semantic_error():
+    """A timeout (slow backend) raises SemanticError naming the exception type."""
     request = httpx.Request("POST", "http://semantic-svc:8003/search/vector")
     semantic = _FakeSemantic(
         AsyncMock(side_effect=httpx.ReadTimeout("timed out", request=request))
     )
 
-    with (
-        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
-        patch("agent.semantic_client.SemanticClient", return_value=semantic),
-    ):
-        results = await _run_find_similar_qdrant(
-            url="https://example.com/herbs",
-            limit=5,
-            scraper_url="http://scraper-svc:8001",
-            semantic_url="http://semantic-svc:8003",
-        )
+    with pytest.raises(SemanticError) as exc_info:
+        await _run(semantic=semantic)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.error_code == "SEMANTIC_SERVICE_ERROR"
+    detail = exc_info.value.detail
+    assert "ReadTimeout" in detail or "timeout" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_connect_error_raises_semantic_error():
+    """An unreachable semantic-svc (connection error) raises SemanticError."""
+    request = httpx.Request("POST", "http://semantic-svc:8003/search/vector")
+    semantic = _FakeSemantic(
+        AsyncMock(side_effect=httpx.ConnectError("connection refused", request=request))
+    )
+
+    with pytest.raises(SemanticError) as exc_info:
+        await _run(semantic=semantic)
+
+    assert isinstance(exc_info.value, GroktoCrawlError)
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.error_code == "SEMANTIC_SERVICE_ERROR"
+    assert "ConnectError" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_scrape_failure_short_circuits_before_search_vector():
+    """A failed scrape returns [] without calling search_vector (no error)."""
+    semantic = _FakeSemantic(
+        AsyncMock(side_effect=AssertionError("search_vector must not be called"))
+    )
+
+    class _FailingScraper:
+        async def scrape(self, url):
+            return {"success": False, "error": "scrape failed"}
+
+        async def close(self):
+            pass
+
+    results = await _run(scraper=_FailingScraper(), semantic=semantic)
 
     assert results == []
+    assert semantic.search_vector_calls == []
+
+
+@pytest.mark.asyncio
+async def test_empty_markdown_short_circuits_before_search_vector():
+    """Empty scraped markdown returns [] without calling search_vector."""
+    semantic = _FakeSemantic(
+        AsyncMock(side_effect=AssertionError("search_vector must not be called"))
+    )
+
+    class _BlankScraper:
+        async def scrape(self, url):
+            return {"success": True, "data": {"markdown": "", "metadata": {}}}
+
+        async def close(self):
+            pass
+
+    results = await _run(scraper=_BlankScraper(), semantic=semantic)
+
+    assert results == []
+    assert semantic.search_vector_calls == []
 
 
 @pytest.mark.asyncio
@@ -119,16 +174,7 @@ async def test_qdrant_success_returns_results():
 
     semantic = _FakeSemantic(_ok)
 
-    with (
-        patch("agent.research.similar.ScraperClient", return_value=_FakeScraper()),
-        patch("agent.semantic_client.SemanticClient", return_value=semantic),
-    ):
-        results = await _run_find_similar_qdrant(
-            url="https://example.com/herbs",
-            limit=5,
-            scraper_url="http://scraper-svc:8001",
-            semantic_url="http://semantic-svc:8003",
-        )
+    results = await _run(semantic=semantic)
 
     assert results == [
         {"url": "https://a.com", "title": "A", "description": "content A"}

--- a/tests/unit/test_qdrant_client_timeout.py
+++ b/tests/unit/test_qdrant_client_timeout.py
@@ -133,6 +133,30 @@ class TestQdrantClientTimeoutDefault:
             )
             assert resolved >= float(query_timeout)
 
+    def test_fractional_query_timeout_rounds_up_not_down(self):
+        """Fractional wrapper timeout must not truncate below itself.
+
+        Regression for the int() truncation finding: with
+        QDRANT_QUERY_TIMEOUT=12.5 the client timeout resolves to 13 (ceil),
+        never 12, so it can never fire before the 12.5s wait_for wrapper.
+        """
+        resolved = _resolve_module_constant(
+            {"QDRANT_QUERY_TIMEOUT": "12.5"}, "QDRANT_CLIENT_TIMEOUT"
+        )
+        assert resolved == 13.0
+        assert resolved > 12.5
+
+    def test_explicit_fractional_client_timeout_rounds_up(self):
+        """An explicitly fractional QDRANT_CLIENT_TIMEOUT is ceil'd too."""
+        resolved = _resolve_module_constant(
+            {
+                "QDRANT_QUERY_TIMEOUT": "12.5",
+                "QDRANT_CLIENT_TIMEOUT": "15.5",
+            },
+            "QDRANT_CLIENT_TIMEOUT",
+        )
+        assert resolved == 16.0
+
 
 class TestQdrantClientTimeoutAppliedAtConstructionSites:
     """VAL-FIND-011: the configured timeout reaches BOTH construction sites."""

--- a/tests/unit/test_qdrant_client_timeout.py
+++ b/tests/unit/test_qdrant_client_timeout.py
@@ -1,0 +1,301 @@
+"""Config tests for the QDRANT_CLIENT_TIMEOUT env var (issue #588).
+
+The semantic-svc Qdrant client previously used a hardcoded 5s timeout in
+``_is_qdrant_ready`` and the qdrant-client library default (5s) in
+``_ensure_qdrant``. On slow-but-healthy indexes that client timeout fired
+BEFORE the ``QDRANT_QUERY_TIMEOUT`` asyncio.wait_for wrapper, making the
+wrapper unreachable and the index look unavailable. ``QDRANT_CLIENT_TIMEOUT``
+(default: ``QDRANT_QUERY_TIMEOUT``) must now govern BOTH construction
+sites so the wrapper stays the binding bound (issue #588 criterion 2,
+unit-level verification decision: no live slow Qdrant required).
+
+Default-resolution cases run in an isolated interpreter via subprocess:
+``semantic-svc/app.py`` computes module constants at import time and the
+module name ``app`` makes in-process re-import fragile (router_search
+binds imported constants at import time).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_SEMANTIC_SVC_DIR = Path(__file__).resolve().parents[2] / "semantic-svc"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Scale real seconds down so an "8s" operation costs ~0.8s wall clock.
+_SCALE = 0.1
+
+
+def _import_app_with_stubbed_routers():
+    """Import semantic-svc app + real routers with circular imports broken.
+
+    Mirrors the workaround in tests/unit/test_semantic_svc_unit.py: stub
+    the router modules, import app with include_router disabled, then let
+    the real router modules load (app is already cached in sys.modules).
+    """
+    import fastapi
+
+    for mod_name in ["router_index", "router_migration", "router_search"]:
+        if mod_name not in sys.modules or not hasattr(
+            sys.modules[mod_name], "__file__"
+        ):
+            mod = types.ModuleType(mod_name)
+            setattr(mod, mod_name, fastapi.APIRouter())
+            sys.modules[mod_name] = mod
+
+    original_include = fastapi.applications.FastAPI.include_router
+    fastapi.applications.FastAPI.include_router = lambda self, router, **kwargs: None
+    try:
+        import app  # noqa: F401
+    finally:
+        fastapi.applications.FastAPI.include_router = original_include
+
+    # Drop the stubs so the REAL router modules can be imported on demand.
+    for mod_name in ["router_index", "router_migration", "router_search"]:
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            del sys.modules[mod_name]
+
+
+def _resolve_module_constant(env: dict[str, str], constant: str) -> float:
+    """Import semantic-svc/app.py in a fresh interpreter with patched env.
+
+    Router imports at the bottom of app.py are stubbed out (same
+    circular-import workaround as tests/unit/test_semantic_svc_unit.py)
+    so no model or service dependencies load; only module constants are
+    evaluated. The environment is NOT inherited from the pytest process
+    beyond PATH/HOME, giving true isolated-interpreter resolution.
+    """
+    code = (
+        "import sys, types\n"
+        "import fastapi\n"
+        "from fastapi import APIRouter\n"
+        "for mod_name in ['router_index', 'router_migration', 'router_search']:\n"
+        "    mod = types.ModuleType(mod_name)\n"
+        f"    setattr(mod, mod_name, APIRouter())\n"
+        "    sys.modules[mod_name] = mod\n"
+        "original_include = fastapi.applications.FastAPI.include_router\n"
+        "fastapi.applications.FastAPI.include_router = "
+        "lambda self, router, **kwargs: None\n"
+        "import app\n"
+        "fastapi.applications.FastAPI.include_router = original_include\n"
+        f"print(repr(app.{constant}))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=_SEMANTIC_SVC_DIR,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", "/tmp"),
+            # app.py imports common.logging/common.middleware from the repo
+            # root (PYTHONPATH-style), like the containerized service does.
+            "PYTHONPATH": str(_REPO_ROOT),
+            **env,
+        },
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    return float(result.stdout.strip())
+
+
+class TestQdrantClientTimeoutDefault:
+    """VAL-FIND-010: unset QDRANT_CLIENT_TIMEOUT tracks QDRANT_QUERY_TIMEOUT."""
+
+    def test_unset_defaults_to_qdrant_query_timeout_default(self):
+        """Both vars unset → resolved default equals 10.0 (QDRANT_QUERY_TIMEOUT)."""
+        assert _resolve_module_constant({}, "QDRANT_QUERY_TIMEOUT") == 10.0
+        assert _resolve_module_constant({}, "QDRANT_CLIENT_TIMEOUT") == 10.0
+
+    def test_unset_tracks_custom_qdrant_query_timeout(self):
+        """QDRANT_QUERY_TIMEOUT=12 with client var unset → resolved value 12."""
+        assert (
+            _resolve_module_constant(
+                {"QDRANT_QUERY_TIMEOUT": "12"}, "QDRANT_CLIENT_TIMEOUT"
+            )
+            == 12.0
+        )
+
+    def test_default_is_never_below_query_wrapper_timeout(self):
+        """Invariant across permutations: default >= QDRANT_QUERY_TIMEOUT."""
+        for query_timeout in ("10", "12"):
+            resolved = _resolve_module_constant(
+                {"QDRANT_QUERY_TIMEOUT": query_timeout}, "QDRANT_CLIENT_TIMEOUT"
+            )
+            assert resolved >= float(query_timeout)
+
+
+class TestQdrantClientTimeoutAppliedAtConstructionSites:
+    """VAL-FIND-011: the configured timeout reaches BOTH construction sites."""
+
+    def test_ensure_qdrant_uses_configured_client_timeout(self, monkeypatch):
+        """The persistent client in _ensure_qdrant gets QDRANT_CLIENT_TIMEOUT."""
+        _import_app_with_stubbed_routers()
+        import app
+
+        captured: dict = {}
+
+        class _FakeQdrantClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def get_collections(self):
+                collections = MagicMock()
+                collections.collections = []
+                return collections
+
+            def create_collection(self, **kwargs):
+                pass
+
+        monkeypatch.setattr(app, "_qdrant", None)
+        monkeypatch.setattr(app, "_qdrant_ready", False)
+        # The module constant is int-typed (qdrant-client contract).
+        monkeypatch.setattr(app, "QDRANT_CLIENT_TIMEOUT", 15)
+        monkeypatch.setattr(app, "QdrantClient", _FakeQdrantClient)
+
+        asyncio.run(app._ensure_qdrant())
+
+        assert captured.get("timeout") == 15
+        assert captured.get("url") == app.QDRANT_URL
+
+    def test_is_qdrant_ready_uses_configured_client_timeout(self, monkeypatch):
+        """The temporary readiness client gets QDRANT_CLIENT_TIMEOUT (not 5)."""
+        _import_app_with_stubbed_routers()
+        import app
+
+        captured: dict = {}
+
+        class _FakeQdrantClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def get_collections(self):
+                return MagicMock()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(app, "_qdrant", None)
+        monkeypatch.setattr(app, "_qdrant_ready", False)
+        monkeypatch.setattr(app, "QDRANT_CLIENT_TIMEOUT", 15)
+        monkeypatch.setattr(app, "QdrantClient", _FakeQdrantClient)
+
+        assert app._is_qdrant_ready() is True
+        assert captured.get("timeout") == 15
+
+
+class TestSlowIndexReachability:
+    """VAL-FIND-012: paired fail-at-5s / succeed-at-15s scenario.
+
+    Simulated unit-level per the verification decision for issue #588
+    criterion 2: the blocking Qdrant query needs ~8 seconds (scaled to
+    ~0.8s wall clock via ``_SCALE``) and the wait_for wrapper is kept
+    non-binding (QDRANT_QUERY_TIMEOUT=30 scaled) so the CLIENT timeout
+    is the constraint actually under test.
+
+    The client-side abort is simulated inside the stubbed blocking call
+    exactly as qdrant-client behaves end-to-end: it aborts AT its
+    configured timeout when the operation outlasts it (the library
+    ceil()s a float timeout onto its REST/gRPC calls and raises a
+    timeout error from inside the blocking call), so a slow-but-healthy
+    index is reachable if and only if QDRANT_CLIENT_TIMEOUT exceeds the
+    operation duration.
+    """
+
+    @staticmethod
+    def _ready_router(monkeypatch, client_timeout):
+        """Wire router_search.search_vector against a slow-but-healthy index.
+
+        The fake Qdrant honors its configured client timeout: an operation
+        needing 8 scaled seconds raises the client-level TimeoutError when
+        the configured timeout is shorter, and completes otherwise.
+        """
+        import numpy as np
+
+        # Import app first with stubbed routers (same workaround as
+        # tests/unit/test_semantic_svc_unit.py), then the real router_search
+        # — avoids the app.py <-> router_search circular import at test time.
+        _import_app_with_stubbed_routers()
+
+        import router_search
+
+        class _SlowHealthyQdrant:
+            def __init__(self, **kwargs):
+                # Configured client timeout arrives in scaled seconds so it
+                # competes on equal footing with the scaled op duration.
+                self.timeout = kwargs["timeout"]
+
+            def query_points(self, **kwargs):
+                needed = 8 * _SCALE  # "8 seconds" (scaled)
+                start = time.monotonic()
+                while time.monotonic() - start < needed:
+                    if time.monotonic() - start > self.timeout:
+                        # The client bound fires INSIDE the blocking call —
+                        # mirroring qdrant-client's real abort behavior.
+                        raise TimeoutError("client timeout fired")
+                    time.sleep(0.02)
+                return type("_Resp", (), {"points": []})()
+
+        class _FakeModel:
+            def encode(self, text, **kwargs):
+                return np.array([0.1] * 8)
+
+        monkeypatch.setenv("QDRANT_CLIENT_TIMEOUT", str(client_timeout))
+        # Wrapper non-binding (30 scaled seconds) so only the client binds.
+        monkeypatch.setattr(router_search, "QDRANT_QUERY_TIMEOUT", 30 * _SCALE)
+        monkeypatch.setattr(router_search, "_get_embed_model", lambda: _FakeModel())
+
+        async def _fake_ensure():
+            return _SlowHealthyQdrant(
+                url="http://qdrant:6333", timeout=client_timeout * _SCALE
+            )
+
+        monkeypatch.setattr(router_search, "_ensure_qdrant", _fake_ensure)
+        import app
+
+        monkeypatch.setattr(app, "_models_ready", True)
+        return router_search
+
+    def test_legacy_5s_client_timeout_fails_the_slow_call(self, monkeypatch):
+        """With the legacy hardcoded 5s client timeout, the ~8s call fails.
+
+        This pins the bug: the short client timeout structurally breaks a
+        slow-but-healthy index even though the wrapper allows ample time.
+        """
+        from fastapi import HTTPException
+        from models import VectorSearchRequest
+
+        router_search = self._ready_router(monkeypatch, client_timeout=5.0)
+
+        started = time.monotonic()
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                router_search.search_vector(VectorSearchRequest(query="herbs", limit=3))
+            )
+        assert exc_info.value.status_code == 503
+        # The failure came from the client bound (~5 scaled s), not the wrapper
+        # (30 scaled s): the call aborted well before the wrapper could fire.
+        assert time.monotonic() - started < 20 * _SCALE
+
+    def test_raised_15s_client_timeout_lets_the_slow_call_succeed(self, monkeypatch):
+        """With QDRANT_CLIENT_TIMEOUT=15, the identical ~8s call completes."""
+        from models import VectorSearchRequest
+
+        router_search = self._ready_router(monkeypatch, client_timeout=15.0)
+
+        started = time.monotonic()
+        resp = asyncio.run(
+            router_search.search_vector(VectorSearchRequest(query="herbs", limit=3))
+        )
+        # The call really ran to completion instead of failing early.
+        assert time.monotonic() - started >= 8 * _SCALE * 0.9
+        assert list(resp.results) == []


### PR DESCRIPTION
Fixes #588

## Problem

`POST /v2/find-similar` (qdrant mode) masked semantic-svc vector-search failures as success: `_run_find_similar_qdrant` caught every `httpx.HTTPError` from `SemanticClient.search_vector` and returned `[]`, which the route folded into HTTP 200 `{"success": true, "data": []}`. The CLI then printed "No similar pages found" and exited 0 — callers could not distinguish "no similar pages" from "the vector backend is down".

Underneath, semantic-svc's Qdrant client used a hardcoded `timeout=5` in `_is_qdrant_ready` and the qdrant-client library default (5s, httpx default) in `_ensure_qdrant`, racing the configurable `QDRANT_QUERY_TIMEOUT` (default 10s) wrapper. Slow-but-healthy indexes died at the client before the wrapper could matter.

## Fix (two layers)

**agent-svc**
- New `SemanticError(GroktoCrawlError)` with `status_code=502`, `error_code="SEMANTIC_SERVICE_ERROR"` (`agent/exceptions.py`).
- `_run_find_similar_qdrant` now **raises** `SemanticError` on any `httpx.HTTPError` from `semantic.search_vector(...)`, with a detail naming the upstream HTTP status or exception type. The raise propagates through the existing `GroktoCrawlError` -> FastAPI handler; the route needs no local try/except.
- Scrape-stage short-circuit preserved: scraper failure / empty markdown -> return `[]` WITHOUT calling search_vector and WITHOUT raising.
- Web mode and sibling `search_vector` callers unchanged.

**semantic-svc**
- New `QDRANT_CLIENT_TIMEOUT` env var (default: `QDRANT_QUERY_TIMEOUT`) applied at BOTH `QdrantClient(url=...)` construction sites (`_is_qdrant_ready`, `_ensure_qdrant`), so the `QDRANT_QUERY_TIMEOUT` `asyncio.wait_for` wrapper remains the binding bound and slow-but-healthy indexes become reachable.

A genuinely empty index still returns `success:true, data:[]`.

## Tests

- `tests/unit/test_find_similar_degradation.py`: rewritten from masking assertions to `pytest.raises(SemanticError)` for 503/500/timeout/connection-error (reusing `_mock_http_status_error`); success-path test kept unmodified; new scrape-stage short-circuit tests assert `search_vector` is never called.
- `tests/service/test_find_similar_route.py` (new): route-level contract through the real handler wiring — 502 + `ErrorResponse` shape with no success-model keys, healthy mapped results, clean-empty `success:true/data:[]`, OpenAPI schema still `FindSimilarResponse`.
- `tests/service/test_find_similar_cli.py` (new): backend failure -> non-zero exit + `API error (502)` on stderr, `--json` stdout carries `SEMANTIC_SERVICE_ERROR`; true empty -> exit 0 + "No similar pages found".
- `tests/unit/test_qdrant_client_timeout.py` (new): default resolution via isolated-interpreter subprocess (unset == `QDRANT_QUERY_TIMEOUT`, tracks `12`, never below it), configured timeout captured at both construction sites, paired fail-at-5s / succeed-at-15s simulated slow-index scenario through `router_search.search_vector`.
- Docs inventory gate updated (`docs/reference/public-surface.md`), verified with `scripts/check-docs-surface.py`.

## Validation

- Scoped: 22 new/rewritten find-similar + config tests green (also under `-o asyncio_mode=strict`).
- Full fast-tests lane: 1759 passed + 42 subtests.
- `ruff check` and `mypy agent-svc/agent semantic-svc common` clean.
