### PR TITLE
test(agent): promote timeout/find-similar edge-case coverage

### DIFF
--- a/tests/service/test_find_similar_route.py
+++ b/tests/service/test_find_similar_route.py
@@ -14,6 +14,7 @@ returns mapped results, a genuinely empty index still yields
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -198,3 +199,137 @@ class TestFindSimilarOpenApiSchema:
             "$ref"
         ].split("/")[-1]
         assert success_ref == "FindSimilarResponse"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Web-mode happy path (promoted from validator scratch coverage, #588
+# follow-up). The #588 fix was scoped to qdrant mode; this pins the web mode's
+# unchanged rerank contract (search → embed → cosine rerank) so it is guarded
+# by the permanent suite rather than a throwaway validation test.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFindSimilarWebModeRerank:
+    def test_web_mode_healthy_path_returns_reranked_results(self):
+        """VAL-FIND-016: web mode reranks searxng results by cosine
+        similarity against the scraped page and maps them to
+        url/title/description dicts — no error raised on the healthy path."""
+        from agent.research.similar import _run_find_similar_web
+
+        # Query embedding for the scraped page's content.
+        query_vec = [1.0, 0.0]
+
+        # Candidate embeddings chosen so cosine similarity against [1, 0] is
+        # deterministic: Alpha -> 1.0, Gamma -> ~0.707, Beta -> 0.0.
+        cand_vecs = {
+            "https://b.example.com/beta": [0.0, 1.0],
+            "https://c.example.com/gamma": [
+                0.7071067811865476,
+                0.7071067811865476,
+            ],
+            "https://a.example.com/alpha": [1.0, 0.0],
+        }
+
+        class _FakeScraper:
+            async def scrape(self, url):
+                return {
+                    "success": True,
+                    "data": {
+                        "markdown": "# Herb Gardens\n\nHydroponic herb gardening tips.",
+                        "metadata": {"title": "Herb Gardens"},
+                    },
+                }
+
+            async def close(self):
+                return None
+
+        class _FakeSearx:
+            """Healthy SearXNG returning three results in a deliberately
+            UNRANKED order (Beta, Gamma, Alpha) so passing requires actual
+            cosine reranking."""
+
+            async def search(self, query, limit=5):
+                results = [
+                    {
+                        "url": "https://b.example.com/beta",
+                        "title": "Beta",
+                        "description": "beta description",
+                    },
+                    {
+                        "url": "https://c.example.com/gamma",
+                        "title": "Gamma",
+                        "description": "gamma description",
+                    },
+                    {
+                        "url": "https://a.example.com/alpha",
+                        "title": "Alpha",
+                        "description": "alpha description",
+                    },
+                ]
+                return results[:limit], {}
+
+            async def close(self):
+                return None
+
+        class _FakeSemantic:
+            def __init__(self):
+                self.embed_calls: list[list[str]] = []
+
+            async def embed(self, texts):
+                self.embed_calls.append(list(texts))
+                if len(texts) == 1:
+                    # Single-text call: the query URL's markdown embedding.
+                    return [query_vec]
+                # Batch call: one embedding per candidate description.
+                vecs = []
+                for text in texts:
+                    for url_hint, vec in cand_vecs.items():
+                        marker = url_hint.split("/")[-1]
+                        if marker in text.lower():
+                            vecs.append(vec)
+                            break
+                    else:
+                        raise AssertionError(f"unexpected embed text: {text!r}")
+                return vecs
+
+            async def close(self):
+                return None
+
+        scraper = _FakeScraper()
+        semantic = _FakeSemantic()
+        searx = _FakeSearx()
+
+        with (
+            patch("agent.research.similar.ScraperClient", return_value=scraper),
+            patch("agent.semantic_client.SemanticClient", return_value=semantic),
+            patch("agent.research.similar.SearXNGClient", return_value=searx),
+        ):
+            # Must not raise; the #588 fix touched only the qdrant path.
+            results = asyncio.run(
+                _run_find_similar_web(
+                    url="https://example.com/herbs",
+                    limit=2,
+                    scraper_url="http://scraper.test",
+                    semantic_url="http://semantic.test",
+                    searxng_url="http://searxng.test",
+                )
+            )
+
+        # Non-empty reranked results, truncated to limit.
+        assert isinstance(results, list)
+        assert len(results) == 2
+
+        # Rerank actually reordered: Alpha (cos 1.0) beats Gamma (~0.707);
+        # raw searxng order was Beta, Gamma, Alpha — Beta must be dropped.
+        assert [r["title"] for r in results] == ["Alpha", "Gamma"]
+
+        # Mapping contract: dicts expose exactly url/title/description.
+        for item in results:
+            assert set(item.keys()) == {"url", "title", "description"}
+            assert item["url"].startswith("https://")
+            assert item["description"].endswith("description")
+
+        # Full pipeline ran: scrape -> search -> embed(query) -> embed(batch).
+        assert len(semantic.embed_calls) == 2
+        assert len(semantic.embed_calls[0]) == 1  # query markdown
+        assert len(semantic.embed_calls[1]) == 3  # candidate descriptions

--- a/tests/service/test_llm.py
+++ b/tests/service/test_llm.py
@@ -1388,8 +1388,12 @@ class TestDefaultTimeoutThreePointBoundary:
                     client.generate(system_prompt="x", user_prompt="y"), timeout=10
                 )
             elapsed = _time.monotonic() - started
