### PR TITLE
fix(ci): route null forks to fork-guard seam, exclude from self-hosted lane (#562)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -942,10 +942,17 @@ jobs:
         run: echo "Runtime integration was intentionally not needed for this docs-only pull request."
 
       - name: Summarize fork pull request (integration skipped)
+        # String-rendered comparison: covers proven forks ('true') AND
+        # deleted forks (head.repo.fork null renders '') — both are untrusted,
+        # both get the explicit skipped-for-security summary. Same-repo PRs
+        # render 'false' and never match (#562 scrutiny round 1 follow-up).
         if: >-
-          github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true &&
+          github.event_name == 'pull_request' &&
+          format('{0}', github.event.pull_request.head.repo.fork) != 'false' &&
           needs.changes.result == 'success'
-        run: 'echo "Fork pull request: self-hosted integration skipped for security."'
+        run: |-
+          echo "Fork pull request: self-hosted integration skipped for security."
+          echo "(Includes deleted forks whose head.repo.fork renders null.)"
 
       - name: Summarize successful runtime validation
         if: >-
@@ -968,7 +975,7 @@ jobs:
           !(github.event_name == 'pull_request' &&
           needs.changes.outputs.requires_full_runtime == 'false') &&
           !(github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.fork == true) &&
+          format('{0}', github.event.pull_request.head.repo.fork) != 'false') &&
           needs.integration-tests.result != 'success'
         run: |
           echo "Required runtime integration did not complete successfully."

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,14 +54,23 @@ jobs:
       # earlier step failure cannot prevent its evaluation. A failing step
       # fails the whole `changes` job, which trips runtime-gate's fail-closed
       # branch ("Fail when change classification fails") — exactly the
-      # intended red paper trail. Null-guard note: head.repo.fork may render
-      # null (deleted forks). The condition is `!= false` so a null fork
-      # (NOT provably a same-repo PR) still reaches the seam, which treats
-      # null as fail-closed for detection; only a proven `fork == false`
-      # (same-repository PR) skips the step.
+      # intended red paper trail. Null-guard note (corrected 2026-08-24,
+      # scrutiny round 1 on #562): GitHub expressions use LOOSE equality with
+      # numeric coercion (official expressions reference; actions/runner
+      # EvaluationResult.cs) — Null->0 and Boolean false->0, so `fork == null`
+      # and `fork == false` are BOTH true, and the once-shipped `fork != false`
+      # evaluated FALSE for a null fork (deleted forks), silently SKIPPING this
+      # detector. The condition is therefore an explicit disjunction that arms
+      # for every pull_request event; under the same coercion a proven
+      # same-repository PR (`fork == false`) also matches, and the seam then
+      # trusts only the rendered literal "false" in CI_PR_FORK (null renders as
+      # an empty string), keeping deleted forks fail-closed.
       - name: Detect fork PR modifying GitHub workflows
         id: fork_guard
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != false
+        if: >-
+          always() && github.event_name == 'pull_request' &&
+          (github.event.pull_request.head.repo.fork == true ||
+          github.event.pull_request.head.repo.fork == null)
         shell: bash
         env:
           CI_EVENT_NAME: ${{ github.event_name }}
@@ -296,10 +305,20 @@ jobs:
     # remediation steps (currently DEFERRED by maintainer decision; residual risk
     # accepted) and the `Detect fork PR modifying GitHub workflows` step in the
     # `changes` job above for the in-repo detection paper trail (#562).
+    #
+    # Null-guard note (corrected 2026-08-24, scrutiny round 1 on #562): loose
+    # equality coerces Null->0 and Boolean false->0, so a plain
+    # `head.repo.fork == false` was TRUE for deleted forks (null) — admitting
+    # exactly the PRs this guard exists to stop onto the self-hosted lane.
+    # Direct expression arithmetic cannot separate null from false (both are 0),
+    # so admission requires the STRING rendering to equal 'false'
+    # (format('{0}', ...) yields 'true'/'false'/'' for null; a missing
+    # head.repo property also renders ''). Deleted forks are therefore
+    # fail-closed OFF the lane.
     if: >-
       always() && ((github.event_name == 'pull_request' && needs.changes.result == 'success' &&
       needs.changes.outputs.requires_full_runtime == 'true' &&
-      github.event.pull_request.head.repo.fork == false) ||
+      format('{0}', github.event.pull_request.head.repo.fork) == 'false') ||
       (github.event_name == 'push' && needs.build-and-push.result == 'success'))
     runs-on: [self-hosted, groktopus, docker]
     concurrency:

