### PR TITLE
fix(cli): omit crawl limit from payload when unset (PR #597 regression)

### DIFF
--- a/groktocrawl
+++ b/groktocrawl
@@ -968,7 +968,7 @@ class Client:
     def crawl(
         self,
         url: str,
-        limit: int = 0,
+        limit: int | None = 0,
         max_depth: int = 2,
         include_paths: list[str] | None = None,
         exclude_paths: list[str] | None = None,
@@ -977,11 +977,21 @@ class Client:
         retry: bool = False,
         **extra: Any,
     ) -> dict[str, Any]:
+        """Start a crawl job.
+
+        ``limit`` caps the number of pages crawled (Firecrawl v2
+        parity). ``0``/``None`` mean "unlimited": the field is OMITTED
+        from the request payload so the server applies its own default,
+        mirroring the ``max_pages=None`` handling below. It must not be
+        serialized as a ``0`` sentinel — server-side validation rejects
+        ``limit < 1``.
+        """
         data: dict[str, Any] = {
             "url": url,
-            "limit": limit,
             "max_depth": max_depth,
         }
+        if limit:
+            data["limit"] = limit
         if max_pages is not None:
             data["max_pages"] = max_pages
         if include_paths:
@@ -2832,8 +2842,8 @@ def make_parser() -> argparse.ArgumentParser:
         "--limit",
         "-l",
         type=int,
-        default=0,
-        help="Max pages to crawl (default: unlimited)",
+        default=None,
+        help="Max pages to crawl (omit for unlimited; must be >= 1 when set)",
     )
     p_crawl.add_argument(
         "--max-pages",

--- a/tests/integration/test_stack.py
+++ b/tests/integration/test_stack.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import time
+from pathlib import Path
 
 import httpx
 import pytest
@@ -2578,6 +2579,49 @@ def test_crawl_cli_json_output():
             raise AssertionError(
                 f"CLI --json output is not valid JSON: {e}\nOutput: {stdout[:200]}"
             ) from e
+
+
+@require_docker
+def test_crawl_cli_default_invocation_no_limit():
+    """Plain `groktocrawl crawl <url>` (no --limit) starts a crawl.
+
+    Regression for the PR #597 follow-up finding: the CLI historically
+    serialized its ``limit=0`` sentinel, but server-side validation now
+    requires ``limit >= 1``, so the DEFAULT invocation deterministically
+    failed with HTTP 422 INVALID_REQUEST. The client must OMIT the field
+    when unset. The lone pre-existing CLI crawl tests pass explicit
+    ``--limit`` and therefore never exercised this path.
+    """
+    import json as _json
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "groktocrawl",
+            "--json",
+            "crawl",
+            TEST_SITE + "/",
+            "--no-poll",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(Path(__file__).resolve().parents[2]),
+    )
+    assert result.returncode == 0, (
+        f"Default CLI crawl failed ({result.returncode}): {result.stderr}"
+    )
+    payload = _json.loads(result.stdout.strip())
+    assert payload["job_id"], f"No job ID in default-crawl output: {payload}"
+
+    # The created job must be a real, running/completed crawl — i.e. the
+    # server ACCEPTED the request instead of answering 422 INVALID_REQUEST.
+    status = httpx.get(AGENT + f"/v2/crawl/{payload['job_id']}", timeout=30)
+    assert status.status_code == 200, (
+        f"Crawl job {payload['job_id']} not found: {status.status_code}"
+    )
 
 
 # ── VAL-CROSS-008: Batch scrape vs Crawl coexistence ────────────

--- a/tests/service/test_cli.py
+++ b/tests/service/test_cli.py
@@ -142,18 +142,34 @@ class TestClientAuthentication:
 class TestClientCrawl:
     """Tests for Client.crawl() parameter mapping."""
 
-    def test_basic_crawl_sends_correct_data(self, client):
-        """Basic crawl sends url, limit, and max_depth."""
+    def test_basic_crawl_omits_limit_by_default(self, client):
+        """Default crawl sends NO limit field (server rejects limit=0, #597 regression).
+
+        The server-side CrawlRequest tightened ``limit`` to ``ge=1``; a
+        serialized ``limit: 0`` sentinel therefore fails validation with
+        HTTP 422. Omission means "unlimited" server-side.
+        """
 
         def _fake_request(method, path, json_data=None, params=None, **kwargs):
             assert json_data["url"] == "http://example.com"
