### PR TITLE
chore: bump slopsearx image pins to DDG-resilient build (#413)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       retries: 20
 
   slopsearx:
-    image: ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d
+    image: ghcr.io/magnus919/slopsearx@sha256:91194d146d205b1cf4688c1989da8f5f6b599a9627be23fd1ee7a4e488fda5b7
     restart: unless-stopped
     ports:
       - "8081:8080"
@@ -26,7 +26,7 @@ services:
       retries: 3
 
   slopsearx-mcp:
-    image: ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d
+    image: ghcr.io/magnus919/slopsearx@sha256:91194d146d205b1cf4688c1989da8f5f6b599a9627be23fd1ee7a4e488fda5b7
     # The MCP companion must never run unauthenticated, but a required-token
     # guard using the Compose `:?` operator would abort a no-config
     # `docker compose up` at load time (Compose interpolates the whole file

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,9 +15,6 @@ Buckets:
 
 ## Now
 
-- **SlopSearX search fallback resilience.** Make the default DuckDuckGo search
-  backend more robust so the zero-config search path degrades gracefully
-  instead of failing ([#413](https://github.com/groktopus/groktocrawl/issues/413)).
 - **Contributor skills directory.** Add `.agent/skills/` with reusable,
   documented skills so contributors can pick up common tasks quickly
   ([#394](https://github.com/groktopus/groktocrawl/issues/394)).

--- a/scripts/twin_provenance.py
+++ b/scripts/twin_provenance.py
@@ -138,7 +138,7 @@ def _image_records(execution_mode: str) -> list[dict[str, object]]:
     references = {
         name: os.environ.get(
             f"TWIN_IMAGE_{name.upper().replace('-', '_')}",
-            "ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d"
+            "ghcr.io/magnus919/slopsearx@sha256:91194d146d205b1cf4688c1989da8f5f6b599a9627be23fd1ee7a4e488fda5b7"
             if name == "slopsearx"
             else name,
         )

--- a/tests/service/test_workflow_contract.py
+++ b/tests/service/test_workflow_contract.py
@@ -59,7 +59,7 @@ def test_required_twin_images_are_immutable():
     compose = (root / "docker-compose.yml").read_text()
     assert (
         compose.count(
-            "ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d"
+            "ghcr.io/magnus919/slopsearx@sha256:91194d146d205b1cf4688c1989da8f5f6b599a9627be23fd1ee7a4e488fda5b7"
         )
         == 2
     )

--- a/tests/unit/test_slopsearx_mcp_compose.py
+++ b/tests/unit/test_slopsearx_mcp_compose.py
@@ -44,7 +44,7 @@ def test_direct_slopsearx_mcp_is_opt_in_and_uses_shared_wiring():
     environment = _environment(service)
 
     assert service["image"] == (
-        "ghcr.io/magnus919/slopsearx@sha256:c7fd83077bf5f189a0125b6377b367740068d012e9caeb48318401a23437711d"
+        "ghcr.io/magnus919/slopsearx@sha256:91194d146d205b1cf4688c1989da8f5f6b599a9627be23fd1ee7a4e488fda5b7"
     )
     # Gated behind a profile so a no-config `docker compose up` does not start
     # the companion; it runs only when the `mcp` profile is enabled.


### PR DESCRIPTION
## Summary

Bumps both SlopSearX image digest pins to the DDG-resilient build, closing the groktocrawl side of #413.

- `docker-compose.yml`: `slopsearx` (line 14) and `slopsearx-mcp` (line 29) both move from `sha256:c7fd83077bf5…` to `sha256:91194d146d20…` — the image published by magnus919/SlopSearX@e68448f (upstream PR magnus919/SlopSearX#225).
- The upstream change makes the DuckDuckGo scrape adapter resilient for zero-config search: a lite.duckduckgo.com/lite/ fallback when the primary html frontend is blocked/unusable (text searches), realistic browser-like session headers with a bounded homepage bootstrap, and honest BLOCKED classification via the adapter's declared failure_classes instead of "success with zero results".
- Digest resolution was done on saru by pull-by-digest (`docker pull ghcr.io/magnus919/slopsearx:sha-e68448f`, then `RepoDigests[0]`) since docker manifest inspect is gated behind DOCKER_CLI_EXPERIMENTAL on that host and the gh token lacks read:packages.
- `docs/roadmap.md`: removes the now-shipped "SlopSearX search fallback resilience" Now item.
- `.env.sample` / public-surface unchanged — no env surface changed; the docs-surface inventory gate stays green.

DDG results remain best-effort (external bot detection is not under our control); validation targets graceful degradation, not guaranteed hits.

## Validation

- New digest pulled by digest on saru and RepoDigests[0] verified equal to the pin.
- grokval slopsearx recreated scoped to that service only; container RepoDigests == new pin, healthcheck healthy.
- `/search?format=json` probes return well-formed JSON (`results` + per-engine status); agent-svc `/v2/search` round-trip completes without crash; repeated probes incl. a likely-blocked query leave the container healthy.
- `python3 scripts/check-docs-surface.py` green.

Fixes #413
