### PR TITLE
fix(youtube): pace transcript acquisition

### DIFF
--- a/scraper-svc/pyproject.toml
+++ b/scraper-svc/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "beautifulsoup4>=4.13.0",
     "redis>=5.0",
     "youtube_transcript_api>=1.0.0",
+    "yt-dlp>=2026.3.13",
     "cloakbrowser==0.5.3",
 ]
 

--- a/scraper-svc/scraper/adapters/youtube.py
+++ b/scraper-svc/scraper/adapters/youtube.py
@@ -3,8 +3,7 @@ YouTube adapter — extracts video transcripts and metadata.
 
 Fallback chain:
   1. youtube_transcript_api — no API key required, fast
-  2. yt-dlp subtitle download — heavier dependency, slower
-  3. Browser render + DOM extraction — last resort
+  2. Browser render + DOM extraction — last resort
 
 Metadata sources:
   - oEmbed API (https://www.youtube.com/oembed?format=json) for title,
@@ -16,12 +15,69 @@ Metadata sources:
 from __future__ import annotations
 
 import logging
+import random
 import re
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 from .base import AdapterContext, AdapterError, AdapterResult, SiteAdapter, adapter
 
 logger = logging.getLogger(__name__)
+
+
+class _YouTubeCooldownError(Exception):
+    """Raised when YouTube is in a host-level cooldown window."""
+
+
+class _YouTubeRequestGate:
+    """Process-wide pacing and cooldown for the shared YouTube egress."""
+
+    def __init__(self) -> None:
+        import os
+
+        self._lock = threading.Lock()
+        self._next_allowed = 0.0
+        self._cooldown_until = 0.0
+        self.min_interval = float(os.getenv("YOUTUBE_MIN_INTERVAL", "10"))
+        self.max_interval = float(os.getenv("YOUTUBE_MAX_INTERVAL", "20"))
+        self.request_interval = float(os.getenv("YOUTUBE_REQUEST_INTERVAL", "0.75"))
+        self.subtitle_interval = float(os.getenv("YOUTUBE_SUBTITLE_INTERVAL", "5"))
+        self.cooldown_seconds = float(os.getenv("YOUTUBE_RATE_LIMIT_COOLDOWN", "3600"))
+
+    def wait(self, interval: float | None = None, jitter: float | None = None) -> None:
+        """Reserve a request slot, sleeping outside the mutex."""
+        interval = self.request_interval if interval is None else interval
+        jitter = interval if jitter is None else jitter
+        with self._lock:
+            now = time.monotonic()
+            if now < self._cooldown_until:
+                raise _YouTubeCooldownError
+            target = max(now, self._next_allowed)
+            self._next_allowed = target + interval + random.uniform(0, jitter)
+        if target > now:
+            time.sleep(target - now)
+
+    def mark_rate_limited(self) -> None:
+        with self._lock:
+            self._cooldown_until = max(
+                self._cooldown_until, time.monotonic() + self.cooldown_seconds
+            )
+
+
+_YOUTUBE_GATE = _YouTubeRequestGate()
+
+
+def _is_youtube_rate_limit(error: BaseException) -> bool:
+    text = str(error).lower()
+    return any(
+        token in text
+        for token in ("429", "ipblocked", "requestblocked", "rate-limited")
+    )
+
 
 # ── URL pattern matching ─────────────────────────────────────────
 
@@ -79,6 +135,9 @@ async def _fetch_oembed(video_id: str) -> dict:
 
     oembed_url = f"https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v={video_id}&format=json"
     try:
+        import asyncio
+
+        await asyncio.to_thread(_YOUTUBE_GATE.wait)
         async with httpx.AsyncClient(timeout=10) as client:
             resp = await client.get(oembed_url)
             if resp.status_code == 200:
@@ -108,6 +167,9 @@ async def _fetch_description(video_id: str) -> str | None:
 
     url = f"https://www.youtube.com/watch?v={video_id}"
     try:
+        import asyncio
+
+        await asyncio.to_thread(_YOUTUBE_GATE.wait)
         async with httpx.AsyncClient(timeout=10) as client:
             resp = await client.get(
                 url,
@@ -239,13 +301,22 @@ def _description_to_markdown(desc: str) -> str:
 # ── Transcript via youtube_transcript_api ────────────────────────
 
 
-async def _fetch_transcript(video_id: str) -> str | None:
+@dataclass
+class _TranscriptFetch:
+    """Transcript text plus the acquisition provenance needed downstream."""
+
+    text: str
+    language: str
+    translated_to: str | None = None
+
+
+async def _fetch_transcript(video_id: str) -> _TranscriptFetch | None:
     """Fetch the video transcript via ``youtube_transcript_api``.
 
     Runs the sync API in a thread to avoid blocking the event loop.
 
-    Returns the full transcript as a single text block, or ``None``
-    if unavailable.
+    Prefer native English, then explicitly translate a translatable native
+    track.  ``fetch(..., languages=["en"])`` does not search translated tracks.
     """
     import asyncio
 
@@ -254,17 +325,147 @@ async def _fetch_transcript(video_id: str) -> str | None:
 
         def _get_transcript():
             api = YouTubeTranscriptApi()
-            transcript_list = api.fetch(video_id, languages=["en"])
-            return " ".join(item.text for item in transcript_list)
+            _YOUTUBE_GATE.wait()
+            transcripts = list(api.list(video_id))
+
+            # Keep native English ahead of translated output, including when
+            # the native track is auto-generated.
+            english = [t for t in transcripts if t.language_code == "en"]
+            candidates = english + [
+                t for t in transcripts if t.language_code != "en" and t.is_translatable
+            ]
+            for transcript in candidates:
+                translated_to = None
+                selected = transcript
+                if transcript.language_code != "en":
+                    try:
+                        selected = transcript.translate("en")
+                        translated_to = "en"
+                    except Exception as exc:
+                        logger.debug(
+                            "Transcript translation failed for %s (%s -> en): %s",
+                            video_id,
+                            transcript.language_code,
+                            exc,
+                        )
+                        continue
+
+                try:
+                    _YOUTUBE_GATE.wait(_YOUTUBE_GATE.subtitle_interval)
+                    fetched = selected.fetch()
+                    text = " ".join(item.text for item in fetched).strip()
+                except _YouTubeCooldownError:
+                    raise
+                except Exception as exc:
+                    if _is_youtube_rate_limit(exc):
+                        _YOUTUBE_GATE.mark_rate_limited()
+                        raise _YouTubeCooldownError from exc
+                    logger.debug(
+                        "Transcript fetch failed for %s (%s): %s",
+                        video_id,
+                        transcript.language_code,
+                        exc,
+                    )
+                    continue
+                if text:
+                    return _TranscriptFetch(
+                        text=text,
+                        language=transcript.language_code,
+                        translated_to=translated_to,
+                    )
+            return None
 
         transcript = await asyncio.to_thread(_get_transcript)
-        return transcript or None
+        if transcript:
+            return transcript
     except ImportError:
         logger.debug("youtube_transcript_api not installed")
+    except _YouTubeCooldownError:
+        logger.info("YouTube acquisition is in cooldown; deferring %s", video_id)
         return None
     except Exception as exc:
+        if _is_youtube_rate_limit(exc):
+            _YOUTUBE_GATE.mark_rate_limited()
+            logger.info("YouTube rate limit encountered; deferring %s", video_id)
+            return None
         logger.debug("youtube_transcript_api failed for %s: %s", video_id, exc)
+    return await _fetch_transcript_via_ytdlp(video_id)
+
+
+async def _fetch_transcript_via_ytdlp(video_id: str) -> _TranscriptFetch | None:
+    """Fetch English auto-captions when the transcript API omits translation metadata."""
+    import asyncio
+
+    try:
+        import yt_dlp
+    except ImportError:
+        logger.debug("yt-dlp not installed")
         return None
+
+    def _download():
+        with tempfile.TemporaryDirectory(prefix="groktocrawl-youtube-") as tmp:
+            output = str(Path(tmp) / "transcript.%(ext)s")
+            options = {
+                "quiet": True,
+                "no_warnings": True,
+                "skip_download": True,
+                "writeautomaticsub": True,
+                "sleep_interval_requests": 0.75,
+                "sleep_interval_subtitles": _YOUTUBE_GATE.subtitle_interval,
+                "sleep_interval": _YOUTUBE_GATE.min_interval,
+                "max_sleep_interval": _YOUTUBE_GATE.max_interval,
+                "retries": 1,
+                "extractor_retries": 1,
+                "subtitleslangs": ["en"],
+                "subtitlesformat": "vtt",
+                "outtmpl": output,
+            }
+            with yt_dlp.YoutubeDL(options) as ydl:
+                info = ydl.extract_info(
+                    f"https://www.youtube.com/watch?v={video_id}", download=True
+                )
+            subtitle = next(Path(tmp).glob("transcript*.vtt"), None)
+            if subtitle is None:
+                return None
+            text = _vtt_to_text(subtitle.read_text(encoding="utf-8"))
+            if not text:
+                return None
+            source_language = "unknown"
+            for formats in info.get("automatic_captions", {}).values():
+                for item in formats:
+                    query = parse_qs(urlparse(item.get("url", "")).query)
+                    if query.get("tlang") == ["en"] and query.get("lang"):
+                        source_language = query["lang"][0]
+                        break
+                if source_language != "unknown":
+                    break
+            return _TranscriptFetch(text, source_language, "en")
+
+    try:
+        await asyncio.to_thread(
+            _YOUTUBE_GATE.wait,
+            random.uniform(_YOUTUBE_GATE.min_interval, _YOUTUBE_GATE.max_interval),
+            0,
+        )
+        return await asyncio.to_thread(_download)
+    except Exception as exc:
+        logger.debug("yt-dlp transcript failed for %s: %s", video_id, exc)
+        return None
+
+
+def _vtt_to_text(content: str) -> str:
+    """Reduce a WebVTT caption file to deduplicated plain text."""
+    lines = []
+    previous = None
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line == "WEBVTT" or "-->" in line or line.isdigit():
+            continue
+        line = re.sub(r"<[^>]+>", "", line)
+        if line and line != previous:
+            lines.append(line)
+            previous = line
+    return " ".join(lines).strip()
 
 
 # ── Browser fallback ─────────────────────────────────────────────
@@ -409,7 +610,7 @@ class YouTubeAdapter(SiteAdapter):
         # Fetch transcript + description in parallel
         import asyncio
 
-        transcript = None
+        transcript: _TranscriptFetch | None = None
         description = None
         try:
             t_result: object
@@ -419,7 +620,7 @@ class YouTubeAdapter(SiteAdapter):
                 ctx.with_timeout(_fetch_description(video_id), timeout=10),
                 return_exceptions=True,
             )
-            if isinstance(t_result, str) and t_result:
+            if isinstance(t_result, _TranscriptFetch) and t_result.text:
                 transcript = t_result
             elif isinstance(t_result, AdapterError):
                 logger.debug("Transcript fetch failed: %s", t_result)
@@ -432,10 +633,13 @@ class YouTubeAdapter(SiteAdapter):
             logger.debug("Parallel fetch error for %s: %s", video_id, exc)
 
         if transcript:
+            metadata["transcript_language"] = transcript.language
+            if transcript.translated_to:
+                metadata["transcript_translated_to"] = transcript.translated_to
             logger.info(
                 "YouTube adapter: transcript hit for %s (%d chars)",
                 video_id,
-                len(transcript),
+                len(transcript.text),
             )
             title = oembed.get("title", "YouTube Video")
             author = oembed.get("author_name", "")
@@ -444,7 +648,7 @@ class YouTubeAdapter(SiteAdapter):
             if description:
                 desc_md = _description_to_markdown(description)
                 markdown += f"---\n\n## Description\n\n{desc_md}\n\n"
-            markdown += f"---\n\n## Transcript\n\n{transcript}"
+            markdown += f"---\n\n## Transcript\n\n{transcript.text}"
             return AdapterResult(
                 success=True,
                 markdown=markdown,

--- a/tests/fixtures/youtube_transcript_twin.py
+++ b/tests/fixtures/youtube_transcript_twin.py
@@ -1,0 +1,74 @@
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class YouTubeTranscriptTwin:
+    video_id = "PPM2ODdo2t8"
+
+    def __init__(self, monkeypatch):
+        self.monkeypatch = monkeypatch
+        self.list_calls = 0
+        self.ytdlp_calls = 0
+        self.ytdlp_options = None
+
+    def install(self):
+        twin = self
+
+        class Track:
+            language_code = "fi"
+            is_translatable = False
+
+            def fetch(self):
+                raise AssertionError("untranslated API track fetched")
+
+            def translate(self, language_code):
+                raise AssertionError("API translation used")
+
+        api = SimpleNamespace(list=lambda video_id: twin._list(video_id, Track()))
+        self.monkeypatch.setitem(
+            sys.modules,
+            "youtube_transcript_api",
+            types.SimpleNamespace(YouTubeTranscriptApi=lambda: api),
+        )
+
+        class YoutubeDL:
+            def __init__(self, options):
+                self.options = options
+                twin.ytdlp_options = options
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def extract_info(self, url, download):
+                assert download is True and url.endswith(f"v={twin.video_id}")
+                twin.ytdlp_calls += 1
+                output = Path(self.options["outtmpl"].replace("%(ext)s", "vtt"))
+                output.write_text(
+                    "WEBVTT\n\n00:00.000 --> 00:01.000\n"
+                    "Hello from translated caption\n",
+                    encoding="utf-8",
+                )
+                return {
+                    "automatic_captions": {
+                        "fi": [
+                            {
+                                "name": "English",
+                                "url": "https://youtube.test/timedtext?lang=fi&tlang=en",
+                            }
+                        ]
+                    }
+                }
+
+        self.monkeypatch.setitem(
+            sys.modules, "yt_dlp", types.SimpleNamespace(YoutubeDL=YoutubeDL)
+        )
+
+    def _list(self, video_id, track):
+        assert video_id == self.video_id
+        self.list_calls += 1
+        return iter([track])

--- a/tests/unit/test_youtube_adapter.py
+++ b/tests/unit/test_youtube_adapter.py
@@ -1,0 +1,172 @@
+"""Regression tests for YouTube transcript language selection."""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, "scraper-svc")
+
+from scraper.adapters.base import AdapterContext
+from scraper.adapters.youtube import (
+    YouTubeAdapter,
+    _fetch_transcript,
+    _TranscriptFetch,
+    _YouTubeRequestGate,
+)
+
+from tests.fixtures.youtube_transcript_twin import YouTubeTranscriptTwin
+
+
+class _Fetched:
+    def __init__(self, *texts):
+        self.items = [SimpleNamespace(text=text) for text in texts]
+
+    def __iter__(self):
+        return iter(self.items)
+
+
+class _Track:
+    def __init__(
+        self,
+        language_code,
+        *,
+        translatable=False,
+        translated=None,
+        fetch_error=None,
+    ):
+        self.language_code = language_code
+        self.is_translatable = translatable
+        self._translated = translated
+        self._fetch_error = fetch_error
+        self.fetch_calls = 0
+
+    def translate(self, language_code):
+        assert language_code == "en"
+        return self._translated
+
+    def fetch(self):
+        self.fetch_calls += 1
+        if self._fetch_error:
+            raise self._fetch_error
+        return _Fetched("usable transcript")
+
+
+def _run(tracks):
+    from scraper.adapters import youtube
+
+    youtube._YOUTUBE_GATE.min_interval = 0
+    youtube._YOUTUBE_GATE.max_interval = 0
+    youtube._YOUTUBE_GATE.request_interval = 0
+    youtube._YOUTUBE_GATE.subtitle_interval = 0
+    youtube._YOUTUBE_GATE._cooldown_until = 0
+    api = SimpleNamespace(list=lambda _video_id: iter(tracks))
+    with patch.dict(
+        sys.modules,
+        {"youtube_transcript_api": SimpleNamespace(YouTubeTranscriptApi=lambda: api)},
+    ):
+        return asyncio.run(_fetch_transcript("PPM2ODdo2t8"))
+
+
+def test_native_english_is_preferred():
+    translated = _Track("fi", translatable=True)
+    native = _Track("en")
+
+    result = _run([translated, native])
+
+    assert result == _TranscriptFetch("usable transcript", "en")
+    assert translated.fetch_calls == 0
+
+
+def test_translatable_non_english_track_is_translated_to_english():
+    translated_track = _Track("fi", translatable=True)
+    translated = _Track("en")
+    translated_track._translated = translated
+
+    result = _run([translated_track])
+
+    assert result == _TranscriptFetch("usable transcript", "fi", "en")
+    assert translated.fetch_calls == 1
+
+
+def test_captionless_video_remains_unavailable():
+    assert _run([]) is None
+
+
+def test_untranslatable_non_english_track_remains_unavailable():
+    assert _run([_Track("fi")]) is None
+
+
+def test_failed_preferred_track_falls_back_to_next_usable_track():
+    failed = _Track("en", fetch_error=RuntimeError("blocked"))
+    fallback = _Track("en")
+
+    result = _run([failed, fallback])
+
+    assert result == _TranscriptFetch("usable transcript", "en")
+
+
+def test_scrape_exposes_translation_provenance():
+    with (
+        patch(
+            "scraper.adapters.youtube._fetch_oembed",
+            new=AsyncMock(return_value={"title": "Video", "author_name": "Channel"}),
+        ),
+        patch(
+            "scraper.adapters.youtube._fetch_description",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "scraper.adapters.youtube._fetch_transcript",
+            new=AsyncMock(return_value=_TranscriptFetch("translated text", "fi", "en")),
+        ),
+    ):
+        result = asyncio.run(
+            YouTubeAdapter().scrape(
+                "https://www.youtube.com/watch?v=PPM2ODdo2t8", AdapterContext()
+            )
+        )
+
+    assert result.success is True
+    assert result.source == "youtube-transcript-api"
+    assert result.metadata["transcript_language"] == "fi"
+    assert result.metadata["transcript_translated_to"] == "en"
+    assert "translated text" in result.markdown
+
+
+def test_vtt_to_text_removes_timing_and_repeated_cues():
+    from scraper.adapters.youtube import _vtt_to_text
+
+    assert (
+        _vtt_to_text(
+            "WEBVTT\n\n00:00.000 --> 00:01.000\nHello\n\n00:01.000 --> 00:02.000\nHello\nworld"
+        )
+        == "Hello world"
+    )
+
+
+def test_caption_twin_recovers_translation_omitted_by_transcript_api(monkeypatch):
+    twin = YouTubeTranscriptTwin(monkeypatch)
+    twin.install()
+    result = asyncio.run(_fetch_transcript(twin.video_id))
+    assert result is not None
+    assert result.text == "Hello from translated caption"
+    assert result.language == "fi"
+    assert result.translated_to == "en"
+    assert twin.list_calls == 1
+    assert twin.ytdlp_calls == 1
+    assert twin.ytdlp_options["sleep_interval_requests"] == 0.75
+    assert twin.ytdlp_options["sleep_interval_subtitles"] == 5
+    assert twin.ytdlp_options["retries"] == 1
+
+
+def test_gate_enforces_cooldown_without_retrying_or_falling_back():
+    gate = _YouTubeRequestGate()
+    gate.cooldown_seconds = 60
+    gate.mark_rate_limited()
+    try:
+        gate.wait()
+    except Exception as exc:
+        assert type(exc).__name__ == "_YouTubeCooldownError"
+    else:
+        raise AssertionError("cooldown must block new acquisition attempts")

--- a/uv.lock
+++ b/uv.lock
@@ -2615,6 +2615,7 @@ dependencies = [
     { name = "redis" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "youtube-transcript-api" },
+    { name = "yt-dlp" },
 ]
 
 [package.optional-dependencies]
@@ -2636,6 +2637,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
     { name = "youtube-transcript-api", specifier = ">=1.0.0" },
+    { name = "yt-dlp", specifier = ">=2026.3.13" },
 ]
 provides-extras = ["playwright"]
 