-            assert json_data["limit"] == 0
+            assert "limit" not in json_data
             assert json_data["max_depth"] == 2
             return {"success": True, "id": "crawl-1234-uuid"}
 
         client._request = _fake_request
         result = client.crawl(url="http://example.com")
         assert result["id"] == "crawl-1234-uuid"
+
+    def test_crawl_sends_explicit_limit(self, client):
+        """An explicit --limit N is still sent as limit=N."""
+
+        def _fake_request(method, path, json_data=None, params=None, **kwargs):
+            assert json_data["limit"] == 25
+            return {"success": True, "id": "job-limit-25"}
+
+        client._request = _fake_request
+        result = client.crawl(url="http://example.com", limit=25)
+        assert result["id"] == "job-limit-25"
 
     def test_crawl_sends_include_paths(self, client):
         """include_paths is passed as include_paths."""
@@ -268,6 +284,99 @@ class TestClientCrawl:
             max_pages=5,
         )
         assert result["id"] == "job-1"
+
+
+# ── Default-invocation payload regression (PR #597 follow-up) ────────────────
+
+
+class TestCrawlDefaultInvocationPayload:
+    """The DEFAULT `groktocrawl crawl <url>` payload must carry no limit field.
+
+    PR #597 tightened the server-side ``CrawlRequest.limit`` to ``ge=1``,
+    but the CLI still serialized its historical ``limit=0`` sentinel, so
+    the plain default invocation deterministically failed with HTTP 422
+    INVALID_REQUEST. These tests drive the REAL parser + cmd_crawl +
+    Client.crawl pipeline (not just Client.crawl in isolation) so a
+    future sentinel reintroduction at any layer is caught.
+    """
+
+    def _run_default_crawl(self, monkeypatch):
+        """Drive `crawl <url>` (no flags) through parser → cmd → client.
+
+        Patches ``requests.request`` so the full CLI pipeline runs against
+        a mocked HTTP transport, and returns the JSON body the CLI put on
+        the wire. Uses ``--no-poll`` only to skip the polling loop; the
+        crawl-creation request payload is unaffected by it.
+        """
+        captured: dict = {}
+
+        def _fake_request(method, url=None, params=None, json=None, **kwargs):
+            captured["method"] = method
+            captured["url"] = url
+            captured["json"] = json
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"success": True, "id": "job-default-1"}
+            response.headers = {}
+            response.url = url
+            return response
+
+        monkeypatch.setattr("requests.request", _fake_request)
+
+        make_parser = _cli_ns["make_parser"]
+        cmd_crawl = _cli_ns["cmd_crawl"]
+        client_cls = _cli_ns["Client"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com", "--no-poll"])
+        client = client_cls(server="http://test-server:8080", dry_run=False)
+        _capture_stdout(cmd_crawl, client, args)
+
+        assert captured["method"] == "POST", f"expected POST, got {captured}"
+        assert captured["url"].endswith("/v2/crawl"), captured["url"]
+        payload = captured["json"]
+        assert payload["url"] == "http://example.com"
+        return payload
+
+    def test_default_invocation_sends_no_limit_field(self, monkeypatch):
+        """`groktocrawl crawl <url>` sends a payload WITHOUT 'limit'."""
+        payload = self._run_default_crawl(monkeypatch)
+        assert "limit" not in payload, (
+            f"default invocation must not serialize limit; got {payload}"
+        )
+
+    def test_default_invocation_keeps_unlimited_semantics(self, monkeypatch):
+        """No limit field means the server-side default: unlimited crawl."""
+        payload = self._run_default_crawl(monkeypatch)
+        assert payload["max_depth"] == 2
+        assert "max_pages" not in payload
+        assert "limit" not in payload
+
+    def test_explicit_limit_flag_still_serialized(self, monkeypatch):
+        """`groktocrawl crawl <url> --limit 3` still sends limit=3."""
+        captured: dict = {}
+
+        def _fake_request(method, url=None, params=None, json=None, **kwargs):
+            captured["json"] = json
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"success": True, "id": "job-limit-3"}
+            response.headers = {}
+            response.url = url
+            return response
+
+        monkeypatch.setattr("requests.request", _fake_request)
+
+        make_parser = _cli_ns["make_parser"]
+        cmd_crawl = _cli_ns["cmd_crawl"]
+        client_cls = _cli_ns["Client"]
+        parser = make_parser()
+        args = parser.parse_args(
+            ["crawl", "http://example.com", "--limit", "3", "--no-poll"]
+        )
+        client = client_cls(server="http://test-server:8080", dry_run=False)
+        _capture_stdout(cmd_crawl, client, args)
+
+        assert captured["json"]["limit"] == 3
 
 
 # ── Connection error handling ────────────────────────────────────────────────