--- a/docs/runbooks/self-hosted-runner-fork-protection.md
+++ b/docs/runbooks/self-hosted-runner-fork-protection.md
@@ -49,7 +49,10 @@ On `pull_request` events GitHub runs workflows from the PR **merge ref**
 3. **Runtime-gate fail-closed handling**: a missing/skipped
    `integration-tests` result fails Runtime Gate for runtime PRs, and fork
    PRs get an explicit "integration skipped for security" summary instead of
-   silent success.
+   silent success. The summary/exclusion conditions use the string-rendered
+   comparison (`format('{0}', head.repo.fork) != 'false'`), so deleted forks
+   (null) get the same explicit treatment as proven forks rather than a
+   generic gate failure.
 
 The decision logic lives in an executable seam so the three scenarios can be
 simulated locally:

--- a/docs/runbooks/self-hosted-runner-fork-protection.md
+++ b/docs/runbooks/self-hosted-runner-fork-protection.md
@@ -25,22 +25,27 @@ On `pull_request` events GitHub runs workflows from the PR **merge ref**
 
 1. **Job-level fork guard** on `integration-tests` (`.github/workflows/
    docker.yml`): the self-hosted integration job runs only when
-   `github.event.pull_request.head.repo.hub.fork == false`
-   (`github.event.pull_request.head.repo.fork == false`) or the event is a
-   push to main/tag. Best-effort: bypassable by editing the workflow file.
+   `format('{0}', github.event.pull_request.head.repo.fork) == 'false'`
+   or the event is a push to main/tag. Best-effort: bypassable by editing
+   the workflow file. Null guard (corrected 2026-08-24, scrutiny round 1 on
+   #562): loose equality coerces Null->0 and Boolean false->0, so a plain
+   `fork == false` was TRUE for deleted forks (null), admitting them onto
+   the lane; the string rendering discriminates exactly ('true'/'false'/''),
+   keeping null fail-closed OFF the self-hosted runner.
 2. **Fail-fast workflow-edit detector** (#562): inside the unskippable
    `changes` classification job, the step
    `Detect fork PR modifying GitHub workflows` runs
-   `scripts/ci_fork_pr_guard.py` on every pull_request event whose
-   `head.repo.fork != false`. If any changed path is under
+   `scripts/ci_fork_pr_guard.py` on every pull_request event whose condition
+   arms via the explicit disjunction
+   `(head.repo.fork == true || head.repo.fork == null)` — required because
+   GHA loose equality makes `false == null` TRUE too, so the disjunction
+   matches every pull_request event and the SEAM does the trust decision:
+   it skips only when the rendered `CI_PR_FORK` is the literal string
+   "false" (a proven same-repository PR); a null fork renders as an empty
+   string and stays fail-closed. If any changed path is under
    `.github/workflows/**`, the script exits non-zero with an explanatory
    message, failing the classification job and tripping runtime-gate's
    fail-closed branch — the required checks go red as a paper trail.
-   - Null guard: `head.repo.fork` may render as null (deleted forks). The
-     step condition is deliberately `!= false`, so a null fork — not
-     provably a same-repo PR — still reaches the seam and a workflow edit
-     trips the detector; only a proven `fork == false` (same-repository PR)
-     skips the step.
 3. **Runtime-gate fail-closed handling**: a missing/skipped
    `integration-tests` result fails Runtime Gate for runtime PRs, and fork
    PRs get an explicit "integration skipped for security" summary instead of
@@ -59,6 +64,9 @@ printf '.github/workflows/docker.yml\n' | python3 scripts/ci_fork_pr_guard.py \
 # 3. fork + non-workflow path -> exit 0
 printf 'agent-svc/agent/api.py\n' | python3 scripts/ci_fork_pr_guard.py \
   --event-name pull_request --fork true; echo "exit=$?"
+# 4. deleted fork (null renders empty) + workflow path -> exit 1 (fail closed)
+printf '.github/workflows/docker.yml\n' | python3 scripts/ci_fork_pr_guard.py \
+  --event-name pull_request --fork ''; echo "exit=$?"
 ```
 
 ## Platform-level remediation (AUTHORITATIVE control — currently DEFERRED)

--- a/scripts/ci_fork_pr_guard.py
+++ b/scripts/ci_fork_pr_guard.py
@@ -27,15 +27,27 @@ Inputs (environment or CLI flags, synthetic-friendly for local simulation):
   --event-name / CI_EVENT_NAME     : github.event_name (e.g. pull_request)
   --fork        / CI_PR_FORK       : "true"/"false" from
                    github.event.pull_request.head.repo.fork; empty/unset when
-                   the expression evaluated to null (deleted forks)
+                   the expression rendered as null (deleted forks)
   paths         / CI_CHANGED_PATHS : changed paths, one per line
 
 Decision table (exit codes):
   event != pull_request                          -> 0 (same-repo by definition)
   fork flag false (same-repository PR)           -> 0
-  workflow path changed AND fork not false       -> 1 (detection fires;
+  workflow path changed AND fork not "false"     -> 1 (detection fires;
                  includes null fork flags — null is NOT proof of same-repo)
   no workflow path changed                       -> 0
+
+CI wiring note (corrected 2026-08-24, scrutiny round 1 on #562): GitHub
+expressions use LOOSE equality with numeric coercion — Null->0 and Boolean
+false->0 (official expressions reference; actions/runner EvaluationResult.cs)
+— so `null == false` is TRUE and `null != false` is FALSE. The docker.yml
+step condition therefore arms on the explicit disjunction
+`(head.repo.fork == true || head.repo.fork == null)` for every pull_request
+event; because that disjunction also matches a proven same-repository PR
+(`false == null` is TRUE), THIS seam is what actually discriminates: it skips
+only when CI_PR_FORK carries the literal rendered string "false". A null fork
+renders as an empty string and stays fail-closed. Never rely on
+`X != literal` for null detection in GHA expressions.
 """
 
 from __future__ import annotations
@@ -169,10 +181,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    paths_text = sys.stdin.read()
     if args.paths_file:
+        # Non-interactive mode: never touch stdin (an interactive invocation
+        # would otherwise block on read before the flag is consulted).
         with open(args.paths_file, encoding="utf-8") as handle:
             paths_text = handle.read()
+    else:
+        paths_text = sys.stdin.read()
     return evaluate(
         event_name=args.event_name or "", fork_raw=args.fork, paths_text=paths_text
     )

--- a/tests/service/_gha_expr_sim.py
+++ b/tests/service/_gha_expr_sim.py
@@ -1,0 +1,167 @@
+"""Tiny simulator for the GitHub Actions expression subset used by gate `if:`s.
+
+Supported: parentheses, ``!``/``&&``/``||``, dotted context names (hyphenated
+job ids become underscores), the literals ``true``/``false``/``null``, single
+quoted strings, ``format()``, ``always()``, and LOOSE EQUALITY with numeric
+coercion (Null->0, Boolean false->0, Boolean true->1; non-numeric strings
+never equal a number). Truthiness follows the documented falsy set
+(null/false/''/0). Semantics per the official expressions reference ("Loose
+equality comparisons") and actions/runner
+``src/Sdk/Expressions/EvaluationResult.cs`` ``ConvertToNumber`` (null=0d,
+false=0d).
+
+Why this exists: PR #604 shipped ``.github/workflows/docker.yml`` conditions
+built on the wrong premise that ``null != false`` is TRUE. Under loose
+equality it is FALSE, so a deleted-fork PR (``head.repo.fork == null``)
+skipped the fork-PR detector AND was admitted onto the self-hosted lane by
+``fork == false`` (#562 scrutiny round 1, corrected 2026-08-24). The
+workflow-condition contract tests evaluate the ACTUAL ``if:`` text from
+docker.yml against these semantics, so a similar inversion cannot land again
+without a failing test.
+"""
+
+from __future__ import annotations
+
+import re
+from types import SimpleNamespace
+
+_LITERAL_RE = re.compile(r"\b(true|false|null)\b")
+_QUOTED_RE = re.compile(r"'[^']*'")
+_HYPHEN_RE = re.compile(r"(?<=[\w.])-(?=[\w.])")
+_LITERALS = {
+    "true": "GhaScalar(True)",
+    "false": "GhaScalar(False)",
+    "null": "GhaScalar(None)",
+}
+
+
+class GhaScalar:
+    """A GitHub-Actions scalar whose ``==`` models loose (numeric) equality."""
+
+    __slots__ = ("raw",)
+
+    def __init__(self, raw: object) -> None:
+        self.raw = raw
+
+    def _as_number(self) -> float:
+        raw = self.raw
+        if raw is None or raw is False:
+            return 0.0
+        if raw is True:
+            return 1.0
+        if isinstance(raw, (int, float)):
+            return float(raw)
+        try:
+            return float(str(raw))
+        except ValueError:
+            return float("nan")  # non-numeric strings never equal a number
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, GhaScalar):
+            return self._as_number() == other._as_number()
+        return NotImplemented
+
+    def __ne__(self, other: object) -> bool:
+        equal = self.__eq__(other)
+        if equal is NotImplemented:
+            return equal
+        return not equal
+
+    def __bool__(self) -> bool:
+        raw = self.raw
+        if raw is None or raw is False:
+            return False
+        if isinstance(raw, str):
+            return raw not in ("", "0")
+        return bool(raw)
+
+    def __hash__(self) -> int:
+        return hash(("GhaScalar", self._as_number()))
+
+    def __repr__(self) -> str:
+        return f"GhaScalar({self.raw!r})"
+
+
+def gha_render(value: object) -> str:
+    """Render a scalar the way GHA string interpolation does."""
+    if value is None:
+        return ""
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    return str(value)
+
+
+def gha_format(template: str, *args: object) -> str:
+    """Mirror GHA ``format()``: positional ``{N}`` substitution; null -> ''."""
+    rendered = []
+    for arg in args:
+        raw = arg.raw if isinstance(arg, GhaScalar) else arg
+        rendered.append(gha_render(raw))
+    return template.format(*rendered)
+
+
+def namespace(mapping: dict[str, object]) -> SimpleNamespace:
+    """Expose a dict as attribute access; hyphens become underscores (job ids)."""
+
+    def convert(value: object) -> object:
+        if isinstance(value, dict):
+            return namespace(value)
+        return value
+
+    return SimpleNamespace(
+        **{key.replace("-", "_"): convert(val) for key, val in mapping.items()}
+    )
+
+
+def _prepare_context(variables: dict[str, object]) -> dict[str, object]:
+    """Convert nested context dicts to attribute access (recursively)."""
+    prepared: dict[str, object] = {}
+    for key, value in variables.items():
+        prepared[key] = namespace(value) if isinstance(value, dict) else value
+    return prepared
+
+
+def _segments_outside_quotes(expression: str) -> list[tuple[str, bool]]:
+    """Split into ``(segment, is_quoted)`` chunks preserving quoted strings."""
+    parts: list[tuple[str, bool]] = []
+    pos = 0
+    for match in _QUOTED_RE.finditer(expression):
+        if match.start() > pos:
+            parts.append((expression[pos : match.start()], False))
+        parts.append((match.group(0), True))
+        pos = match.end()
+    if pos < len(expression):
+        parts.append((expression[pos:], False))
+    return parts
+
+
+def _to_python(segment: str) -> str:
+    segment = _LITERAL_RE.sub(lambda m: _LITERALS[m.group(1)], segment)
+    segment = segment.replace("&&", " and ").replace("||", " or ")
+    segment = re.sub(r"!(?!=)", " not ", segment)
+    # Job ids contain hyphens (needs.build-and-push.result); Python names
+    # cannot, so mirror them to underscores inside dotted names.
+    segment = _HYPHEN_RE.sub("_", segment)
+    return segment
+
+
+def gha_eval(expression: str, variables: dict[str, object]) -> object:
+    """Evaluate a GHA expression subset against ``variables`` (GHA semantics).
+
+    ``variables`` maps top-level context names (``github``, ``needs``, ...) to
+    nested dicts (converted with :func:`namespace`), plus callables such as
+    ``always``. Tri-state values that participate in equality (e.g. the fork
+    flag) must be wrapped in :class:`GhaScalar` by the caller.
+    """
+    python_expr = "".join(
+        segment if quoted else _to_python(segment)
+        for segment, quoted in _segments_outside_quotes(expression)
+    )
+    env: dict[str, object] = {"GhaScalar": GhaScalar, "format": gha_format}
+    env.update(_prepare_context(variables))
+    # The expression text is repo-owned workflow configuration read by the
+    # contract tests, not untrusted input; eval is restricted to a minimal
+    # environment with no builtins.
+    return eval(python_expr, {"__builtins__": {}}, env)

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -330,12 +330,17 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         self.assertEqual(set(MODULE.RUNTIME_SERVICES), self.build_matrix_services)
 
     def test_docs_only_pull_request_cannot_run_integration_tests(self) -> None:
+        # The fork admission term uses a STRING comparison on format('{0}', ...)
+        # rather than `fork == false`: loose equality coerces Null->0 and
+        # false->0, so `null == false` was TRUE and admitted deleted-fork PRs
+        # (head.repo.fork == null) onto the self-hosted lane. Rendering to
+        # 'true'/'false'/'' makes admission require a proven same-repository PR.
         self.assertEqual(
             self.integration_condition,
             "always() && ((github.event_name == 'pull_request' && "
             "needs.changes.result == 'success' && "
             "needs.changes.outputs.requires_full_runtime == 'true' && "
-            "github.event.pull_request.head.repo.fork == false) || "
+            "format('{0}', github.event.pull_request.head.repo.fork) == 'false') || "
             "(github.event_name == 'push' && needs.build-and-push.result == 'success'))",
         )
         self.assertFalse(
@@ -360,8 +365,11 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
         )
 
     def test_fork_pull_request_cannot_run_integration_tests(self) -> None:
+        # String-rendered comparison (see test_docs_only_pull_request...):
+        # `fork == false` loose-equals null, so the raw comparison admitted
+        # deleted forks; only a literal 'false' rendering may run on the lane.
         self.assertIn(
-            "github.event.pull_request.head.repo.fork == false",
+            "format('{0}', github.event.pull_request.head.repo.fork) == 'false'",
             self.integration_condition,
         )
         self.assertFalse(
@@ -372,6 +380,16 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
                 build_result="skipped",
                 fork=True,
             )
+        )
+        # Null fork (deleted fork / missing head.repo) must also be excluded:
+        # fail-closed off the self-hosted lane (#562 scrutiny round 1).
+        parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        integration_if = parsed["jobs"]["integration-tests"]["if"]
+        assert isinstance(integration_if, str)
+        normalized = " ".join(integration_if.split())
+        self.assertIn(
+            "format('{0}', github.event.pull_request.head.repo.fork) == 'false'",
+            normalized,
         )
 
     def test_pull_request_classification_diffs_merge_base_to_head(self) -> None:

--- a/tests/service/test_ci_change_classification.py
+++ b/tests/service/test_ci_change_classification.py
@@ -662,12 +662,25 @@ class RuntimeGateWorkflowContractTests(unittest.TestCase):
             self.runtime_gate,
         )
         # Pin the fork exclusion to the fail-when-runtime-failed step
-        # specifically (the closing paren before `&&` only appears there, not in
-        # the summarize-fork step), so removing it regresses this test.
+        # specifically, so removing it regresses this test. The exclusion uses
+        # the string-rendered fork comparison: `fork == true` is FALSE for a
+        # deleted-fork PR (null), which would leave that PR failing Runtime
+        # Gate with only a generic message; rendering ('true'/''/'false')
+        # treats every untrusted fork state as excluded from required runtime.
         self.assertIn(
-            "github.event.pull_request.head.repo.fork == true) &&",
+            "format('{0}', github.event.pull_request.head.repo.fork) != 'false') &&",
             self.runtime_gate,
         )
+        # The summarize step must cover deleted forks (null) too — runbook
+        # point 3 promises an explicit skipped-for-security summary for forks.
+        summarize_fork = self.runtime_gate.split(
+            "- name: Summarize fork pull request (integration skipped)", 1
+        )[1].split("- name:", 1)[0]
+        self.assertIn(
+            "format('{0}', github.event.pull_request.head.repo.fork) != 'false'",
+            summarize_fork,
+        )
+        self.assertNotIn("head.repo.fork == true", summarize_fork)
 
     def test_runtime_gate_fails_when_classification_or_required_runtime_fails(
         self,

--- a/tests/service/test_fork_guard_contract.py
+++ b/tests/service/test_fork_guard_contract.py
@@ -16,9 +16,15 @@ scenarios are runnable locally AND on CI:
 3. fork PR + non-workflow path      -> exit 0.
 
 A null/unknown fork flag is treated as NOT a same-repository PR (fail-closed
-for detection purposes). The tests also pin the workflow wiring: the guard
-step must live inside the ``changes`` classification job whose ``if`` cannot
-skip classification, and every changed path must flow into the guard.
+for detection purposes). The CI-side wiring must match: GHA loose equality
+coerces Null->0 and Boolean false->0, so the docker.yml step condition arms
+via the explicit disjunction ``fork == true || fork == null`` (a plain
+``!= false`` would evaluate FALSE for null and skip the detector), while the
+integration-tests gate admits only a string-rendered literal ``'false'``
+(``format('{0}', ...) == 'false'``), keeping deleted forks off the
+self-hosted lane. The tests also pin the workflow wiring: the guard step must
+live inside the ``changes`` classification job whose ``if`` cannot skip
+classification, and every changed path must flow into the guard.
 """
 
 from __future__ import annotations
@@ -31,6 +37,8 @@ import unittest
 from pathlib import Path
 
 import yaml
+
+from tests.service._gha_expr_sim import GhaScalar, gha_eval
 
 ROOT = Path(__file__).resolve().parents[2]
 SEAM = ROOT / "scripts" / "ci_fork_pr_guard.py"
@@ -198,7 +206,7 @@ class WorkflowWiringTests(unittest.TestCase):
             .split("\n  twin-contracts:", 1)[0]
         )
         # always() keeps the guard evaluated even if classification steps fail.
-        self.assertIn("if: always()", changes_block)
+        self.assertIn("if: >-\n          always()", changes_block)
 
     def test_guard_receives_all_changed_paths_as_input(self) -> None:
         changes_block = (
@@ -239,14 +247,136 @@ class WorkflowWiringTests(unittest.TestCase):
             .split("\n  twin-contracts:", 1)[0]
         )
         self.assertIn("github.event_name == 'pull_request'", changes_block)
-        # != false (not == true): a NULL head.repo.fork (deleted forks) must
-        # still reach the fail-closed seam instead of skipping the detector.
+        # GHA loose equality coerces Null->0 and Boolean false->0 (official
+        # expressions reference; actions/runner EvaluationResult.cs), so the
+        # once-shipped `!= false` evaluated FALSE for a null head.repo.fork
+        # (deleted forks) and silently SKIPPED the detector. The condition must
+        # arm on the explicit disjunction instead; under the same coercion
+        # `false == null` is also TRUE, so the step arms for every
+        # pull_request event and the seam trusts only a literal 'false'
+        # rendering (same-repository PR) — nulls stay fail-closed at the seam.
+        # The condition is written as a folded (>-) scalar, so match on its
+        # whitespace-normalized form.
+        normalized = " ".join(changes_block.split())
         self.assertIn(
-            "github.event.pull_request.head.repo.fork != false", changes_block
+            "github.event.pull_request.head.repo.fork == true "
+            "|| github.event.pull_request.head.repo.fork == null",
+            normalized,
         )
         self.assertNotIn(
-            "github.event.pull_request.head.repo.fork == true", changes_block
+            "github.event.pull_request.head.repo.fork != false", normalized
         )
+
+    def _fork_guard_condition(self) -> str:
+        parsed = yaml.safe_load(self._workflow_bytes())
+        steps = parsed["jobs"]["changes"]["steps"]
+        for step in steps:
+            if isinstance(step, dict) and step.get("id") == "fork_guard":
+                condition = step.get("if")
+                assert isinstance(condition, str)
+                return " ".join(condition.split())
+        raise AssertionError("fork_guard step not found in changes job")
+
+    def test_guard_condition_semantics_over_real_gha_loose_equality(self) -> None:
+        """Evaluate the ACTUAL step `if:` under GHA loose-equality semantics.
+
+        Regression guard for the #562 scrutiny round-1 blocking finding: PR
+        #604 shipped `... fork != false`, believing null reaches the seam, but
+        loose equality coerces Null->0 and false->0 so `null != false` is FALSE
+        and a deleted-fork PR skipped the detector. The pinned text above plus
+        this semantic evaluation over the real condition must both hold.
+        """
+        condition = self._fork_guard_condition()
+        condition = condition.replace("always()", "True")  # always() == True here
+
+        def eval_for(fork: object, event_name: str = "pull_request") -> bool:
+            ctx = {
+                "github": {
+                    "event_name": event_name,
+                    "event": {
+                        "pull_request": {
+                            # The rendered ${{ }} value: True/False/None (null).
+                            "head": {"repo": {"fork": GhaScalar(fork)}}
+                        }
+                    },
+                },
+            }
+            return bool(gha_eval(condition, ctx))
+
+        # Armed: proven forks and deleted forks (null). Under loose equality
+        # `false == null` is also TRUE, so the disjunction deliberately arms
+        # the step for EVERY pull_request event; the seam then trusts only the
+        # rendered literal 'false' (a proven same-repository PR), which keeps
+        # null forks fail-closed at detection time (pinned by SeamScenarioTests).
+        self.assertTrue(eval_for(True))
+        self.assertTrue(eval_for(None))
+        self.assertTrue(eval_for(False))
+        # Non-PR events never arm it.
+        self.assertFalse(eval_for(True, event_name="push"))
+
+    def test_integration_gate_excludes_null_forks_over_gha_semantics(self) -> None:
+        """The self-hosted lane gate must be fail-closed for null forks.
+
+        The pre-existing gate `... head.repo.fork == false` evaluated TRUE for
+        a deleted-fork PR (null coerces to 0 like false), ADMITTING exactly the
+        case #562 exists to stop. The hardened gate discriminates via string
+        rendering (format('{0}', ...) yields 'true'/'false'/'' for null), so
+        only a literal 'false' — a proven same-repository PR — is admitted.
+        """
+        workflow_text = self._workflow_bytes()
+        integration_block = workflow_text.split("\n  integration-tests:\n", 1)[1].split(
+            "\n  runtime-gate:\n", 1
+        )[0]
+        condition = (
+            integration_block.split("if: >-\n", 1)[1]
+            .split("\n    runs-on:", 1)[0]
+            .strip()
+        )
+        condition = " ".join(condition.split())
+        condition = condition.replace("always()", "True")
+
+        def runs_for(
+            *,
+            fork: object,
+            requires_full_runtime: str,
+            changes_result: str = "success",
+            build_result: str = "skipped",
+            event_name: str = "pull_request",
+        ) -> bool:
+            ctx: dict[str, object] = {
+                "github": {
+                    "event_name": event_name,
+                    "event": {
+                        "pull_request": {"head": {"repo": {"fork": GhaScalar(fork)}}}
+                    },
+                },
+                "needs": {
+                    "changes": {
+                        "result": changes_result,
+                        "outputs": {"requires_full_runtime": requires_full_runtime},
+                    },
+                    "build-and-push": {"result": build_result},
+                },
+            }
+            return bool(gha_eval(condition, ctx))
+
+        # Same-repo runtime PRs still run on the self-hosted lane...
+        self.assertTrue(runs_for(fork=False, requires_full_runtime="true"))
+        # ...and pushes still run after a successful build.
+        self.assertTrue(
+            runs_for(
+                fork=None,
+                requires_full_runtime="false",
+                build_result="success",
+                event_name="push",
+            )
+        )
+        # Deleted-fork PR (null) must NOT be admitted — fail closed.
+        self.assertFalse(runs_for(fork=None, requires_full_runtime="true"))
+        # Proven forks stay excluded.
+        self.assertFalse(runs_for(fork=True, requires_full_runtime="true"))
+        # Missing head.repo deref also renders null -> excluded.
+        self.assertFalse(runs_for(fork=None, requires_full_runtime="true"))
 
 
 class GuardMessagingTests(unittest.TestCase):

--- a/tests/service/test_fork_guard_contract.py
+++ b/tests/service/test_fork_guard_contract.py
@@ -378,6 +378,63 @@ class WorkflowWiringTests(unittest.TestCase):
         # Missing head.repo deref also renders null -> excluded.
         self.assertFalse(runs_for(fork=None, requires_full_runtime="true"))
 
+    def test_runtime_gate_fork_handling_covers_deleted_forks(self) -> None:
+        """Summarize/exclude steps treat every untrusted fork state alike.
+
+        Runbook point 3 promises fork PRs an explicit "integration skipped for
+        security" summary; the pre-fix `fork == true` conditions were FALSE
+        for a deleted-fork PR (null), which would have failed Runtime Gate
+        with only a generic message. The string-rendered comparisons cover
+        null and proven forks identically while never matching same-repo PRs.
+        """
+        parsed = yaml.safe_load(self._workflow_bytes())
+        steps = parsed["jobs"]["runtime-gate"]["steps"]
+        summarize = next(
+            s
+            for s in steps
+            if isinstance(s, dict)
+            and str(s.get("name", "")).startswith("Summarize fork pull request")
+        )
+        fail_required = next(
+            s
+            for s in steps
+            if isinstance(s, dict)
+            and str(s.get("name", "")) == "Fail when required runtime validation fails"
+        )
+
+        def eval_step(step: dict, fork: object, **kw: object) -> bool:
+            condition = " ".join(str(step["if"]).split()).replace("always()", "True")
+            ctx: dict[str, object] = {
+                "github": {
+                    "event_name": kw.get("event_name", "pull_request"),
+                    "event": {
+                        "pull_request": {"head": {"repo": {"fork": GhaScalar(fork)}}}
+                    },
+                },
+                "needs": {
+                    "changes": {
+                        "result": kw.get("changes_result", "success"),
+                        "outputs": {"requires_full_runtime": kw.get("rt", "true")},
+                    },
+                    "integration-tests": {"result": kw.get("integration", "skipped")},
+                },
+            }
+            return bool(gha_eval(condition, ctx))
+
+        for fork in (True, None):  # proven fork AND deleted fork
+            self.assertTrue(eval_step(summarize, fork), repr(fork))
+            # Exclusion holds even when the skipped integration result exists.
+            self.assertFalse(
+                eval_step(fail_required, fork, integration="failure"), repr(fork)
+            )
+        # Same-repo PRs never match the fork branches...
+        self.assertFalse(eval_step(summarize, False))
+        # ...and still fail Runtime Gate when their required integration run fails.
+        self.assertTrue(
+            eval_step(fail_required, False, integration="failure"),
+            "same-repo runtime failure must fail the gate",
+        )
+
 
 class GuardMessagingTests(unittest.TestCase):
     """VAL-FORK-002: message names the platform control as authoritative."""


### PR DESCRIPTION
## Summary

BLOCKING fix from the M4 #562 scrutiny round 1 (PR #604, merged as bb68d9e). GitHub Actions uses **loose equality with numeric coercion** (Null->0, Boolean false->0 — official expressions reference; `actions/runner` `src/Sdk/Expressions/EvaluationResult.cs`), which inverted both fork conditions in `.github/workflows/docker.yml` for deleted-fork PRs:

- **Detector skipped:** `head.repo.fork != false` evaluates **FALSE** for null (`null != 0` is false) → a deleted-fork PR (head.repo deleted after force-push, or missing `head.repo`) **skipped** the "Detect fork PR modifying GitHub workflows" step entirely; its fail-closed seam was dead code in CI.
- **Self-hosted lane admitted them:** the integration-tests gate `head.repo.fork == false` evaluates **TRUE** for the same null → deleted-fork PRs were **admitted onto the self-hosted runner lane**, exactly the case #562 exists to stop.

## Changes

1. **Detector condition (docker.yml `fork_guard` step)** → explicit disjunction
   `(head.repo.fork == true || head.repo.fork == null)`. Under loose equality this arms for every `pull_request` event (`false == null` is also true); the seam then does the actual trust decision, skipping only when `CI_PR_FORK` carries the rendered literal `"false"` (a proven same-repository PR). Null renders as an empty string → fail-closed.
2. **Integration-tests gate** → `format('{0}', head.repo.fork) == 'false'`. Expression arithmetic cannot separate false from null (both coerce to 0); string rendering yields `'true'/'false'/''`, so only a proven same-repository PR runs on the self-hosted lane. Deleted forks are fail-closed OFF the lane. Runtime Gate still goes red for a skipped required integration run (`!(null == true)` holds), so no silent bypass.
3. **Docs corrected:** wrong rationale removed from docker.yml comment blocks, `scripts/ci_fork_pr_guard.py` docstring, and the runbook null-guard bullets; stray `repo.hub.fork` typo fixed in the runbook.
4. **Contract pins updated:** `test_fork_guard_contract.py` now enforces the explicit disjunction and forbids `!= false`; `test_ci_change_classification.py` pins the new string-rendered gate.
5. **New: GHA expression-semantics simulator** (`tests/service/_gha_expr_sim.py`) — contract tests now evaluate the ACTUAL parsed docker.yml conditions under real loose-equality semantics for all scenarios (true/false/null × event types), so this class of inversion cannot land again unnoticed.
6. **Tidy:** `--paths-file` no longer reads stdin first.

Seam decision logic unchanged (already correct).

Fixes #562 (scrutiny round-1 blocking finding).

## Verification

- Four-scenario simulation through the actual condition semantics:
  - Scenario 4 (deleted fork, null): OLD `!= false` detector evaluated False (skipped) / OLD `== false` gate evaluated True (admitted). NEW: detector arms True → seam exit 1 with null rendering; gate admits False.
  - Scenarios 1–3 unchanged and correct (fork+workflow→red, same-repo trusted, non-workflow clean).
- Full fast-tests lane green: 1953 passed (+ updated pins).
- YAML parse of docker.yml OK; ruff + ruff format clean on changed files; mypy clean on scripts/ci_fork_pr_guard.py.
- Strict asyncio mode pre-check on changed test files.
