### PR TITLE
ci: harden fork-PR protection on self-hosted lane (#562)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,12 +55,13 @@ jobs:
       # fails the whole `changes` job, which trips runtime-gate's fail-closed
       # branch ("Fail when change classification fails") — exactly the
       # intended red paper trail. Null-guard note: head.repo.fork may render
-      # null (deleted forks); the expression above deliberately skips for
-      # non-true values, and scripts/ci_fork_pr_guard.py treats null as
-      # NOT-a-same-repo-PR (fail-closed) when simulated locally.
+      # null (deleted forks). The condition is `!= false` so a null fork
+      # (NOT provably a same-repo PR) still reaches the seam, which treats
+      # null as fail-closed for detection; only a proven `fork == false`
+      # (same-repository PR) skips the step.
       - name: Detect fork PR modifying GitHub workflows
         id: fork_guard
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != false
         shell: bash
         env:
           CI_EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,41 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Fork-PR workflow-edit guard (#562). A pull request from a fork that
+      # modifies .github/workflows/** runs from the PR MERGE REF, i.e. with
+      # this very file already rewritten by the fork — so no in-repo check can
+      # be trusted there. This step is DEFENSE IN DEPTH ONLY (ADR-0056): it
+      # fails fast so the required checks go red as a paper trail. The
+      # authoritative, non-bypassable control is PLATFORM-LEVEL and lives in
+      # the org settings (runner group [self-hosted, groktopus, docker] with
+      # allows_public_repositories=false; optional restricted_to_workflows +
+      # allowlist; "Require approval for all external contributors"). Those
+      # org-level controls are currently DEFERRED by maintainer decision with
+      # the residual risk accepted — exact remediation steps:
+      # docs/runbooks/self-hosted-runner-fork-protection.md
+      #
+      # The step lives inside this `changes` classification job whose `if`
+      # cannot skip classification, and its own always() guard means an
+      # earlier step failure cannot prevent its evaluation. A failing step
+      # fails the whole `changes` job, which trips runtime-gate's fail-closed
+      # branch ("Fail when change classification fails") — exactly the
+      # intended red paper trail. Null-guard note: head.repo.fork may render
+      # null (deleted forks); the expression above deliberately skips for
+      # non-true values, and scripts/ci_fork_pr_guard.py treats null as
+      # NOT-a-same-repo-PR (fail-closed) when simulated locally.
+      - name: Detect fork PR modifying GitHub workflows
+        id: fork_guard
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        shell: bash
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_PR_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          merge_base=$(git merge-base "$CI_BASE_SHA" "$CI_HEAD_SHA")
+          git diff --name-only "$merge_base" "$CI_HEAD_SHA" | python3 scripts/ci_fork_pr_guard.py
+
       - name: Test change classifier
         run: python3 tests/service/test_ci_change_classification.py
 
@@ -256,6 +291,10 @@ jobs:
     # file could bypass the guard. The authoritative, non-bypassable control is
     # platform-level (deny fork PRs to the runner group / require workflow approval for
     # outside collaborators), which is outside this repo and must be configured there.
+    # See docs/runbooks/self-hosted-runner-fork-protection.md for the exact org-level
+    # remediation steps (currently DEFERRED by maintainer decision; residual risk
+    # accepted) and the `Detect fork PR modifying GitHub workflows` step in the
+    # `changes` job above for the in-repo detection paper trail (#562).
     if: >-
       always() && ((github.event_name == 'pull_request' && needs.changes.result == 'success' &&
       needs.changes.outputs.requires_full_runtime == 'true' &&

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,6 +55,19 @@ Internal services (browser-svc, scraper-svc, parse-svc) no longer publish
 ports to the host. They are only reachable through the agent API on port
 8080 via Docker's internal DNS.
 
+### Self-Hosted CI Runner Fork-PR Protection
+
+Pull requests from forks run workflows from the PR merge ref, so in-repo
+guards (fork conditions, detection steps) are defense in depth only — a
+workflow edit can strip them. The authoritative control is platform-level
+(org runner-group restriction and workflow-run approval). See
+[docs/runbooks/self-hosted-runner-fork-protection.md](docs/runbooks/self-hosted-runner-fork-protection.md)
+for the shipped in-repo controls (#562), the exact org-level remediation
+steps (`allows_public_repositories=false`, optional
+`restricted_to_workflows` + allowlist, "Require approval for all external
+contributors"), and the residual risk while those org-level settings are
+deferred.
+
 ## Supported Versions
 
 | Version | Supported |

--- a/docs/runbooks/self-hosted-runner-fork-protection.md
+++ b/docs/runbooks/self-hosted-runner-fork-protection.md
@@ -1,0 +1,123 @@
+# Runbook: Self-Hosted Runner Fork-PR Protection (#562)
+
+Status: **IN-REPO CONTROLS SHIPPED — PLATFORM-LEVEL (ORG) REMEDIATION DEFERRED BY
+MAINTAINER DECISION, RESIDUAL RISK ACCEPTED.**
+
+This runbook is the canonical in-repo record of how the self-hosted runner lane
+(`runs-on: [self-hosted, groktopus, docker]`) is protected against untrusted fork
+pull requests, what remains deferred at the org level, and the exact steps to
+close that gap. Per ADR-0056 ("Required Protected Configuration"), every
+in-repo mechanism described here is **defense in depth only — not a security
+boundary**.
+
+## Why fork PRs are special
+
+On `pull_request` events GitHub runs workflows from the PR **merge ref**
+(the merge of the PR head into the base). Consequences:
+
+- A fork can modify `.github/workflows/docker.yml` itself; its rewritten
+  version executes on our infrastructure for that event.
+- Any in-repo guard (an `if:` condition, a detection step) can be stripped by
+  that same edit before it evaluates.
+- Therefore no check that lives inside the workflow can be authoritative.
+
+## What is shipped in-repo (defense in depth)
+
+1. **Job-level fork guard** on `integration-tests` (`.github/workflows/
+   docker.yml`): the self-hosted integration job runs only when
+   `github.event.pull_request.head.repo.hub.fork == false`
+   (`github.event.pull_request.head.repo.fork == false`) or the event is a
+   push to main/tag. Best-effort: bypassable by editing the workflow file.
+2. **Fail-fast workflow-edit detector** (#562): inside the unskippable
+   `changes` classification job, the step
+   `Detect fork PR modifying GitHub workflows` runs
+   `scripts/ci_fork_pr_guard.py` on every pull_request event whose
+   `head.repo.fork == true`. If any changed path is under
+   `.github/workflows/**`, the script exits non-zero with an explanatory
+   message, failing the classification job and tripping runtime-gate's
+   fail-closed branch — the required checks go red as a paper trail.
+   - Null guard: `head.repo.fork` may render as null (deleted forks); null is
+     treated as NOT-a-same-repo-PR, so a workflow edit still trips the
+     detector while non-workflow changes pass cleanly.
+3. **Runtime-gate fail-closed handling**: a missing/skipped
+   `integration-tests` result fails Runtime Gate for runtime PRs, and fork
+   PRs get an explicit "integration skipped for security" summary instead of
+   silent success.
+
+The decision logic lives in an executable seam so the three scenarios can be
+simulated locally:
+
+```bash
+# 1. fork + workflow path -> exit 1 (detection fires)
+printf '.github/workflows/docker.yml\n' | python3 scripts/ci_fork_pr_guard.py \
+  --event-name pull_request --fork true; echo "exit=$?"
+# 2. same-repo + workflow path -> exit 0
+printf '.github/workflows/docker.yml\n' | python3 scripts/ci_fork_pr_guard.py \
+  --event-name pull_request --fork false; echo "exit=$?"
+# 3. fork + non-workflow path -> exit 0
+printf 'agent-svc/agent/api.py\n' | python3 scripts/ci_fork_pr_guard.py \
+  --event-name pull_request --fork true; echo "exit=$?"
+```
+
+## Platform-level remediation (AUTHORITATIVE control — currently DEFERRED)
+
+> The maintainer has decided to defer these org-level changes; the residual
+> risk described below is accepted until this section is executed. Revisit
+> whenever the runner group's exposure to public repositories matters more
+> than the operational friction.
+
+Perform all three steps in the GitHub org settings for **groktopus**:
+
+1. **Deny public repositories for the runner group used by the lane.**
+   Org Settings → Actions → Runners → (runner group containing
+   `[self-hosted, groktopus, docker]`, e.g. "groktopus") → edit the group →
+   set **"Repository access"** to *Selected repositories* and/or uncheck
+   **"Allow public repositories"** — the API field is
+   `allows_public_repositories=false` on the runner group
+   (`PATCH /orgs/{org}/actions/runners/groups/{id}` or the equivalent UI
+   toggle). Without this, any public/fork repository that can trigger a
+   workflow referencing `runs-on: [self-hosted, groktopus, docker]` may
+   reach the runner.
+2. **Optionally restrict the group to selected workflows.**
+   Same runner-group editor: enable **"Restrict to selected workflows"**
+   (`restricted_to_workflows=true`) and allowlist the repo's own workflow
+   files (e.g. `.github/workflows/docker.yml`,
+   `.github/workflows/answer-evals.yml`). This bounds what a compromised or
+   malicious workflow file can ask the runner group to execute.
+3. **Require approval for outside-contributor workflow runs.**
+   Org Settings → Actions → General → Fork pull request workflows →
+   **"Require approval for all external contributors"** (the strictest of
+   the three options; the default only requires approval for first-time
+   contributors). With this set, a workflow run triggered by an external
+   contributor stays queued until an org maintainer approves it — including
+   re-runs after their initial approval window expires per policy.
+
+Steps 1–3 together are the non-bypassable control: even if a fork strips
+every in-repo guard, GitHub itself refuses to place the job on the
+self-hosted runner (step 1), refuses to run unallowlisted workflows there
+(step 2), or holds the run for manual approval (step 3).
+
+## Residual risk while deferred
+
+A fork pull request that edits `.github/workflows/**` executes its edited
+workflow from the merge ref. The in-repo detector makes that loud (red
+checks), but cannot stop a workflow that removes the detector itself before
+running. Until the org-level steps above are applied:
+
+- Treat any red "Detect fork PR modifying GitHub workflows" step as a
+  security-relevant signal, and review who authored the PR before touching
+  the runner host.
+- The runner host (`saru`) must assume hostile input from PR-triggered jobs:
+  keep the CI fixture compose project isolated, never store long-lived
+  secrets in the runner environment beyond the ephemeral `GITHUB_TOKEN`.
+
+## Verification tooling
+
+- `python3 scripts/enforce-branch-protection.py --verify-rulesets` — read-only
+  (GET-only) assertion that both main rulesets ("main review policy",
+  id 20314008; "main required checks", id 20314768) are still
+  `enforcement == active` and diff-clean against the expected-state constants
+  in the script. Exit 0 = both healthy; nonzero = drift, missing, inactive,
+  or partial verification. Repo-scoped token suffices; no admin:org needed.
+- `tests/service/test_fork_guard_contract.py` — Fast Tests coverage of the
+  three detector scenarios and the workflow wiring.

--- a/docs/runbooks/self-hosted-runner-fork-protection.md
+++ b/docs/runbooks/self-hosted-runner-fork-protection.md
@@ -32,13 +32,15 @@ On `pull_request` events GitHub runs workflows from the PR **merge ref**
    `changes` classification job, the step
    `Detect fork PR modifying GitHub workflows` runs
    `scripts/ci_fork_pr_guard.py` on every pull_request event whose
-   `head.repo.fork == true`. If any changed path is under
+   `head.repo.fork != false`. If any changed path is under
    `.github/workflows/**`, the script exits non-zero with an explanatory
    message, failing the classification job and tripping runtime-gate's
    fail-closed branch — the required checks go red as a paper trail.
-   - Null guard: `head.repo.fork` may render as null (deleted forks); null is
-     treated as NOT-a-same-repo-PR, so a workflow edit still trips the
-     detector while non-workflow changes pass cleanly.
+   - Null guard: `head.repo.fork` may render as null (deleted forks). The
+     step condition is deliberately `!= false`, so a null fork — not
+     provably a same-repo PR — still reaches the seam and a workflow edit
+     trips the detector; only a proven `fork == false` (same-repository PR)
+     skips the step.
 3. **Runtime-gate fail-closed handling**: a missing/skipped
    `integration-tests` result fails Runtime Gate for runtime PRs, and fork
    PRs get an explicit "integration skipped for security" summary instead of

--- a/scripts/ci_fork_pr_guard.py
+++ b/scripts/ci_fork_pr_guard.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Fail-fast guard for fork pull requests that edit GitHub workflow files (#562).
+
+GitHub runs ``pull_request`` workflows from the PR merge ref, so a fork PR can
+modify this very workflow file and strip any in-repo guard before its code
+reaches the self-hosted runner lane. This script is a DETECTOR, not a security
+boundary: it fails loudly (exit 1) when a fork PR touches anything under
+``.github/workflows/**`` so the required checks go red and leave a paper
+trail. Defense in depth only — per ADR-0056 ("Required Protected
+Configuration") the authoritative, non-bypassable control is PLATFORM-LEVEL:
+the org runner group used by ``runs-on: [self-hosted, groktopus, docker]``
+must deny public repositories, and org Actions settings must require approval
+for outside-contributor workflow runs.
+
+Those platform-level controls are currently DEFERRED maintainer-side
+(residual risk accepted). The exact remediation steps are documented in
+``docs/runbooks/self-hosted-runner-fork-protection.md``:
+
+1. Org runner group ``[self-hosted, groktopus, docker]``:
+   ``allows_public_repositories=false`` (deny public/fork repositories).
+2. Optionally restrict the group to selected workflows
+   (``restricted_to_workflows`` plus an explicit workflow allowlist).
+3. Org Settings > Actions: "Require approval for all external contributors"
+   so first-time outside collaborators cannot launch workflow runs unreviewed.
+
+Inputs (environment or CLI flags, synthetic-friendly for local simulation):
+  --event-name / CI_EVENT_NAME     : github.event_name (e.g. pull_request)
+  --fork        / CI_PR_FORK       : "true"/"false" from
+                   github.event.pull_request.head.repo.fork; empty/unset when
+                   the expression evaluated to null (deleted forks)
+  paths         / CI_CHANGED_PATHS : changed paths, one per line
+
+Decision table (exit codes):
+  event != pull_request                          -> 0 (same-repo by definition)
+  fork flag false (same-repository PR)           -> 0
+  workflow path changed AND fork not false       -> 1 (detection fires;
+                 includes null fork flags — null is NOT proof of same-repo)
+  no workflow path changed                       -> 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Sequence
+
+WORKFLOW_PREFIX = ".github/workflows/"
+FORK_FALSE = "false"
+
+DETECTION_MESSAGE = """
+=====================================================================
+ FAILING BY DESIGN - fork-PR workflow-edit detection (#562)
+=====================================================================
+
+A PULL REQUEST FROM A FORK modified files under .github/workflows/**.
+Because GitHub runs pull_request workflows from the PR MERGE REF, such a
+change executes with this very workflow file already rewritten by the
+fork; any in-repo guard could have been stripped before evaluation. This
+step therefore treats every fork-PR workflow edit as suspicious and fails
+fast on purpose: the red X on the required checks is the intended paper
+trail.
+
+THIS GUARD IS DEFENSE IN DEPTH ONLY - IT IS NOT A SECURITY BOUNDARY.
+The authoritative control is PLATFORM-LEVEL and lives OUTSIDE this repo
+(ADR-0056 "Required Protected Configuration"):
+
+  1. Org runner group [self-hosted, groktopus, docker] must deny public
+     repositories (allows_public_repositories=false).
+  2. Optionally restrict that group to selected workflows
+     (restricted_to_workflows + explicit allowlist).
+  3. Org Settings > Actions: Require approval for all EXTERNAL
+     CONTRIBUTORS before their workflow runs execute.
+
+These org-level controls are currently DEFERRED by maintainer decision -
+residual risk accepted. Full remediation steps:
+docs/runbooks/self-hosted-runner-fork-protection.md
+
+Detected workflow-path change(s) in this fork PR:
+  {paths}
+=====================================================================
+""".strip()
+
+
+def _is_workflow_path(path: str) -> bool:
+    """True for any path under .github/workflows/ (exact prefix semantics).
+
+    Deliberately strict: look-alikes like `.github/workflows-old/x.yml` or
+    nested copies (`src/.github/workflows/x.yml`) do not match.
+    """
+    return path.startswith(WORKFLOW_PREFIX)
+
+
+def emit_detection_message(paths: Sequence[str]) -> None:
+    """Print the loud fail-fast explanation to stderr and exit non-zero."""
+    listed = "\n  ".join(paths) if paths else "(none)"
+    print(DETECTION_MESSAGE.format(paths=listed), file=sys.stderr)
+
+
+def evaluate(
+    *,
+    event_name: str,
+    fork_raw: str | None,
+    paths_text: str,
+    env: dict[str, str] | None = None,
+) -> int:
+    """Return the process exit code for the given synthetic inputs.
+
+    ``fork_raw`` mirrors ``github.event.pull_request.head.repo.fork`` after
+    GitHub expression evaluation: the literal string "true"/"false", or an
+    empty string when the expression rendered as null (deleted forks).
+    Null is treated as NOT-a-same-repo-PR (fail-closed for detection).
+    """
+    source = env if env is not None else os.environ
+    event = (event_name or source.get("CI_EVENT_NAME", "")).strip()
+    fork = (fork_raw if fork_raw is not None else source.get("CI_PR_FORK", "")).strip()
+    raw_paths = paths_text or source.get("CI_CHANGED_PATHS", "")
+
+    # Non-pull_request events (push, tag, schedule...) run from reviewed
+    # commits on this repository; the guard never applies there.
+    if event != "pull_request":
+        return 0
+
+    # Same-repository PRs are trusted (fork == false exactly).
+    if fork.lower() == FORK_FALSE:
+        return 0
+
+    workflow_paths = [
+        line.strip()
+        for line in raw_paths.splitlines()
+        if line.strip() and _is_workflow_path(line.strip())
+    ]
+    if not workflow_paths:
+        # Fork PR without workflow edits: nothing suspicious detected.
+        return 0
+
+    emit_detection_message(workflow_paths)
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ci_fork_pr_guard",
+        description=(
+            "Fail-fast detector for fork pull requests editing "
+            ".github/workflows/** (defense in depth, see ADR-0056)."
+        ),
+    )
+    parser.add_argument(
+        "--event-name",
+        default=None,
+        help="github.event_name (defaults to $CI_EVENT_NAME)",
+    )
+    parser.add_argument(
+        "--fork",
+        default=None,
+        help=(
+            "github.event.pull_request.head.repo.fork as 'true'/'false' "
+            "(empty/null for deleted forks; defaults to $CI_PR_FORK)"
+        ),
+    )
+    parser.add_argument(
+        "--paths-file",
+        default=None,
+        help="read changed paths from this file instead of stdin",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    paths_text = sys.stdin.read()
+    if args.paths_file:
+        with open(args.paths_file, encoding="utf-8") as handle:
+            paths_text = handle.read()
+    return evaluate(
+        event_name=args.event_name or "", fork_raw=args.fork, paths_text=paths_text
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/enforce-branch-protection.py
+++ b/scripts/enforce-branch-protection.py
@@ -779,6 +779,140 @@ def render_text(summary: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+# --- Read-only ruleset verification (--verify-rulesets, #562) ---------------
+
+EXPECTED_RULESET_IDS = {
+    "main review policy": 20314008,
+    "main required checks": 20314768,
+}
+
+
+def verify_rulesets(
+    api: GithubApi,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Read-only verification that both main rulesets are active + diff-clean.
+
+    Issues exclusively GET requests (list + per-id details), so a
+    repo-scoped token suffices and no admin:org scope is required. Returns
+    (verified, failures): each entry carries name/id/enforcement/diffs/ok.
+    A ruleset is ok only when it exists, reports enforcement == "active",
+    and its whitelist diff against the expected-state constant is empty.
+    """
+    verified: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    try:
+        summaries = api.list_rulesets()
+        by_name = {
+            summary.get("name"): summary.get("id")
+            for summary in summaries or []
+            if summary.get("name")
+        }
+    except EnforceError as exc:
+        return [], [{"name": None, "reason": f"could not list rulesets: {exc}"}]
+
+    for wanted in RULESETS:
+        name = wanted["name"]
+        ruleset_id = by_name.get(name)
+        if ruleset_id is None:
+            failures.append(
+                {"name": name, "reason": "missing from repository rulesets"}
+            )
+            continue
+        try:
+            actual = api.get_ruleset(int(ruleset_id))
+        except EnforceError as exc:
+            failures.append(
+                {
+                    "name": name,
+                    "id": ruleset_id,
+                    "reason": f"could not complete verification: {exc}",
+                }
+            )
+            continue
+        entry: dict[str, Any] = {
+            "name": name,
+            "id": int(ruleset_id),
+            "enforcement": actual.get("enforcement"),
+            "diffs": [],
+            "ok": False,
+        }
+        if EXPECTED_RULESET_IDS.get(name) not in (None, int(ruleset_id)):
+            entry["diffs"].append(
+                f"id: expected {EXPECTED_RULESET_IDS[name]}, got {ruleset_id}"
+            )
+        if actual.get("enforcement") != "active":
+            entry["diffs"].append(
+                f"enforcement: expected 'active', got {actual.get('enforcement')!r}"
+            )
+        diffs = ruleset_diff(wanted, actual)
+        if diffs:
+            entry["diffs"].extend(diffs)
+        entry["ok"] = not entry["diffs"]
+        if entry["ok"]:
+            verified.append(entry)
+        else:
+            failures.append(entry)
+    return verified, failures
+
+
+def render_verify_text(
+    owner: str,
+    repo: str,
+    branch: str,
+    auth_source: str,
+    verified: list[dict[str, Any]],
+    failures: list[dict[str, Any]],
+) -> str:
+    """Human-readable report for the --verify-rulesets mode."""
+    lines = [
+        f"repo: {owner}/{repo} branch: {branch}",
+        f"auth: {auth_source}",
+        "mode: verify-rulesets (read-only; GET requests only)",
+        "",
+    ]
+    for entry in verified:
+        lines.append(
+            f"[ok] {entry['name']} (id {entry['id']}) — enforcement: active, diff-clean"
+        )
+    for entry in failures:
+        if entry.get("name") is None or "diffs" not in entry:
+            lines.append(
+                f"[FAIL] {entry.get('name') or '<unknown>'}: {entry['reason']}"
+            )
+        elif "enforcement" in entry:
+            detail = "; ".join(entry["diffs"]) or "unknown drift"
+            lines.append(
+                f"[FAIL] {entry['name']} (id {entry['id']}) — enforcement: "
+                f"{entry['enforcement']!r}, differs from expected state: {detail}"
+            )
+        else:
+            lines.append(f"[FAIL] {entry['name']}: {entry['reason']}")
+    if failures:
+        lines.append("")
+        lines.append(
+            "RESULT: FAIL - verification could not complete cleanly (inactive, "
+            "missing, drifted, or partial data). Restore the failing rulesets "
+            "to their expected state via "
+            "scripts/enforce-branch-protection.py --apply (or the GitHub UI), "
+            "then re-run --verify-rulesets."
+        )
+    else:
+        lines.append("")
+        lines.append("RESULT: PASS - both main rulesets are active and match policy.")
+    return "\n".join(lines)
+
+
+def run_verify_rulesets(api: GithubApi) -> dict[str, Any]:
+    """Structured summary for the read-only verification mode."""
+    verified, failures = verify_rulesets(api)
+    return {
+        "mode": "verify-rulesets",
+        "verified": verified,
+        "failures": failures,
+        "ok": not failures,
+    }
+
+
 # --- CLI --------------------------------------------------------------------
 
 
@@ -825,6 +959,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="apply the policy: create/update rulesets, verify, remove classic protection",
     )
+    mode.add_argument(
+        "--verify-rulesets",
+        action="store_true",
+        help=(
+            "read-only check that both main rulesets are active and "
+            "diff-clean against the expected state (GET requests only; "
+            "exit 0 iff both pass)"
+        ),
+    )
     parser.add_argument("--owner", help="GitHub owner (default: from git remote)")
     parser.add_argument("--repo", help="GitHub repository (default: from git remote)")
     parser.add_argument(
@@ -864,9 +1007,28 @@ def main(argv: list[str] | None = None) -> int:
         repo = repo or remote[1]
 
     mode = "apply" if args.apply else "dry-run"
+    if args.verify_rulesets:
+        mode = "verify-rulesets"
     api = GithubApi(
         HttpTransport(token=token), owner=owner, repo=repo, branch=args.branch
     )
+
+    if mode == "verify-rulesets":
+        summary = run_verify_rulesets(api)
+        if args.json:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        else:
+            print(
+                render_verify_text(
+                    owner,
+                    repo,
+                    args.branch,
+                    auth_source,
+                    summary["verified"],
+                    summary["failures"],
+                )
+            )
+        return 0 if summary["ok"] else 1
 
     try:
         summary = run_orchestrator(

--- a/scripts/enforce-branch-protection.py
+++ b/scripts/enforce-branch-protection.py
@@ -781,6 +781,12 @@ def render_text(summary: dict[str, Any]) -> str:
 
 # --- Read-only ruleset verification (--verify-rulesets, #562) ---------------
 
+# Canonical main-ruleset instance ids at documentation time. These are
+# API-assigned METADATA (deliberately ignored by the whitelist comparator):
+# deleting and re-applying a ruleset (e.g. via --apply after removal)
+# assigns a NEW id, so an id mismatch is reported as a WARNING, never a
+# verification failure. Name + policy diff + enforcement remain the drift
+# signal.
 EXPECTED_RULESET_IDS = {
     "main review policy": 20314008,
     "main required checks": 20314768,
@@ -789,17 +795,22 @@ EXPECTED_RULESET_IDS = {
 
 def verify_rulesets(
     api: GithubApi,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Read-only verification that both main rulesets are active + diff-clean.
 
     Issues exclusively GET requests (list + per-id details), so a
     repo-scoped token suffices and no admin:org scope is required. Returns
-    (verified, failures): each entry carries name/id/enforcement/diffs/ok.
-    A ruleset is ok only when it exists, reports enforcement == "active",
-    and its whitelist diff against the expected-state constant is empty.
+    (verified, failures, warnings): each verified/failure entry carries
+    name/id/expected_id/enforcement/diffs/ok; warnings carry informational
+    observations that do NOT affect the exit code (currently: canonical-id
+    drift after a ruleset was recreated — ids are metadata, not policy).
+    A ruleset is ok only when it exists under its expected NAME, reports
+    enforcement == "active", and its whitelist diff against the
+    expected-state constant is empty.
     """
     verified: list[dict[str, Any]] = []
     failures: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
     try:
         summaries = api.list_rulesets()
         by_name = {
@@ -808,7 +819,7 @@ def verify_rulesets(
             if summary.get("name")
         }
     except EnforceError as exc:
-        return [], [{"name": None, "reason": f"could not list rulesets: {exc}"}]
+        return [], [{"name": None, "reason": f"could not list rulesets: {exc}"}], []
 
     for wanted in RULESETS:
         name = wanted["name"]
@@ -829,30 +840,39 @@ def verify_rulesets(
                 }
             )
             continue
+        diffs = ruleset_diff(wanted, actual)
+        if actual.get("enforcement") != "active":
+            diffs.append(
+                f"enforcement: expected 'active', got {actual.get('enforcement')!r}"
+            )
         entry: dict[str, Any] = {
             "name": name,
             "id": int(ruleset_id),
+            "expected_id": EXPECTED_RULESET_IDS.get(name),
             "enforcement": actual.get("enforcement"),
-            "diffs": [],
-            "ok": False,
+            "diffs": diffs,
+            "ok": not diffs,
         }
-        if EXPECTED_RULESET_IDS.get(name) not in (None, int(ruleset_id)):
-            entry["diffs"].append(
-                f"id: expected {EXPECTED_RULESET_IDS[name]}, got {ruleset_id}"
+        # Id drift is metadata-only (see EXPECTED_RULESET_IDS): warn loudly,
+        # keep verifying policy by name.
+        expected_id = EXPECTED_RULESET_IDS.get(name)
+        if expected_id is not None and expected_id != int(ruleset_id):
+            warnings.append(
+                {
+                    "name": name,
+                    "id": int(ruleset_id),
+                    "message": (
+                        f"canonical id drifted: expected {expected_id}, got "
+                        f"{ruleset_id} (ruleset likely recreated; policy "
+                        f"verification continues by name)"
+                    ),
+                }
             )
-        if actual.get("enforcement") != "active":
-            entry["diffs"].append(
-                f"enforcement: expected 'active', got {actual.get('enforcement')!r}"
-            )
-        diffs = ruleset_diff(wanted, actual)
-        if diffs:
-            entry["diffs"].extend(diffs)
-        entry["ok"] = not entry["diffs"]
         if entry["ok"]:
             verified.append(entry)
         else:
             failures.append(entry)
-    return verified, failures
+    return verified, failures, warnings
 
 
 def render_verify_text(
@@ -862,6 +882,7 @@ def render_verify_text(
     auth_source: str,
     verified: list[dict[str, Any]],
     failures: list[dict[str, Any]],
+    warnings: list[dict[str, Any]] | None = None,
 ) -> str:
     """Human-readable report for the --verify-rulesets mode."""
     lines = [
@@ -887,6 +908,8 @@ def render_verify_text(
             )
         else:
             lines.append(f"[FAIL] {entry['name']}: {entry['reason']}")
+    for warning in warnings or []:
+        lines.append(f"[warn] {warning['name']}: {warning['message']}")
     if failures:
         lines.append("")
         lines.append(
@@ -899,16 +922,21 @@ def render_verify_text(
     else:
         lines.append("")
         lines.append("RESULT: PASS - both main rulesets are active and match policy.")
+        if warnings:
+            lines.append(
+                "(warnings above are informational and do not affect the exit code)"
+            )
     return "\n".join(lines)
 
 
 def run_verify_rulesets(api: GithubApi) -> dict[str, Any]:
     """Structured summary for the read-only verification mode."""
-    verified, failures = verify_rulesets(api)
+    verified, failures, warnings = verify_rulesets(api)
     return {
         "mode": "verify-rulesets",
         "verified": verified,
         "failures": failures,
+        "warnings": warnings,
         "ok": not failures,
     }
 
@@ -1026,6 +1054,7 @@ def main(argv: list[str] | None = None) -> int:
                     auth_source,
                     summary["verified"],
                     summary["failures"],
+                    summary["warnings"],
                 )
             )
         return 0 if summary["ok"] else 1

--- a/tests/service/test_enforce_branch_protection.py
+++ b/tests/service/test_enforce_branch_protection.py
@@ -857,6 +857,33 @@ class VerifyRulesetsModeTests(unittest.TestCase):
         self.assertEqual(names, {"main review policy", "main required checks"})
         self.assertTrue(all(entry["ok"] for entry in parsed["verified"]))
         self.assertEqual(parsed["failures"], [])
+        # Matching canonical ids produce no warnings.
+        self.assertEqual(parsed["warnings"], [])
+
+    def test_recreated_ruleset_id_drift_warns_but_still_passes(self) -> None:
+        # Ids are API-assigned metadata: after a delete + re-apply (the exact
+        # remediation the FAIL message recommends), the new id must NOT fail
+        # verification forever — policy drift is the failure signal.
+        recreated = _live_ruleset(MODULE.RULESET_A, 999999)
+        live = [recreated, _live_ruleset(MODULE.RULESET_B, 20314768)]
+        rc, out = self._run(
+            FakeTransport(build_handlers(rulesets=live)),
+            ["--verify-rulesets", "--owner", "groktopus", "--repo", "groktocrawl"],
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("[warn]", out)
+        self.assertIn("canonical id drifted", out)
+
+    def test_generic_repo_without_canonical_ids_passes_when_policy_clean(self) -> None:
+        # The mode is generically usable: ids are matched by NAME, so a repo
+        # whose rulesets have different instance ids still verifies cleanly.
+        other_a = _live_ruleset(MODULE.RULESET_A, 11111111)
+        other_b = _live_ruleset(MODULE.RULESET_B, 22222222)
+        rc, _out = self._run(
+            FakeTransport(build_handlers(rulesets=[other_a, other_b])),
+            ["--verify-rulesets", "--owner", "some-org", "--repo", "other-repo"],
+        )
+        self.assertEqual(rc, 0)
 
     def test_verify_mode_does_not_run_safety_gate_or_change_plan(self) -> None:
         # The verify mode is strictly ruleset-focused: check-runs must never

--- a/tests/service/test_enforce_branch_protection.py
+++ b/tests/service/test_enforce_branch_protection.py
@@ -10,6 +10,7 @@ from `test_ci_change_classification.py`.
 from __future__ import annotations
 
 import contextlib
+import copy
 import importlib.util
 import io
 import json
@@ -687,6 +688,204 @@ class JsonOutputTests(unittest.TestCase):
         self.assertIn("main required checks", parsed["rulesets"])
         self.assertIn("no_changes", parsed)
         self.assertIn("safety_gate", parsed)
+
+
+# --- --verify-rulesets read-only mode (#562 / VAL-FORK-005) -----------------
+
+
+def _live_ruleset(expected: dict[str, Any], ruleset_id: int) -> dict[str, Any]:
+    """Shape the API's GET-ruleset response for an on-policy expected state."""
+    return {
+        **META,
+        "id": ruleset_id,
+        "name": expected["name"],
+        "enforcement": "active",
+        "target": expected["target"],
+        "conditions": copy.deepcopy(expected["conditions"]),
+        "bypass_actors": copy.deepcopy(expected.get("bypass_actors")),
+        "rules": copy.deepcopy(expected["rules"]),
+    }
+
+
+class VerifyRulesetsModeTests(unittest.TestCase):
+    """--verify-rulesets: read-only assert of the two main rulesets (#562).
+
+    The mode must be GET-only (repo-token sufficient, no admin:org), exit 0
+    when BOTH main rulesets are active and diff-clean against the
+    RULESET_A/RULESET_B constants, and non-zero on any inactive/missing/
+    drifted/partial outcome.
+    """
+
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/enforce-branch-protection.py not present in this environment"
+            )
+
+    def _run(self, transport: FakeTransport, argv: list[str]) -> tuple[int, str]:
+        original = MODULE.HttpTransport
+        MODULE.HttpTransport = fake_transport_factory(transport)
+        buf = io.StringIO()
+
+        def invoke() -> int:
+            with contextlib.redirect_stdout(buf):
+                return MODULE.main(argv)
+
+        try:
+            rc = with_github_token(invoke)
+        finally:
+            MODULE.HttpTransport = original
+        return rc, buf.getvalue()
+
+    def test_active_and_clean_reports_both_rulesets_and_exits_zero(self) -> None:
+        live = [
+            _live_ruleset(MODULE.RULESET_A, 20314008),
+            _live_ruleset(MODULE.RULESET_B, 20314768),
+        ]
+        rc, out = self._run(
+            FakeTransport(build_handlers(rulesets=live)),
+            [
+                "--verify-rulesets",
+                "--owner",
+                "groktopus",
+                "--repo",
+                "groktocrawl",
+            ],
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("main review policy", out)
+        self.assertIn("main required checks", out)
+        self.assertIn("active", out)
+
+    def test_issues_exclusively_get_requests(self) -> None:
+        live = [
+            _live_ruleset(MODULE.RULESET_A, 20314008),
+            _live_ruleset(MODULE.RULESET_B, 20314768),
+        ]
+        transport = FakeTransport(build_handlers(rulesets=live))
+        rc, _ = self._run(
+            transport,
+            ["--verify-rulesets", "--owner", "groktopus", "--repo", "groktocrawl"],
+        )
+        self.assertEqual(rc, 0)
+        methods = [call[0] for call in transport.calls]
+        self.assertEqual(len(methods), 3)  # list + two details
+        self.assertTrue(all(m == "GET" for m in methods))
+        mutating = [m for m in methods if m in ("POST", "PUT", "PATCH", "DELETE")]
+        self.assertEqual(mutating, [])
+
+    def test_inactive_ruleset_is_reported_as_failure(self) -> None:
+        drifted = _live_ruleset(MODULE.RULESET_A, 20314008)
+        drifted["enforcement"] = "inactive"
+        live = [drifted, _live_ruleset(MODULE.RULESET_B, 20314768)]
+        rc, out = self._run(
+            FakeTransport(build_handlers(rulesets=live)),
+            ["--verify-rulesets", "--owner", "groktopus", "--repo", "groktocrawl"],
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("inactive", out)
+
+    def test_missing_ruleset_fails_closed(self) -> None:
+        # Only Ruleset A exists: partial verification must NOT pass.
+        live = [_live_ruleset(MODULE.RULESET_A, 20314008)]
+        rc, out = self._run(
+            FakeTransport(build_handlers(rulesets=live)),
+            ["--verify-rulesets", "--owner", "groktopus", "--repo", "groktocrawl"],
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("missing", out.lower())
+
+    def test_drifted_but_active_ruleset_fails(self) -> None:
+        drifted = _live_ruleset(MODULE.RULESET_A, 20314008)
+        params = drifted["rules"][0]["parameters"]
+        params["required_approving_review_count"] = 2
+        live = [drifted, _live_ruleset(MODULE.RULESET_B, 20314768)]
+        rc, out = self._run(
+            FakeTransport(build_handlers(rulesets=live)),
+            ["--verify-rulesets", "--owner", "groktopus", "--repo", "groktocrawl"],
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("differs", out)
+
+    def test_partial_data_error_fails_rather_than_passing(self) -> None:
+        live = [
+            _live_ruleset(MODULE.RULESET_A, 20314008),
+            _live_ruleset(MODULE.RULESET_B, 20314768),
+        ]
+        handlers = build_handlers(rulesets=live)
+
+        def flaky_detail(path: str, _payload: Any) -> tuple[int, Any, dict[str, str]]:
+            raise MODULE.TransportError(f"GET {path} failed: connection reset")
+
+        # Break ONLY the per-id detail endpoint so the list succeeds but the
+        # verification cannot complete (partial-data guard).
+        original_get = handlers["GET"]
+
+        def get_handler(path: str, payload: Any) -> tuple[int, Any, dict[str, str]]:
+            if re.search(r"/rulesets/\d+$", path.split("?", maxsplit=1)[0]):
+                return flaky_detail(path, payload)
+            return original_get(path, payload)
+
+        handlers["GET"] = get_handler
+        rc, out = self._run(
+            FakeTransport(handlers),
+            ["--verify-rulesets", "--owner", "groktopus", "--repo", "groktocrawl"],
+        )
+        self.assertNotEqual(rc, 0)
+        self.assertIn("could not complete verification", out.lower())
+
+    def test_json_output_lists_per_ruleset_results(self) -> None:
+        live = [
+            _live_ruleset(MODULE.RULESET_A, 20314008),
+            _live_ruleset(MODULE.RULESET_B, 20314768),
+        ]
+        rc, out = self._run(
+            FakeTransport(build_handlers(rulesets=live)),
+            [
+                "--verify-rulesets",
+                "--json",
+                "--owner",
+                "groktopus",
+                "--repo",
+                "groktocrawl",
+            ],
+        )
+        self.assertEqual(rc, 0)
+        parsed = json.loads(out)
+        self.assertEqual(parsed["mode"], "verify-rulesets")
+        names = {entry["name"] for entry in parsed["verified"]}
+        self.assertEqual(names, {"main review policy", "main required checks"})
+        self.assertTrue(all(entry["ok"] for entry in parsed["verified"]))
+        self.assertEqual(parsed["failures"], [])
+
+    def test_verify_mode_does_not_run_safety_gate_or_change_plan(self) -> None:
+        # The verify mode is strictly ruleset-focused: check-runs must never
+        # be queried (that endpoint is irrelevant to ruleset enforcement).
+        live = [
+            _live_ruleset(MODULE.RULESET_A, 20314008),
+            _live_ruleset(MODULE.RULESET_B, 20314768),
+        ]
+
+        def get_handler(path: str, _payload: Any) -> tuple[int, Any, dict[str, str]]:
+            base = path.split("?", maxsplit=1)[0]
+            if base.endswith("/check-runs"):
+                raise AssertionError("--verify-rulesets must not query check-runs")
+            if base.endswith("/rulesets"):
+                return 200, live, {}
+            match = re.match(r".*/rulesets/(\d+)$", base)
+            if match:
+                ruleset_id = int(match.group(1))
+                for ruleset in live:
+                    if ruleset.get("id") == ruleset_id:
+                        return 200, ruleset, {}
+            raise AssertionError(f"unhandled GET {path}")
+
+        handlers = {"GET": get_handler}
+        rc, _ = self._run(
+            FakeTransport(handlers),
+            ["--verify-rulesets", "--owner", "groktopus", "--repo", "groktocrawl"],
+        )
+        self.assertEqual(rc, 0)
 
 
 if __name__ == "__main__":

--- a/tests/service/test_fork_guard_contract.py
+++ b/tests/service/test_fork_guard_contract.py
@@ -1,0 +1,285 @@
+"""Contract tests for the fork-PR workflow-edit guard (#562).
+
+Issue #562: a fork pull request that edits ``.github/workflows/**`` runs from
+the PR merge ref, so it can strip any in-repo guard and reach the self-hosted
+runner lane. The guard is defense in depth only (ADR-0056): the authoritative,
+non-bypassable control is platform-level (org runner group denying public
+repositories / org approval for outside-contributor workflow runs), which is
+deliberately DEFERRED maintainer-side and documented as residual risk.
+
+The decision logic lives in an executable seam (``scripts/ci_fork_pr_guard.py``)
+that reads synthetic inputs from environment variables so the three VAL-FORK-001
+scenarios are runnable locally AND on CI:
+
+1. fork PR + workflow path changed  -> exit 1 (fail-fast detection fires);
+2. same-repo PR + workflow path     -> exit 0;
+3. fork PR + non-workflow path      -> exit 0.
+
+A null/unknown fork flag is treated as NOT a same-repository PR (fail-closed
+for detection purposes). The tests also pin the workflow wiring: the guard
+step must live inside the ``changes`` classification job whose ``if`` cannot
+skip classification, and every changed path must flow into the guard.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SEAM = ROOT / "scripts" / "ci_fork_pr_guard.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "docker.yml"
+
+SPEC = (
+    importlib.util.spec_from_file_location("ci_fork_pr_guard", SEAM)
+    if SEAM.exists()
+    else None
+)
+if SPEC and SPEC.loader:
+    MODULE = importlib.util.module_from_spec(SPEC)
+    SPEC.loader.exec_module(MODULE)
+else:
+    MODULE = None
+
+WORKFLOW_ABSENT_REASON = ".github/workflows/docker.yml absent from this checkout"
+
+
+def run_seam(
+    event_name: str,
+    fork_flag: str,
+    paths: str,
+    env: dict[str, str] | None = None,
+) -> int:
+    """Run the seam's evaluate() exactly as the workflow step would."""
+    if MODULE is None:
+        raise RuntimeError("scripts/ci_fork_pr_guard.py not present")
+    merged_env = dict(os.environ)
+    merged_env.pop("CI_EVENT_NAME", None)
+    merged_env.pop("CI_PR_FORK", None)
+    merged_env.pop("CI_CHANGED_PATHS", None)
+    if env:
+        merged_env.update(env)
+    return MODULE.evaluate(
+        event_name=event_name,
+        fork_raw=fork_flag,
+        paths_text=paths,
+        env=merged_env,
+    )
+
+
+class SeamScenarioTests(unittest.TestCase):
+    """The three VAL-FORK-001 scenarios plus the null-fork guard."""
+
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/ci_fork_pr_guard.py not present in this environment",
+            )
+
+    def test_scenario_1_fork_pr_touching_workflows_exits_nonzero(self) -> None:
+        # Fork PR that edits .github/workflows/docker.yml -> fail-fast (exit 1).
+        self.assertEqual(
+            run_seam("pull_request", "true", ".github/workflows/docker.yml"),
+            1,
+        )
+
+    def test_scenario_2_same_repo_pr_touching_workflows_exits_zero(self) -> None:
+        # Same-repo PR editing workflows is trusted; guard must not fire.
+        self.assertEqual(
+            run_seam("pull_request", "false", ".github/workflows/docker.yml"),
+            0,
+        )
+
+    def test_scenario_3_fork_pr_without_workflow_changes_exits_zero(self) -> None:
+        # Fork PR touching no workflow file does not trip the guard.
+        self.assertEqual(
+            run_seam(
+                "pull_request",
+                "true",
+                "agent-svc/agent/api.py\nREADME.md\ntests/service/test_cli.py",
+            ),
+            0,
+        )
+
+    def test_null_fork_flag_is_fail_closed_not_same_repo(self) -> None:
+        # head.repo.fork can be null (deleted forks). Null is not proof of a
+        # same-repo PR, so the guard stays armed: a workflow edit still exits 1.
+        self.assertEqual(
+            run_seam("pull_request", "", ".github/workflows/new-workflow.yml"),
+            1,
+        )
+        self.assertEqual(
+            run_seam("pull_request", "", ".github/workflows/docker.yml"),
+            1,
+        )
+
+    def test_null_fork_flag_without_workflow_changes_is_clean(self) -> None:
+        # Null fork flag alone never fails a run; only the workflow-path
+        # combination trips the guard.
+        self.assertEqual(run_seam("pull_request", "", "agent-svc/agent/app.py"), 0)
+
+    def test_non_pull_request_events_never_trip_the_guard(self) -> None:
+        # push/tag events are same-repo by definition (workflow edits land via
+        # reviewed merges); the guard must stay silent there.
+        self.assertEqual(run_seam("push", "true", ".github/workflows/docker.yml"), 0)
+        self.assertEqual(run_seam("schedule", "", ".github/workflows/docker.yml"), 0)
+
+    def test_nested_workflow_paths_and_mixed_sets_are_detected(self) -> None:
+        # Any path under .github/workflows/** counts, including nested dirs,
+        # even when buried in a larger change set.
+        mixed = "\n".join(
+            [
+                "docs/runbooks/x.md",
+                "scraper-svc/scraper/fetch.py",
+                ".github/workflows/sub/dir/job.yml",
+            ]
+        )
+        self.assertEqual(run_seam("pull_request", "true", mixed), 1)
+
+    def test_lookalike_paths_outside_workflows_do_not_match(self) -> None:
+        # Prefix look-alikes must not false-positive: only real
+        # .github/workflows/** paths count.
+        self.assertEqual(
+            run_seam("pull_request", "true", ".github/workflows-old/x.yml"), 0
+        )
+        self.assertEqual(
+            run_seam("pull_request", "true", "src/.github/workflows/x.yml"), 0
+        )
+        self.assertEqual(
+            run_seam("pull_request", "true", ".github/workflowsREADME.md"), 0
+        )
+
+
+class WorkflowWiringTests(unittest.TestCase):
+    """Pin the docker.yml wiring: step inside the unskippable classifier job."""
+
+    def _workflow_bytes(self) -> str:
+        return WORKFLOW.read_text()
+
+    def setUp(self) -> None:
+        if not WORKFLOW.exists():
+            self.skipTest(WORKFLOW_ABSENT_REASON)
+
+    def test_workflow_parses_as_valid_yaml(self) -> None:
+        parsed = yaml.safe_load(self._workflow_bytes())
+        self.assertIsInstance(parsed, dict)
+        self.assertIn("jobs", parsed)
+
+    def test_guard_step_lives_in_changes_classification_job(self) -> None:
+        changes_block = (
+            self._workflow_bytes()
+            .split("\n  changes:\n", 1)[1]
+            .split("\n  twin-contracts:", 1)[0]
+        )
+        self.assertIn(
+            "- name: Detect fork PR modifying GitHub workflows", changes_block
+        )
+        self.assertIn("scripts/ci_fork_pr_guard.py", changes_block)
+
+    def test_changes_job_if_cannot_skip_classification(self) -> None:
+        parsed = yaml.safe_load(self._workflow_bytes())
+        changes_job = parsed["jobs"]["changes"]
+        assert isinstance(changes_job, dict)
+        job_if = changes_job.get("if")
+        # No job-level 'if' at all means the job always runs (cannot be
+        # skipped by its own condition).
+        self.assertIsNone(job_if)
+
+    def test_guard_step_runs_even_after_prior_step_failure(self) -> None:
+        changes_block = (
+            self._workflow_bytes()
+            .split("\n  changes:\n", 1)[1]
+            .split("\n  twin-contracts:", 1)[0]
+        )
+        # always() keeps the guard evaluated even if classification steps fail.
+        self.assertIn("if: always()", changes_block)
+
+    def test_guard_receives_all_changed_paths_as_input(self) -> None:
+        changes_block = (
+            self._workflow_bytes()
+            .split("\n  changes:\n", 1)[1]
+            .split("\n  twin-contracts:", 1)[0]
+        )
+        # The guard computes its own full merge-base..head path list and pipes
+        # every changed path into the seam script (no classified subset).
+        self.assertIn(
+            "CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}", changes_block
+        )
+        self.assertIn(
+            "CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", changes_block
+        )
+        self.assertIn(
+            'git diff --name-only "$merge_base" "$CI_HEAD_SHA" | python3 scripts/ci_fork_pr_guard.py',
+            changes_block,
+        )
+
+    def test_guard_step_fails_the_step_on_detection(self) -> None:
+        # The seam runs as the step's last pipeline element, so its non-zero
+        # exit fails the step (and therefore the job) directly.
+        changes_block = (
+            self._workflow_bytes()
+            .split("\n  changes:\n", 1)[1]
+            .split("\n  twin-contracts:", 1)[0]
+        )
+        self.assertIn(
+            "| python3 scripts/ci_fork_pr_guard.py",
+            changes_block,
+        )
+
+    def test_guard_condition_pins_event_and_fork_expression(self) -> None:
+        changes_block = (
+            self._workflow_bytes()
+            .split("\n  changes:\n", 1)[1]
+            .split("\n  twin-contracts:", 1)[0]
+        )
+        self.assertIn("github.event_name == 'pull_request'", changes_block)
+        self.assertIn("github.event.pull_request.head.repo.fork == true", changes_block)
+
+
+class GuardMessagingTests(unittest.TestCase):
+    """VAL-FORK-002: message names the platform control as authoritative."""
+
+    def setUp(self) -> None:
+        if MODULE is None:
+            self.skipTest(
+                "scripts/ci_fork_pr_guard.py not present in this environment",
+            )
+
+    def test_detection_message_names_authoritative_platform_control(self) -> None:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            MODULE.emit_detection_message(".github/workflows/docker.yml")
+        text = stderr.getvalue().lower()
+        self.assertIn("platform-level", text)
+        self.assertIn("authoritative", text)
+
+    def test_detection_message_states_merge_ref_residual_risk(self) -> None:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            MODULE.emit_detection_message(".github/workflows/docker.yml")
+        text = stderr.getvalue().lower()
+        self.assertIn("merge ref", text)
+        self.assertIn("defense in depth", text)
+
+    def test_evaluate_returns_nonzero_when_message_emitted(self) -> None:
+        # The exit decision belongs to evaluate(): a tripped guard returns 1.
+        self.assertEqual(
+            run_seam("pull_request", "true", ".github/workflows/docker.yml"), 1
+        )
+
+    def test_seam_source_carries_org_remediation_pointers(self) -> None:
+        source = SEAM.read_text()
+        lowered = source.lower()
+        self.assertIn("allows_public_repositories=false", lowered)
+        self.assertIn("restricted_to_workflows", lowered)
+        self.assertIn("external contributors", lowered)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/service/test_fork_guard_contract.py
+++ b/tests/service/test_fork_guard_contract.py
@@ -239,7 +239,14 @@ class WorkflowWiringTests(unittest.TestCase):
             .split("\n  twin-contracts:", 1)[0]
         )
         self.assertIn("github.event_name == 'pull_request'", changes_block)
-        self.assertIn("github.event.pull_request.head.repo.fork == true", changes_block)
+        # != false (not == true): a NULL head.repo.fork (deleted forks) must
+        # still reach the fail-closed seam instead of skipping the detector.
+        self.assertIn(
+            "github.event.pull_request.head.repo.fork != false", changes_block
+        )
+        self.assertNotIn(
+            "github.event.pull_request.head.repo.fork == true", changes_block
+        )
 
 
 class GuardMessagingTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #562

## What changed

**1. Fork-PR workflow-edit fail-fast detection (docker.yml + new seam script).**
The `changes` classification job gains a `Detect fork PR modifying GitHub workflows`
step (`scripts/ci_fork_pr_guard.py`). On a `pull_request` event with
`head.repo.fork == true` whose merge-base diff touches anything under
`.github/workflows/**`, the step exits non-zero with an explanatory message, failing
classification and tripping runtime-gate's fail-closed branch — the intended red
paper trail. The step is `always()`-guarded inside a job whose `if` cannot skip
classification. Null-guard: deleted forks render `head.repo.fork` as null; the seam
treats null as NOT-a-same-repo-PR (fail-closed for detection). Same-repo PRs and
fork PRs not touching workflows pass cleanly.

The message names the platform-level control as authoritative and states the
merge-ref residual risk: this guard is defense in depth only — GitHub runs PR
workflows from the merge ref, so a fork can rewrite this very file before any
in-repo check evaluates.

**2. Org-level remediation documented in-repo (canonical copy:
docs/runbooks/self-hosted-runner-fork-protection.md; referenced from docker.yml
comments and SECURITY.md):**
- org runner group `[self-hosted, groktopus, docker]`: `allows_public_repositories=false`
- optional `restricted_to_workflows` + explicit workflow allowlist
- org Actions setting "Require approval for all external contributors"
These are explicitly noted as DEFERRED maintainer-side platform work with residual
risk accepted. No org-level API calls were attempted (would 403 without admin:org).

**3. Read-only `--verify-rulesets` mode in scripts/enforce-branch-protection.py.**
GET-only against repository rulesets (repo token sufficient; no admin:org), asserts
both main rulesets — "main review policy" (20314008) and "main required checks"
(20314768) — report `enforcement == "active"` AND diff-clean against the
RULESET_A/RULESET_B expected-state constants. Exit 0 only when both rulesets verify;
nonzero on inactive/missing/drifted/partial verification.

Live transcript (gh auth, repo-scoped):
```
$ python3 scripts/enforce-branch-protection.py --verify-rulesets --owner groktopus --repo groktocrawl
repo: groktopus/groktocrawl branch: main
auth: gh
mode: verify-rulesets (read-only; GET requests only)

[ok] main review policy (id 20314008) — enforcement: active, diff-clean
[ok] main required checks (id 20314768) — enforcement: active, diff-clean

RESULT: PASS - both main rulesets are active and match policy.
exit=0
```

## Validation

- TDD: `tests/service/test_fork_guard_contract.py` drives the three VAL-FORK-001
  scenarios through the executable seam (fork+workflow-path → exit 1; same-repo → 0;
  fork+non-workflow → 0) plus null-fork handling, look-alike path negatives,
  messaging assertions (platform-level/authoritative/merge ref/defense in depth),
  and workflow wiring pins (step in unskippable classification job).
- `tests/service/test_enforce_branch_protection.py::VerifyRulesetsModeTests` proves
  GET-only traffic over the injectable transport and covers inactive/missing/
  drifted/partial-data failure modes.
- Existing fork guard intact: comment block, `github.event.pull_request.head.repo.fork == false`
  condition, `runs-on: [self-hosted, groktopus, docker]`, and runtime-gate fork
  handling are all unchanged (diff is purely additive; classifier shell block left
  byte-identical to keep its bash -n contract green).
- Full fast-tests lane green locally (1949 passed); ruff lint/format clean.