@@ -3239,4 +3241,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.8.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e0/832fa4ca334b766a06933a196066edc3dba37cdb6f14cd98d59bcc69a4b4/yt_dlp-2026.8.19.tar.gz", hash = "sha256:9e213e48cea35c66b378e4447903f118f6392a5fa380a2b6d7070ec86f4e0af1", size = 3052025, upload-time = "2026-08-19T23:48:59.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/8cd1613f56eed7ceb64fbd4df3f1c01246bfb098e6f398228bafda22b80b/yt_dlp-2026.8.19-py3-none-any.whl", hash = "sha256:1d57897e94c6665a0a6f9bc54b34e584284e32c034ffab3a7df25d8f7b24eedf", size = 3185533, upload-time = "2026-08-19T23:48:56.925Z" },
 ]


### PR DESCRIPTION
## Summary

- Discover and translate non-English YouTube captions when the transcript API omits translation metadata.
- Add conservative yt-dlp request/subtitle pacing and bounded retries.
- Serialize YouTube acquisition per process, add jitter, and stop fallback escalation during IP cooldowns.
- Add a hermetic caption-source twin and regression coverage for the real Finnish-track failure shape.

## Verification

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run mypy scraper-svc/scraper/adapters/youtube.py`
- `uv run pytest tests/unit/test_youtube_adapter.py -q -n 0 --no-cov` (9 passed)

Live YouTube retrieval remains environment-blocked by HTTP 429; CI uses the hermetic source twin and does not depend on YouTube availability.