@@ -560,6 +669,32 @@ class TestCrawlParser:
         parser = make_parser()
         args = parser.parse_args(["crawl", "http://example.com", "--limit", "10"])
         assert args.limit == 10
+
+    def test_parse_crawl_args_limit_defaults_none(self):
+        """--limit defaults to None (field omitted → unlimited server-side).
+
+        The historical default was the 0 sentinel, which PR #597's
+        server-side ``limit: ge=1`` validation turned into a guaranteed
+        HTTP 422 on every plain `groktocrawl crawl <url>`.
+        """
+        make_parser = _cli_ns["make_parser"]
+        parser = make_parser()
+        args = parser.parse_args(["crawl", "http://example.com"])
+        assert args.limit is None
+
+    def test_crawl_help_does_not_claim_zero_is_unlimited(self):
+        """crawl --help must not present limit=0 as the unlimited default."""
+        parser = _cli_ns["make_parser"]()
+
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        stdout = StringIO()
+        with pytest.raises(SystemExit):
+            with redirect_stdout(stdout):
+                parser.parse_args(["crawl", "--help"])
+        help_text = stdout.getvalue()
+        assert "(default: unlimited)" not in help_text
 
     def test_global_help_shows_crawl(self):
         """Top-level --help lists the crawl subcommand."""


### PR DESCRIPTION
Fixes the blocking finding from the misc-qa-hardening scrutiny of PR #597: after `CrawlRequest.limit` was tightened to `ge=1`, the bundled `groktocrawl` CLI still serialized its historical `limit=0` ("unlimited") sentinel — `Client.crawl()` always put `limit` into the payload and argparse defaulted `--limit` to 0. The DEFAULT `groktocrawl crawl <url>` therefore deterministically failed with HTTP 422 `INVALID_REQUEST` ("Input should be greater than or equal to 1") instead of starting an unlimited crawl.

## What changed

- **`groktocrawl` (`Client.crawl()`)**: omit `limit` from the crawl payload when 0/unset, mirroring the existing `max_pages=None` handling; explicit limits are unchanged.
- **argparse**: `--limit` now defaults to `None`, and the help text no longer claims a false `(default: unlimited)` zero-sentinel (now "omit for unlimited; must be >= 1 when set").
- **`tests/service/test_cli.py`**: replace the `json_data["limit"] == 0` pin with omission + explicit-limit pins, and add default-invocation payload regression tests that drive the REAL parser → `cmd_crawl` → `Client.crawl` pipeline against a mocked HTTP transport (not just mocked-transport shape pins).
- **`tests/integration/test_stack.py`**: add a live default-invocation CLI crawl test (no `--limit`) asserting job creation is accepted. The pre-existing CLI crawl tests passed explicit `--limit 1` and mocked transports, which is how CI missed this regression.
- First-party producer audit per repo convention: `mcp-svc` (`create_crawl`) already omits unset `limit`; server-side `_resolve_effective_max_pages` is already None-safe — no changes needed there.

## Validation

- TDD red→green on the new/updated CLI tests; full fast-tests lane **1846 passed**; `ruff check` clean; `mypy agent-svc/agent scraper-svc/scraper semantic-svc common/` clean; `scripts/check-docs-surface.py` OK.
- Live on the grokval stack (saru): old script `crawl <url>` → `422 INVALID_REQUEST`; fixed script → job started (HTTP 200) and completed; explicit `--limit 1` still honored and completed.