-            # Aborted by the 1.2s bound, i.e. before D could complete.
-            assert elapsed < 1.5
+            # The ProviderOutputError itself proves the configured bound
+            # aborted the call before the provider could succeed (point B
+            # shows the same D succeeds under a raised T); the generous
+            # elapsed ceiling keeps the wall-clock check flake-free on
+            # loaded CI runners while still bounding the failure path.
+            assert elapsed < 3.0
             await asyncio.wait_for(client.close(), timeout=5)
         finally:
             load_settings.cache_clear()
@@ -1580,7 +1584,9 @@ class TestWorkerRecordsSynthesisTimeoutReason:
                 new=AsyncMock(return_value=discovered),
             ),
             patch(
-                "agent.webhook.deliver_webhook",
+                # The wrapper calls its own module-level import, so the
+                # interception point is agent.worker.deliver_webhook.
+                "agent.worker.deliver_webhook",
                 new=AsyncMock(return_value=None),
             ) as webhook_mock,
         ):
@@ -1597,4 +1603,12 @@ class TestWorkerRecordsSynthesisTimeoutReason:
 
         assert captured_fail.get("reason"), "job must be marked failed"
         assert "timed out" in captured_fail["reason"]
-        webhook_mock.assert_not_called()  # no webhook configured
+        # No webhook configured: the wrapper still routes the failure event
+        # through deliver_webhook, but with webhook_config=None, which makes
+        # delivery a no-op (no HTTP POST is ever attempted).
+        webhook_mock.assert_called_once()
+        call = webhook_mock.call_args
+        assert call.args[0] is None  # webhook_config
+        assert call.args[1] == "failed"
+        assert call.args[2] == "job-fixture"
+        assert call.args[3] == {"error": "LLM synthesis timed out"}

