### PR TITLE
ci: string-render droid-review fork gate; harden gha expr sim (#562)

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -36,7 +36,27 @@ jobs:
 
   droid-review:
     needs: assess-depth
-    if: github.event.pull_request.draft == false && github.actor != 'app/dependabot' && github.event.pull_request.head.repo.fork == false
+    # Fork gate hygiene (#562 round 2): mirrors docker.yml's integration-lane
+    # gate (PR #605). GHA loose equality coerces Null->0 and Boolean false->0,
+    # so the previous raw `head.repo.fork == false` evaluated TRUE for deleted
+    # forks (null) and admitted them onto automated AI review — low impact on
+    # this hosted, review-only lane, but it was the last raw-comparison fork
+    # gate under .github/workflows/. Direct expression arithmetic cannot
+    # separate null from false (both coerce to 0), so PR admission requires the
+    # STRING rendering to equal 'false' (format('{0}', ...) yields
+    # 'true'/'false'/'' for null; a missing head.repo property also renders
+    # ''). Deleted forks therefore fail closed OFF review.
+    #
+    # The explicit workflow_dispatch branch preserves manual runs of this
+    # workflow (its own declared trigger): on dispatch events the entire
+    # pull_request context is null, so under the OLD loose comparisons the job
+    # ran — keep that behavior instead of silently dropping the trigger.
+    if: >-
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.actor != 'app/dependabot' &&
+      format('{0}', github.event.pull_request.head.repo.fork) == 'false') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tests/service/_gha_expr_sim.py
+++ b/tests/service/_gha_expr_sim.py
@@ -22,6 +22,7 @@ without a failing test.
 
 from __future__ import annotations
 
+import math
 import re
 from types import SimpleNamespace
 
@@ -58,7 +59,15 @@ class GhaScalar:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, GhaScalar):
-            return self._as_number() == other._as_number()
+            mine = self._as_number()
+            theirs = other._as_number()
+            # NaN (coerced non-numeric strings, raw NaN) never equals anything
+            # — including another NaN. Python's IEEE `float ==` already
+            # provides this; the explicit guard keeps the contract independent
+            # of that accident (#562 round 2).
+            if math.isnan(mine) or math.isnan(theirs):
+                return False
+            return mine == theirs
         return NotImplemented
 
     def __ne__(self, other: object) -> bool:
@@ -68,11 +77,13 @@ class GhaScalar:
         return not equal
 
     def __bool__(self) -> bool:
+        # Runner IsTruthy falsifies only null, Boolean false, the EMPTY
+        # string, and number zero. Strings '0' and 'false' are TRUTHY
+        # (JavaScript-style string-zero falsiness is NOT GHA semantics;
+        # corrected #562 round 2).
         raw = self.raw
-        if raw is None or raw is False:
+        if raw is None or raw is False or raw == "":
             return False
-        if isinstance(raw, str):
-            return raw not in ("", "0")
         return bool(raw)
 
     def __hash__(self) -> int:

