### PR TITLE
docs: reflect Round 2 barrier, search, and fork-protection changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ curl -N -X POST http://localhost:8080/v2/crawl \
 
 | Area | Capabilities |
 |---|---|
-| Web data | Scrape, batch scrape, map, crawl, parse, browser sessions, and llms.txt generation; the scraper recovers low-yield (card-style) page bodies and warns on partial extractions |
-| Search and retrieval | SlopSearX search, rich/deep research modes, semantic index, and similarity search; vector-search backend failures surface as errors rather than silent empty results |
+| Web data | Scrape, batch scrape, map, crawl, parse, browser sessions, and llms.txt generation; the scraper recovers low-yield (card-style) page bodies, warns on partial extractions, and detects bot-challenge pages (e.g. Fastly JS challenges) so barrier content is never served as article content |
+| Search and retrieval | SlopSearX search (DuckDuckGo engine falls back to its lite endpoint when the primary frontend is bot-blocked; results best-effort), rich/deep research modes, semantic index, and similarity search; vector-search backend failures surface as errors rather than silent empty results |
 | Research | Grounded answers, streaming agent research, plans, sessions, citations, and reusable research memory |
 | Operations | Monitors, webhooks, health probes, Prometheus metrics, cache controls, and politeness controls |
 | Integrations | Portal UI, Model Context Protocol server, and site adapters for code, publishing, commerce, and security sources |
@@ -101,6 +101,8 @@ Site adapters run before the generic scraper pipeline and fall back safely to it
 ## Security
 
 Set `API_KEY` for authentication, restrict network exposure, and review outbound proxy and robots/politeness settings before production use. The service emits an `X-Security-Warning` header while authentication is disabled. See [deployment and configuration](docs/guides/deployment.md#security) for the operational baseline.
+
+Self-hosted CI is hardened against untrusted fork PRs: workflow edits on fork PRs fail closed (defense in depth — the platform-level control is authoritative), and deleted-fork PRs are excluded from the self-hosted runner lane. `scripts/enforce-branch-protection.py` gains a read-only `--verify-rulesets` mode that asserts both `main` rulesets are active and diff-clean. See [self-hosted runner fork protection](docs/runbooks/self-hosted-runner-fork-protection.md) and [SECURITY.md](SECURITY.md); the org-level runner-group settings remain deferred with residual risk accepted.
 
 ## Status
 


### PR DESCRIPTION
Docs-only README update reflecting the Round 2 changes: Fastly bot-challenge detection, SlopSearX DuckDuckGo lite fallback, and fork-PR self-hosted runner hardening / --verify-rulesets. No code or config changes.