--- a/tests/service/test_llm.py
+++ b/tests/service/test_llm.py
@@ -5,7 +5,7 @@ using mocked HTTP responses.
 """
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -1019,9 +1019,14 @@ async def _collect(agen) -> list:
     return [item async for item in agen]
 
 
-def _effective_timeout_seconds(timeout: object) -> float:
+def _effective_timeout_seconds(timeout: httpx.Timeout | float) -> float:
     """Normalize httpx.Timeout | float into a single comparable number."""
-    return float(timeout.read) if hasattr(timeout, "read") else float(timeout)
+    if isinstance(timeout, httpx.Timeout):
+        # Tests always construct the client with an explicit scalar timeout,
+        # so the per-op values are set (not None).
+        assert timeout.read is not None
+        return float(timeout.read)
+    return float(timeout)
 
 
 class TestTimeoutDiagnosabilityLogging:
@@ -1326,3 +1331,270 @@ class TestScopeBoundaryNoOtherLLMClients:
         assert offenders == [], (
             f"modules besides agent/llm.py reference chat/completions: {offenders}"
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Regression-hardening promotions (validator scratch tests, #589/#588 follow-up)
+#
+# These pin semantic gaps the milestone-1 user-testing validators covered with
+# throwaway tests; they claim no new contract assertions (those milestones are
+# sealed). Time semantics are unchanged: scaled-down REAL delays against real
+# sockets — never virtual-clock mocking, never httpx.MockTransport for
+# timeout behavior (MockTransport handler sleeps are invisible to httpx's
+# timeout machinery).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDefaultTimeoutThreePointBoundary:
+    """VAL-LLM-001/005 three-point boundary at the unset-default anchor.
+
+    Scaled 100x against production numbers: unset default 120s ↔ 1.2s
+    (default equivalent), raised config 300s ↔ 3.0s (configured T),
+    provider delay 150s ↔ 1.5s (D). So 1.2 < 1.5 < 3.0: the same D that
+    is abandoned under the default-equivalent bound succeeds once the knob
+    is raised past D. The repo's TestSlowProviderTimeoutEnvelope covers the
+    configured-T side (D=1.5s vs T=3s success and T=0.05s failure); the
+    default-equivalent point below is the piece only the scratch validator
+    exercised.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unset_default_is_120_at_full_scale(self, monkeypatch):
+        """Anchor the scaling: env absent → the real default is 120.0."""
+        monkeypatch.delenv("LLM_CALL_TIMEOUT", raising=False)
+        load_settings.cache_clear()
+        try:
+            assert load_settings().llm_call_timeout == 120.0
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_delay_exceeding_default_equivalent_times_out(
+        self, slow_1500ms_url, monkeypatch
+    ):
+        """Point A: with the effective bound AT the scaled default
+        equivalent (1.2s), the D=1.5s provider is abandoned before it can
+        respond — proving D genuinely exceeds the default-equivalent
+        scale (ProviderOutputError, bounded elapsed < D)."""
+        from agent.llm import LLMClient
+
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "1.2")
+        load_settings.cache_clear()
+        try:
+            client = LLMClient(slow_1500ms_url, api_key="", model="fixture-model")
+            started = _time.monotonic()
+            with pytest.raises(ProviderOutputError):
+                await asyncio.wait_for(
+                    client.generate(system_prompt="x", user_prompt="y"), timeout=10
+                )
+            elapsed = _time.monotonic() - started
+            # Aborted by the 1.2s bound, i.e. before D could complete.
+            assert elapsed < 1.5
+            await asyncio.wait_for(client.close(), timeout=5)
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_same_delay_under_raised_timeout_succeeds(
+        self, slow_1500ms_url, monkeypatch
+    ):
+        """Point B: identical D=1.5s provider completes once T is raised to
+        3s (scaled image of LLM_CALL_TIMEOUT=300 vs the unset 120 default)."""
+        from agent.llm import LLMClient
+
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", "3")
+        load_settings.cache_clear()
+        try:
+            client = LLMClient(slow_1500ms_url, api_key="", model="fixture-model")
+            started = _time.monotonic()
+            result = await asyncio.wait_for(
+                client.generate(system_prompt="Be helpful.", user_prompt="Say hi."),
+                timeout=10,
+            )
+            elapsed = _time.monotonic() - started
+            assert "Synthesized answer from provided context." in result
+            # Waited out the full real delay D, and finished under T.
+            assert 1.5 <= elapsed < 3.0
+            await asyncio.wait_for(client.close(), timeout=5)
+        finally:
+            load_settings.cache_clear()
+
+
+class TestStreamSuccessEnvelope:
+    """Success-side stream envelope on the raw-SSE fixture path.
+
+    The repo's stream tests drive generate_stream through mocked httpx
+    clients; these pin the same contract against the real uvicorn raw-SSE
+    fixture (real socket, real httpx per-op timeout machinery).
+    """
+
+    @pytest.mark.asyncio
+    async def test_fast_provider_stream_ends_with_done_event(self, raw_sse):
+        """VAL-LLM-006 success side: a fast provider yields token events
+        ending in a done event with full content, and never an error."""
+        from agent.llm import LLMClient
+
+        # Three instant token chunks, no stall, straight through to [DONE].
+        raw_sse.configure(stall_after=3, quiet_seconds=0.0)
+        client = LLMClient(raw_sse.base_url, api_key="", model="fixture-model")
+        try:
+            events = await asyncio.wait_for(
+                _collect(client.generate_stream(system_prompt="x", user_prompt="y")),
+                timeout=10,
+            )
+        finally:
+            await asyncio.wait_for(client.close(), timeout=5)
+        assert events
+        assert events[-1]["type"] == "done"
+        assert events[-1].get("full_content", "").strip()
+        assert not any(event["type"] == "error" for event in events)
+
+    @pytest.mark.asyncio
+    async def test_stream_forced_timeout_yields_error_releases_slot_no_leak(
+        self, raw_sse, monkeypatch
+    ):
+        """VAL-LLM-009 stream side: a forced timeout inside generate_stream
+        yields the error event, releases the admission slot (generator
+        finally), and closes without a dangling-client hang. The repo's
+        TestCleanTimeoutFailure covers only the generate() path."""
+        from agent.admission import get_admission
+        from agent.llm import LLMClient
+
+        call_timeout = 0.5
+        raw_sse.configure(stall_after=2, quiet_seconds=3.0)
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", str(call_timeout))
+        load_settings.cache_clear()
+        try:
+            admission = get_admission()
+            assert admission.active("llm") == 0
+            client = LLMClient(raw_sse.base_url, api_key="", model="fixture-model")
+            started = _time.monotonic()
+            events = await asyncio.wait_for(
+                _collect(client.generate_stream(system_prompt="x", user_prompt="y")),
+                timeout=call_timeout + 5,
+            )
+            elapsed = _time.monotonic() - started
+            assert events
+            assert events[-1]["type"] == "error"
+            assert events[-1]["classification"] == "non_retryable"
+            assert not any(e["type"] == "done" for e in events)
+            # Bounded by ~T, not ∞.
+            assert call_timeout <= elapsed < 3.0
+            # Admission slot released by the generator's finally block.
+            assert admission.active("llm") == 0
+            # Persistent client still closes cleanly — no dangling-client hang.
+            await asyncio.wait_for(client.close(), timeout=5)
+        finally:
+            load_settings.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_stall_aborts_and_releases_admission_slot(
+        self, raw_sse, monkeypatch
+    ):
+        """VAL-LLM-014 slot hygiene: abort after a mid-stream stall leaves
+        the admission controller clean (the existing quiet-period test
+        asserts timing + error event but not slot release)."""
+        from agent.admission import get_admission
+        from agent.llm import LLMClient
+
+        call_timeout = 0.5
+        raw_sse.configure(stall_after=1, quiet_seconds=3.0)
+        monkeypatch.setenv("LLM_CALL_TIMEOUT", str(call_timeout))
+        load_settings.cache_clear()
+        try:
+            admission = get_admission()
+            assert admission.active("llm") == 0
+            client = LLMClient(raw_sse.base_url, api_key="", model="fixture-model")
+            events = await asyncio.wait_for(
+                _collect(client.generate_stream(system_prompt="x", user_prompt="y")),
+                timeout=call_timeout + 5,
+            )
+            assert events
+            assert events[-1]["type"] == "error"
+            assert events[-1].get("classification") == "non_retryable"
+            assert not any(e["type"] == "done" for e in events)
+            assert admission.active("llm") == 0  # released on abort
+            await asyncio.wait_for(client.close(), timeout=5)
+        finally:
+            load_settings.cache_clear()
+
+
+class TestWorkerRecordsSynthesisTimeoutReason:
+    """VAL-LLM-016(b): a schema-path synthesis ProviderOutputError reaches
+    store.fail_job with the provider reason via the real worker wrapper —
+    job failure is never a silent truncation."""
+
+    @pytest.mark.asyncio
+    async def test_schema_synthesis_timeout_fails_job_with_reason(self, monkeypatch):
+        """ProviderOutputError from run_research propagates through the real
+        _run_job_with_observability wrapper into store.fail_job."""
+        from agent.research.loop import run_research
+        from agent.worker import _run_job_with_observability
+
+        async def observed_work():
+            # Mirrors worker._process_agent_async's work_fn: the awaited
+            # run_research re-raises the pipeline's ProviderOutputError.
+            return await run_research(
+                prompt="question",
+                schema={"type": "object"},
+                llm_model="fixture-model",
+            )
+
+        searxng = MagicMock()
+        searxng.close = AsyncMock()
+        scraper = MagicMock()
+        scraper.close = AsyncMock()
+        llm = MagicMock()
+        llm.close = AsyncMock()
+        llm.generate = AsyncMock(
+            side_effect=ProviderOutputError(detail="LLM synthesis timed out")
+        )
+        plan = {
+            "focused_queries": ["question"],
+            "research_strategy": "focused",
+            "reasoning": "fixture",
+        }
+        discovered = {
+            "context": "source context",
+            "source_details": [
+                {"url": "https://example.com", "source": "fixture", "char_count": 14}
+            ],
+            "search_results": [{"url": "https://example.com"}],
+        }
+        captured_fail: dict = {}
+
+        class StoreSpy:
+            def fail_job(self, job_id: str, error_message: str) -> None:
+                captured_fail["reason"] = error_message
+
+        with (
+            patch("agent.research.loop.SearXNGClient", return_value=searxng),
+            patch("agent.research.loop.ScraperClient", return_value=scraper),
+            patch("agent.research.loop.LLMClient", return_value=llm),
+            patch(
+                "agent.research.loop._generate_research_plan",
+                new=AsyncMock(return_value=plan),
+            ),
+            patch(
+                "agent.research.loop._run_research_discover_and_scrape",
+                new=AsyncMock(return_value=discovered),
+            ),
+            patch(
+                "agent.webhook.deliver_webhook",
+                new=AsyncMock(return_value=None),
+            ) as webhook_mock,
+        ):
+            await asyncio.wait_for(
+                _run_job_with_observability(
+                    "job-fixture",
+                    "agent",
+                    StoreSpy(),  # type: ignore[arg-type]
+                    None,  # no webhook config → deliver_webhook no-ops anyway
+                    observed_work,
+                ),
+                timeout=10,
+            )
+
+        assert captured_fail.get("reason"), "job must be marked failed"
+        assert "timed out" in captured_fail["reason"]
+        webhook_mock.assert_not_called()  # no webhook configured