--- a/tests/service/test_droid_review_fork_gate.py
+++ b/tests/service/test_droid_review_fork_gate.py
@@ -1,0 +1,154 @@
+"""Contract tests for the Droid Auto Review fork gate hygiene (#562, round 2).
+
+PR #605 hardened docker.yml's self-hosted-lane admission onto the string-
+rendered ``format('{0}', ... fork) == 'false'`` because GHA loose equality
+coerces Null->0 and Boolean false->0 (actions/runner
+``src/Sdk/Expressions/EvaluationResult.cs``): a raw ``fork == false`` evaluates
+TRUE for deleted forks (``head.repo.fork == null``). ``droid-review.yml``
+retained that pre-existing raw comparison — low impact (review-only job on the
+hosted lane, no self-hosted exposure) but after #605 it was the LAST raw fork
+comparison under ``.github/workflows/``.
+
+These tests pin (1) the string-rendered form on the review job's ``if``, (2)
+the ACTUAL condition's semantics over the simulated GHA loose-equality subset
+(``tests.service._gha_expr_sim``) for fork in {proven, deleted, same-repo}, and
+(3) a directory-wide sweep asserting the raw-comparison class cannot quietly
+return in any workflow.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from tests.outcome_governance import governed_skip
+from tests.service._gha_expr_sim import GhaScalar, gha_eval
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+DROID_REVIEW = WORKFLOW_DIR / "droid-review.yml"
+
+if not DROID_REVIEW.exists():
+    governed_skip(
+        ".github/workflows/droid-review.yml not present in this checkout",
+        owner="repository-maintainer",
+        issue="#562",
+        classification="retained",
+        environment=(
+            "agent-svc integration container provisions only docker.yml/fast-tests.yml"
+        ),
+        allow_module_level=True,
+    )
+
+
+def _workflow_text() -> str:
+    return DROID_REVIEW.read_text()
+
+
+def _review_condition() -> str:
+    parsed = yaml.safe_load(_workflow_text())
+    condition = parsed["jobs"]["droid-review"]["if"]
+    assert isinstance(condition, str)
+    return " ".join(condition.split())
+
+
+class TestDroidReviewGateText:
+    """Pin the string-rendered fork gate on the review job."""
+
+    def test_workflow_parses_as_valid_yaml(self) -> None:
+        parsed = yaml.safe_load(_workflow_text())
+        assert isinstance(parsed, dict)
+        assert "jobs" in parsed
+
+    def test_review_job_uses_string_rendered_fork_gate(self) -> None:
+        condition = _review_condition()
+        # The PR #605 hardened form: admission requires the STRING rendering to
+        # equal 'false' (renders 'true'/'false'/'' for null), so deleted forks
+        # fail closed OFF automated AI review.
+        assert (
+            "format('{0}', github.event.pull_request.head.repo.fork) == 'false'"
+            in condition
+        )
+        # The raw loose comparison must be gone: under Null->0/false->0
+        # coercion it admitted null forks (deleted forks) onto the lane.
+        assert "github.event.pull_request.head.repo.fork == false" not in condition
+
+    def test_raw_quoted_fork_comparison_is_gone_repo_wide(self) -> None:
+        """No workflow may loosely compare head.repo.fork against a quoted literal.
+
+        Sweep every workflow file: strip the sanctioned format()-rendered
+        occurrences, then assert neither a quoted-literal loose comparison nor
+        the raw ``fork == false`` keyword form remains anywhere. Keyword
+        ``== true`` / ``== null`` stay legal — the documented detector
+        disjunction (``fork == true || fork == null``) arms for every
+        pull_request event by design and the seam discriminates on the
+        rendered value; ``== false`` has NO sanctioned use because loose
+        equality admits null forks onto whatever the condition gates.
+        """
+        quoted_pattern = re.compile(
+            r"github\.event\.pull_request\.head\.repo\.fork\s*[=!]=\s*'"
+        )
+        offenders: list[str] = []
+        for workflow in sorted(WORKFLOW_DIR.glob("*.y*ml")):
+            normalized = " ".join(workflow.read_text().split())
+            sanitized = normalized.replace(
+                "format('{0}', github.event.pull_request.head.repo.fork)", ""
+            )
+            if quoted_pattern.search(sanitized) or (
+                "github.event.pull_request.head.repo.fork == false" in sanitized
+            ):
+                offenders.append(workflow.name)
+        assert offenders == []
+
+
+class TestDroidReviewGateSemantics:
+    """Evaluate the ACTUAL review-job condition over GHA loose equality."""
+
+    @staticmethod
+    def _runs_for(
+        *,
+        fork: object,
+        draft: bool = False,
+        actor: str = "maintainer",
+        event_name: str = "pull_request",
+    ) -> bool:
+        ctx: dict[str, object] = {
+            "github": {
+                "event_name": event_name,
+                "actor": actor,
+                "event": {
+                    "pull_request": {
+                        "draft": GhaScalar(draft),
+                        "head": {"repo": {"fork": GhaScalar(fork)}},
+                    }
+                },
+            },
+        }
+        return bool(gha_eval(_review_condition(), ctx))
+
+    def test_same_repo_pr_is_reviewed(self) -> None:
+        # Proven same-repository PR renders 'false' -> admitted to review.
+        assert self._runs_for(fork=False)
+
+    def test_deleted_fork_pr_null_is_not_reviewed(self) -> None:
+        # head.repo deref on a deleted fork renders null -> '' != 'false'
+        # -> fail closed. The raw `fork == false` gate admitted this case.
+        assert not self._runs_for(fork=None)
+
+    def test_proven_fork_pr_is_not_reviewed(self) -> None:
+        assert not self._runs_for(fork=True)
+
+    def test_dependabot_actor_is_not_reviewed(self) -> None:
+        assert not self._runs_for(fork=False, actor="app/dependabot")
+
+    def test_draft_pr_is_not_reviewed(self) -> None:
+        assert not self._runs_for(fork=False, draft=True)
+
+    def test_manual_dispatch_still_runs_the_review(self) -> None:
+        # workflow_dispatch is a declared trigger of droid-review.yml; on
+        # dispatch events the whole pull_request context is null, so the OLD
+        # loose comparisons made the job run there. The explicit dispatch
+        # branch preserves that behavior instead of silently dropping it.
+        assert self._runs_for(fork=None, event_name="workflow_dispatch")

--- a/tests/service/test_gha_expr_sim.py
+++ b/tests/service/test_gha_expr_sim.py
@@ -1,0 +1,115 @@
+"""Fidelity tests for the GHA expression simulator's scalar semantics (#562).
+
+``tests/service/_gha_expr_sim.py`` backs the workflow-condition contract
+tests; its :class:`~tests.service._gha_expr_sim.GhaScalar` must track
+actions/runner semantics, not Python accidents. The two fidelity edge cases
+pinned here are unreachable from the current workflow pins, so tightening
+them cannot shift those pins' outcomes:
+
+- **NaN equality**: a non-numeric string coerces to NaN in ``_as_number``, and
+  NaN never equals ANYTHING -- including another NaN. The explicit
+  ``math.isnan`` guard in ``__eq__`` keeps that guarantee independent of the
+  Python ``float ==`` accident (IEEE NaN != NaN) that previously supplied it.
+- **Truthiness**: actions/runner ``IsTruthy`` falsifies only null, Boolean
+  false, the EMPTY string, and number zero. String ``'0'`` and ``'false'``
+  are TRUTHY; the previous ``raw not in ("", "0")`` check wrongly made string
+  ``'0'`` falsy (a JavaScript-flavored mistake GHA does not share).
+"""
+
+from __future__ import annotations
+
+import math
+
+from tests.service._gha_expr_sim import GhaScalar, gha_eval
+
+
+class TestNanEquality:
+    """Non-numeric strings coerce to NaN, and NaN never equals anything."""
+
+    def test_non_numeric_string_never_equals_itself(self) -> None:
+        # Direct __eq__ call: the NaN guard returns False, never NotImplemented.
+        assert GhaScalar("abc").__eq__(GhaScalar("abc")) is False
+        assert GhaScalar("abc") != GhaScalar("abc")
+
+    def test_distinct_unparseable_strings_are_unequal_both_ways(self) -> None:
+        assert GhaScalar("abc") != GhaScalar("xyz")
+        assert GhaScalar("xyz") != GhaScalar("abc")
+
+    def test_nan_bearing_scalar_never_equals_a_number(self) -> None:
+        assert GhaScalar("abc") != GhaScalar(5)
+        assert GhaScalar(5) != GhaScalar("abc")
+        assert GhaScalar("abc").__eq__(GhaScalar(5)) is False
+
+    def test_raw_nan_value_never_equals_itself(self) -> None:
+        nan = float("nan")
+        assert math.isnan(nan)
+        assert GhaScalar(nan) != GhaScalar(nan)
+
+    def test_eq_against_plain_python_values_stays_not_implemented(self) -> None:
+        # Quoted literals in an expression stay plain Python strs; the
+        # format()-rendered comparisons rely on the NotImplemented fallback
+        # (reflected str.__eq__) rather than numeric coercion.
+        assert GhaScalar("abc").__eq__("abc") is NotImplemented
+
+    def test_numeric_coercion_semantics_are_unchanged(self) -> None:
+        # Core loose-equality behaviors the existing pins depend on.
+        assert GhaScalar(2) == GhaScalar(2.0)
+        assert GhaScalar("3") == GhaScalar(3)  # parseable string coerces
+        assert GhaScalar(None) == GhaScalar(False)  # Null->0, false->0
+        assert GhaScalar(True) == GhaScalar(1)
+        assert GhaScalar(True).__eq__(GhaScalar(1)) is True
+
+
+class TestTruthiness:
+    """Only null/false/empty-string/number-zero are falsy (runner IsTruthy)."""
+
+    def test_string_zero_is_truthy(self) -> None:
+        # Changed in #562 round 2: the old `raw not in ("", "0")` made the
+        # string '0' falsy, but GHA only falsifies the EMPTY string.
+        assert bool(GhaScalar("0"))
+
+    def test_string_false_is_truthy(self) -> None:
+        assert bool(GhaScalar("false"))
+
+    def test_empty_string_is_falsy(self) -> None:
+        assert not bool(GhaScalar(""))
+
+    def test_null_and_boolean_false_are_falsy_true_is_truthy(self) -> None:
+        assert not bool(GhaScalar(None))
+        assert not bool(GhaScalar(False))
+        assert bool(GhaScalar(True))
+
+    def test_number_zero_is_falsy(self) -> None:
+        assert not bool(GhaScalar(0))
+        assert not bool(GhaScalar(0.0))
+
+    def test_nonzero_numbers_and_nan_number_are_truthy(self) -> None:
+        assert bool(GhaScalar(5))
+        assert bool(GhaScalar(0.5))
+        # Runner IsTruthy: NaN != 0d, so a NaN NUMBER is truthy (distinct
+        # from the NaN-equality rule, which forbids == entirely).
+        assert bool(GhaScalar(float("nan")))
+
+    def test_non_empty_strings_are_truthy(self) -> None:
+        assert bool(GhaScalar("abc"))
+        assert bool(GhaScalar(" "))
+
+    def test_string_zero_flips_logical_evaluation_through_gha_eval(self) -> None:
+        # End-to-end through the evaluator: with the old falsy-'0' bug the
+        # `&&` chain short-circuited onto the falsy scalar; now it yields the
+        # right-hand operand, matching runner semantics.
+        result = gha_eval("flag && 'taken'", {"flag": GhaScalar("0")})
+        assert result == "taken"
+
+    def test_nan_operands_flow_through_gha_eval_unequal(self) -> None:
+        ctx: dict[str, object] = {
+            "a": GhaScalar("abc"),
+            "b": GhaScalar("abc"),
+        }
+        assert not bool(gha_eval("a == b", ctx))
+        assert bool(gha_eval("a != b", ctx))
+
+    def test_string_zero_is_truthy_through_gha_eval_not_operator(self) -> None:
+        # The runner falsifies only null/false/''/0(number); `!` over the
+        # string '0' must be False now that __bool__ matches IsTruthy.
+        assert not bool(gha_eval("!flag", {"flag": GhaScalar("0")}))


### PR DESCRIPTION
Round-2 CI-hygiene follow-ups to the #562 fork-guard scrutiny (PR #605 merged as 8da8427). No `Fixes` — #562 is already closed.

## 1. droid-review.yml: string-rendered fork gate

Replaces the last raw comparison under `.github/workflows/`:

```yaml
# before
github.event.pull_request.head.repo.fork == false
# after
format('{0}', github.event.pull_request.head.repo.fork) == 'false'
```

GHA loose equality coerces `Null -> 0` and Boolean `false -> 0`, so the raw form evaluated TRUE for deleted-fork PRs (`head.repo.fork` null) and admitted them onto automated AI review. Low impact on this hosted, review-only lane, but it is now the exact hardened form used by docker.yml's self-hosted integration gate (PR #605), so both gates read identically.

An explicit `github.event_name == 'workflow_dispatch'` branch preserves manual runs: droid-review declares that trigger, and on dispatch events the whole `pull_request` context is null — under the OLD all-loose comparisons such runs passed, so the hardening deliberately does not silently drop the trigger.

## 2. `_gha_expr_sim.py`: two fidelity guards

- **NaN equality**: explicit `math.isnan` guard in `__eq__` — non-numeric strings coerce to NaN and never compare equal to anything (previously supplied only by Python's IEEE `float ==` accident; raw NaN values are covered too).
- **Truthiness**: `__bool__` falsiness restricted to null / Boolean false / EMPTY string / number zero per runner `IsTruthy`. The old check made string `'0'` falsy (JavaScript-style semantics GHA does not have).

Both edge cases were unreachable from the current workflow pins, so **no existing pin semantics changed** — `tests/service/test_fork_guard_contract.py` passes unmodified.

## Tests

New `tests/service/test_droid_review_fork_gate.py`:
- pins the string-rendered form + absence of the raw form in the parsed job condition;
- evaluates the ACTUAL condition text over the GHA expression simulator for fork ∈ {true, false, null} × draft/actor/dispatch;
- sweeps every workflow file so neither a quoted-literal nor raw `fork == false` comparison can quietly return (format()-rendered occurrences and the documented `== true || == null` detector disjunction stay sanctioned).

New `tests/service/test_gha_expr_sim.py`: NaN-equality and IsTruthy-truthiness fidelity pins, including end-to-end `&&`/`!` flows through `gha_eval`.

Governed module-level skip when `droid-review.yml` is absent (the integration containers provision only docker.yml/fast-tests.yml).

## Validation

- TDD: red phase confirmed pre-fix (4 failures exactly at the changed behaviors), green after.
- Full fast-tests lane: `PYTHONPATH=... uv run --no-sync pytest tests/unit/ tests/service/` → 1990 passed + 42 subtests.
- `ruff check` + `ruff format --check` clean on all three Python files; mypy clean on all three changed files.
- Strict-asyncio mode pre-verified for the new test files.
- YAML parse of droid-review.yml and docker.yml verified; new `if:` evaluated under simulated loose equality incl. dispatch.
