### PR TITLE
fix(compose): pass Qdrant timeout tuning through to semantic-svc (#588)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -80,7 +80,9 @@
 # Client-side timeout (seconds) for blocking Qdrant HTTP calls. Defaults to
 # QDRANT_QUERY_TIMEOUT so the server-side query wrapper stays the binding
 # bound; raise it if a slow-but-healthy index times out at the client first.
-# QDRANT_CLIENT_TIMEOUT=10
+# Example raises both together (default tracks QDRANT_QUERY_TIMEOUT, not 10):
+# QDRANT_QUERY_TIMEOUT=15
+# QDRANT_CLIENT_TIMEOUT=15
 
 # ── Content-Based Near-Duplicate Detection (Phase 3) ─────────────
 # Cosine similarity threshold for near-duplicate detection (default: 0.95)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,13 @@ services:
       - EMBED_MODEL_NAME=${EMBED_MODEL_NAME:-BAAI/bge-m3}
       - EMBED_DIM=${EMBED_DIM:-1024}
       - ACTIVE_EMBED_MODEL=${ACTIVE_EMBED_MODEL:-v_bge-m3}
+      # Qdrant timeout tuning must pass through from .env or operator
+      # overrides are silently ignored (#588 follow-up). app.py parses
+      # both vars with float() at import time, so the fallbacks must stay
+      # non-empty numeric values equal to today's effective defaults — an
+      # empty ${VAR:-} fallback would inject "" and crash-loop the service.
+      - QDRANT_QUERY_TIMEOUT=${QDRANT_QUERY_TIMEOUT:-10}
+      - QDRANT_CLIENT_TIMEOUT=${QDRANT_CLIENT_TIMEOUT:-10}
     volumes:
       - hf-cache:/root/.cache/huggingface
     depends_on:

--- a/docs/reference/public-surface.md
+++ b/docs/reference/public-surface.md
@@ -171,6 +171,7 @@ The configuration inventory follows `.env.sample`; unlisted implementation-only 
 - NEAR_DUP_MODE
 - NEAR_DUP_THRESHOLD
 - QDRANT_CLIENT_TIMEOUT
+- QDRANT_QUERY_TIMEOUT
 - QDRANT_URL
 - PARSE_MAX_SIZE_MB
 - QA_MAX_BOILERPLATE_RATIO

--- a/tests/service/test_compose_semantic_env_passthrough.py
+++ b/tests/service/test_compose_semantic_env_passthrough.py
@@ -22,9 +22,18 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
+
+# The containerized integration lane provisions only docker-compose.yml into
+# /app as the Compose contract input (see .github/workflows/docker.yml); the
+# dotfile .env.sample never reaches that filesystem. The .env.sample doc
+# contract below is enforced where the file exists (local dev, Fast Tests,
+# and the `inventory` job running scripts/check-docs-surface.py) and skipped
+# otherwise.
+ENV_SAMPLE = ROOT / ".env.sample"
 
 _TIMEOUT_VARS = ("QDRANT_CLIENT_TIMEOUT", "QDRANT_QUERY_TIMEOUT")
 
@@ -102,6 +111,15 @@ class TestFallbackSafety:
 class TestEnvSampleDoc:
     """.env.sample must not imply a fixed default for QDRANT_CLIENT_TIMEOUT."""
 
+    @pytest.mark.skipif(
+        not ENV_SAMPLE.exists(),
+        reason=".env.sample is not provisioned in the containerized "
+        "integration lane; the docs inventory gate enforces it on every PR",
+        owner="repository-maintainer",
+        issue="#588",
+        classification="retained",
+        environment=".env.sample absent from /app in containerized runs",
+    )
     def test_example_value_does_not_state_fixed_default_of_10(self):
         text = (ROOT / ".env.sample").read_text()
         examples = re.findall(
@@ -115,6 +133,15 @@ class TestEnvSampleDoc:
             ".env.sample example must not present 10 as a fixed default"
         )
 
+    @pytest.mark.skipif(
+        not ENV_SAMPLE.exists(),
+        reason=".env.sample is not provisioned in the containerized "
+        "integration lane; the docs inventory gate enforces it on every PR",
+        owner="repository-maintainer",
+        issue="#588",
+        classification="retained",
+        environment=".env.sample absent from /app in containerized runs",
+    )
     def test_comment_documents_query_timeout_tracking(self):
         text = (ROOT / ".env.sample").read_text()
         marker = "# Client-side timeout (seconds) for blocking Qdrant HTTP calls."

--- a/tests/service/test_compose_semantic_env_passthrough.py
+++ b/tests/service/test_compose_semantic_env_passthrough.py
@@ -1,0 +1,127 @@
+"""Compose passthrough contract for semantic-svc QDRANT timeout env vars.
+
+Issue #588 follow-up (found during PR #592 scrutiny): the ``semantic-svc``
+service in ``docker-compose.yml`` has NO ``env_file`` and its
+``environment`` block omits ``QDRANT_CLIENT_TIMEOUT``/``QDRANT_QUERY_TIMEOUT``,
+so values set in the operator's ``.env`` never reach the container and
+operator tuning is silently ignored. The environment block must substitute
+both variables from ``.env``.
+
+The substitution MUST carry a NON-EMPTY numeric fallback:
+``semantic-svc/app.py`` parses both variables with ``float(...)`` at import
+time, and Compose injects an EMPTY STRING into the container when an unset
+variable falls through ``${VAR:-}`` (verified empirically: the slopsearx
+container carries ``ENGINE_BRAVE_API_KEY=`` from its unset ``${BRAVE_API_KEY}``),
+which would crash-loop semantic-svc on startup. The fallback values must
+equal today's effective defaults (10s) so unset-``.env`` deployments are
+unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+_TIMEOUT_VARS = ("QDRANT_CLIENT_TIMEOUT", "QDRANT_QUERY_TIMEOUT")
+
+
+def _semantic_environment() -> list[str]:
+    """Return the semantic-svc compose environment list."""
+    compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text())
+    env = compose["services"]["semantic-svc"]["environment"]
+    assert isinstance(env, list), "semantic-svc environment must stay list-style"
+    return env
+
+
+def _raw_value(env: list[str], var: str) -> str:
+    """Return the compose-side value expression for ``var``."""
+    matches = [entry for entry in env if entry.startswith(f"{var}=")]
+    assert len(matches) == 1, f"expected exactly one {var} entry, got {matches}"
+    return matches[0].split("=", 1)[1]
+
+
+def _fallback(env: list[str], var: str) -> str:
+    """Extract the ``${VAR:-fallback}`` fallback for ``var``."""
+    raw = _raw_value(env, var)
+    match = re.fullmatch(r"\$\{" + var + r":-(.+)\}", raw)
+    assert match, f"{var} must use ${{{var}:-<fallback>}} form, got {raw!r}"
+    return match.group(1)
+
+
+class TestComposeEnvPassthrough:
+    """The semantic-svc environment block substitutes Qdrant timeouts."""
+
+    def test_semantic_svc_substitutes_both_qdrant_timeout_vars(self):
+        env = _semantic_environment()
+        for var in _TIMEOUT_VARS:
+            raw = _raw_value(env, var)
+            assert "${" in raw and "}" in raw, (
+                f"{var} must be substituted from .env, got literal {raw!r}"
+            )
+
+    def test_preexisting_semantic_env_vars_are_untouched(self):
+        env = _semantic_environment()
+        for var in (
+            "QDRANT_URL",
+            "VECTOR_INDEX_MAX_DOCS",
+            "EMBED_MODEL_NAME",
+            "EMBED_DIM",
+            "ACTIVE_EMBED_MODEL",
+        ):
+            _raw_value(env, var)
+
+
+class TestFallbackSafety:
+    """An unset variable must not crash-loop the service or change defaults.
+
+    ``app.py`` evaluates ``float(os.getenv(...))`` for both variables at
+    import time, so an empty-string injection (what ``${VAR:-}`` delivers)
+    is fatal. The fallback doubles as the documented default.
+    """
+
+    def test_fallback_is_non_empty_and_float_parseable(self):
+        env = _semantic_environment()
+        for var in _TIMEOUT_VARS:
+            fallback = _fallback(env, var)
+            assert fallback.strip() != "", f"{var} fallback must be non-empty"
+            float(fallback)
+
+    def test_fallback_preserves_todays_effective_defaults(self):
+        env = _semantic_environment()
+        assert float(_fallback(env, "QDRANT_QUERY_TIMEOUT")) == 10.0
+        # The client timeout's code-level default tracks QDRANT_QUERY_TIMEOUT,
+        # which is 10 unless the operator raises it — so the passthrough
+        # fallback mirrors 10 to keep unset-.env behavior byte-identical.
+        assert float(_fallback(env, "QDRANT_CLIENT_TIMEOUT")) == 10.0
+
+
+class TestEnvSampleDoc:
+    """.env.sample must not imply a fixed default for QDRANT_CLIENT_TIMEOUT."""
+
+    def test_example_value_does_not_state_fixed_default_of_10(self):
+        text = (ROOT / ".env.sample").read_text()
+        examples = re.findall(
+            r"^#\s*QDRANT_CLIENT_TIMEOUT=(\S+)\s*$", text, re.MULTILINE
+        )
+        assert len(examples) == 1, f"expected exactly one example line, got {examples}"
+        # The default TRACKS QDRANT_QUERY_TIMEOUT; showing "=10" reads as a
+        # fixed default. Any illustrative override value other than 10 is
+        # acceptable (e.g. raising it alongside a raised query timeout).
+        assert float(examples[0]) != 10.0, (
+            ".env.sample example must not present 10 as a fixed default"
+        )
+
+    def test_comment_documents_query_timeout_tracking(self):
+        text = (ROOT / ".env.sample").read_text()
+        marker = "# Client-side timeout (seconds) for blocking Qdrant HTTP calls."
+        assert marker in text
+        tail = text.split(marker, 1)[1]
+        head = tail.split("\n\n", 1)[0]
+        assert "QDRANT_QUERY_TIMEOUT" in head, (
+            "the QDRANT_CLIENT_TIMEOUT comment must reference "
+            "QDRANT_QUERY_TIMEOUT tracking"
+        )


### PR DESCRIPTION
Fixes #588 (follow-up).

## Problem

PR #592 made the semantic-svc Qdrant client timeout configurable via
`QDRANT_CLIENT_TIMEOUT`, but `docker-compose.yml` never delivers it: the
`semantic-svc` service (indexing profile) has **no `env_file`** and its
`environment` block omits both `QDRANT_CLIENT_TIMEOUT` and
`QDRANT_QUERY_TIMEOUT`. Operator values set in `.env` therefore never reach
the container, and timeout tuning is silently ignored — the same class of
silent misconfiguration issue #588 targets.

## Change

- `docker-compose.yml` (`semantic-svc.environment`): substitute both vars
  from `.env` with **non-empty numeric fallbacks**:
  - `QDRANT_QUERY_TIMEOUT=${QDRANT_QUERY_TIMEOUT:-10}`
  - `QDRANT_CLIENT_TIMEOUT=${QDRANT_CLIENT_TIMEOUT:-10}`

  Why not `${VAR:-}`: Compose injects an empty string into the container when
  an unset variable falls through `:-` (verified empirically — the slopsearx
  container carries `ENGINE_BRAVE_API_KEY=` from its unset
  `${BRAVE_API_KEY}`). `semantic-svc/app.py` parses both variables with
  `float(...)` at import time, so `""` would crash-loop the service on
  startup. The fallback values equal today's effective defaults (10s), so
  unset-`.env` deployments are byte-identical to before.
- `.env.sample`: the commented `QDRANT_CLIENT_TIMEOUT=10` example read as a
  fixed default; the default actually tracks `QDRANT_QUERY_TIMEOUT`. The
  example now raises both together and says so.
- `docs/reference/public-surface.md`: add `QDRANT_QUERY_TIMEOUT` to the env
  inventory (required by the `check-docs-surface.py` CI gate now that it
  appears in `.env.sample`).
- New contract tests: `tests/service/test_compose_semantic_env_passthrough.py`
  (6 cases: passthrough present, fallback safety/non-empty/float-parseable,
  default preservation, pre-existing env entries untouched, .env.sample doc).

No runtime code changed.

## Validation

- TDD red→green on the new test file; full fast-tests lane green
  (**1803 passed**, 42 subtests); `ruff check` clean;
  `python3 scripts/check-docs-surface.py` passes; scoped mypy clean.
- Live on the grokval stack (saru):
  - `docker compose -p grokval --profile indexing config` shows
    `QDRANT_CLIENT_TIMEOUT: "10"` / `QDRANT_QUERY_TIMEOUT: "10"` by default,
    and `"25"`/`"20"` with overrides set.
  - With `QDRANT_CLIENT_TIMEOUT=25` / `QDRANT_QUERY_TIMEOUT=20` in `.env`,
    `docker exec grokval-semantic-svc-1 env` shows both values inside the
    container and `/health` reports `{"status":"ok","models":"loaded",
    "qdrant":"ready"}`.
  - After restoring `.env`, the recreated container runs at the defaults
    (10/10) and is healthy — unset-`.env` behavior unchanged.