### PR DESCRIPTION
## Summary

Promotes the milestone-1 user-testing validator scratch tests into the permanent repo suite. Test-only change: **no runtime code is modified**. This is pure regression-hardening — it claims no new validation-contract assertions (the #589/#588 milestones are sealed); it converts throwaway validation evidence into committed regression tests.

### `tests/service/test_llm.py` (from `.ut-scratch-issue-589/` groups a/b/c)
- **VAL-LLM-001/005 three-point default boundary** (group-a): the unset-default anchor (`120.0`) plus the missing point-A case — a D=1.5s provider abandoned under the scaled default-equivalent bound (`LLM_CALL_TIMEOUT=1.2`) with `ProviderOutputError`, completing the configured-T success side already covered by `TestSlowProviderTimeoutEnvelope`. Real delays via the llm-svc fixture's real uvicorn socket; no virtual-clock mocking.
- **Stream-side admission-slot release** for VAL-LLM-009/016 (group-c): forced timeout inside `generate_stream` and mid-stream stall both yield the error event, release the admission slot, and close without dangling-client hangs. The existing `TestCleanTimeoutFailure` covered only `generate()`.
- **VAL-LLM-016(b) worker failure recording** (group-c): schema-path synthesis `ProviderOutputError` propagates through the real `_run_job_with_observability` wrapper into `store.fail_job` with the provider reason ("timed out"), proving job failures are never silent truncation.
- Success-side stream envelope against the raw-SSE fixture (tokens -> done, no error), complementing the mocked-transport stream tests.

### `tests/service/test_find_similar_route.py` (from `.ut-scratch-issue-588/group-b-route-contract/`)
- **VAL-FIND-016 web-mode rerank contract**: `_run_find_similar_web` healthy path — scrape -> searxng search (deliberately unranked order) -> embed query + candidates -> cosine rerank -> top-N `{url,title,description}` mapping. Previously only guarded by throwaway validation tests.

Also tightens `_effective_timeout_seconds` typing so mypy is clean on the touched file.

Scratch dirs `.ut-scratch-issue-589/` / `.ut-scratch-issue-588/` become redundant once this lands (removed from the working tree separately; they were never tracked).

## Validation

- `pytest tests/service/test_llm.py tests/service/test_find_similar_route.py -o asyncio_mode=strict -q` -> 60 passed (strict mode matches CI container behavior; all async fixtures use `@pytest_asyncio.fixture`)
- Full fast-tests lane: `pytest tests/unit/ tests/service/ -q` -> 1797 passed + 42 subtests
- `ruff check` on both files -> clean; pre-commit ruff format -> clean
- `mypy` on both files -> clean
