### PR TITLE
feat(parse): add explicit hosted OCR mode

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -749,7 +749,7 @@ jobs:
           docker cp mcp-svc/. "$svc:/app/mcp-svc/"
 
       - name: Install critical test dependencies
-        run: docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-timeout jinja2 tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.1.9 pypdf -q
+        run: docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-timeout jinja2 tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.2.4 pypdf -q
 
       - name: Verify LLM fixture contract and agent routing
         run: |
@@ -861,7 +861,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-xdist pytest-timeout jinja2 tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.1.9 pypdf PyYAML -q
+          docker compose exec -T agent-svc pip install pytest pytest-asyncio pytest-cov pytest-xdist pytest-timeout jinja2 tabulate markdownify==1.2.3 readability-lxml==0.8.4.1 firecrawl-anydoc==0.2.4 pypdf PyYAML -q
           docker compose exec -T agent-svc mkdir -p /app/coverage
           set +e
           docker compose exec -T agent-svc env \

--- a/agent-svc/agent/routes/parse.py
+++ b/agent-svc/agent/routes/parse.py
@@ -73,8 +73,15 @@ async def parse_file(request: Request) -> Any:
 
     - Direct: multipart form with ``file`` field (small files)
     - Two-step: form field ``upload_id`` referencing a pre-uploaded file
+
+    ``ocr=hosted`` is an explicit opt-in and is forwarded only when the caller
+    requests hosted OCR. The parse service remains local-first by default.
     """
     form = await request.form()
+    form_ocr = form.get("ocr", "local")
+    ocr = form_ocr if isinstance(form_ocr, str) else "local"
+    if ocr not in {"local", "hosted"}:
+        raise InvalidRequestError(detail="ocr must be 'local' or 'hosted'")
 
     # Two-step mode: retrieve pre-uploaded file from Valkey
     upload_id_raw = form.get("upload_id")
@@ -110,6 +117,7 @@ async def parse_file(request: Request) -> Any:
             resp = await client.post(
                 f"{PARSE_SVC_URL}/parse",
                 files={"file": (filename, content, content_type)},
+                data={"ocr": ocr},
             )
             try:
                 return resp.json()
@@ -127,7 +135,6 @@ async def parse_file(request: Request) -> Any:
 
     upload = form["file"]  # type: ignore[union-attr]
     content = await upload.read()  # type: ignore[union-attr]
-
     async with httpx.AsyncClient(timeout=120) as client:
         resp = await client.post(
             f"{PARSE_SVC_URL}/parse",
@@ -138,6 +145,7 @@ async def parse_file(request: Request) -> Any:
                     upload.content_type or "application/octet-stream",  # type: ignore[union-attr]
                 )
             },
+            data={"ocr": ocr},
         )
         try:
             return resp.json()

--- a/groktocrawl
+++ b/groktocrawl
@@ -1197,14 +1197,20 @@ class Client:
 
     # ---- Parse ----
 
-    def parse_file(self, filepath):
+    def parse_file(self, filepath, ocr="local"):
         import requests
 
         url = self._url("/parse")
         if self.dry_run:
-            return {"dry_run": True, "method": "POST", "url": url, "file": filepath}
+            return {
+                "dry_run": True,
+                "method": "POST",
+                "url": url,
+                "file": filepath,
+                "ocr": ocr,
+            }
         with open(filepath, "rb") as f:
-            resp = requests.post(url, files={"file": f}, timeout=120)
+            resp = requests.post(url, files={"file": f}, data={"ocr": ocr}, timeout=120)
         if resp.status_code >= 400:
             try:
                 body = resp.json()
@@ -2597,7 +2603,7 @@ def cmd_parse(client: Client, args: argparse.Namespace) -> None:
         die(f"File not found: {args.filepath}")
 
     try:
-        result = client.parse_file(args.filepath)
+        result = client.parse_file(args.filepath, ocr=args.ocr)
     except ApiError as e:
         die(e)
 
@@ -3038,6 +3044,12 @@ def make_parser() -> argparse.ArgumentParser:
         "-o", "--output", help="Write output to file instead of stdout"
     )
     p_parse.add_argument("--upload-id", help="Parse a pre-uploaded file by upload ID")
+    p_parse.add_argument(
+        "--ocr",
+        choices=["local", "hosted"],
+        default="local",
+        help="OCR mode for scanned PDFs; hosted uploads the whole document to Parse",
+    )
 
     # --- Parse Upload ---
     p_parse_upload = subparsers.add_parser(

--- a/parse-svc/parse_svc/app.py
+++ b/parse-svc/parse_svc/app.py
@@ -94,8 +94,8 @@ SUPPORTED_FORMATS = {
 # ---- Individual parsers ----
 
 
-def _parse_pdf(content: bytes, filename: str) -> dict:
-    """Parse PDF — try text extraction first, fall back to OCR."""
+def _parse_pdf(content: bytes, filename: str, ocr: str = "local") -> dict:
+    """Parse PDF locally first, with optional explicit hosted OCR."""
     markdown_parts = []
     metadata: dict[str, Any] = {"format": "pdf", "filename": filename}
     text_extracted = False
@@ -118,8 +118,8 @@ def _parse_pdf(content: bytes, filename: str) -> dict:
     except Exception as e:
         logger.warning("pypdf failed: %s", e)
 
-    # Tier 2: OCR for scanned PDFs (if pypdf got little or nothing)
-    if not text_extracted or len("".join(markdown_parts)) < 100:
+    # Tier 2: local OCR is the default; hosted mode is deliberately separate.
+    if ocr != "hosted" and (not text_extracted or len("".join(markdown_parts)) < 100):
         try:
             import pytesseract
             from pdf2image import convert_from_bytes
@@ -138,7 +138,7 @@ def _parse_pdf(content: bytes, filename: str) -> dict:
                 ocr_text = "\n\n".join(ocr_parts).strip()
                 if len(ocr_text) > 50:
                     markdown_parts = [ocr_text]
-                    metadata["extraction"] = "ocr"
+                    metadata["extraction"] = "local_ocr"
                     text_extracted = True
         except ImportError:
             logger.warning("pytesseract/pdf2image not available, skipping OCR")
@@ -167,7 +167,32 @@ def _parse_pdf(content: bytes, filename: str) -> dict:
     except Exception as e:
         logger.debug("Table extraction failed: %s", e)
 
-    return {"markdown": "\n\n".join(markdown_parts).strip(), "metadata": metadata}
+    markdown = "\n\n".join(markdown_parts).strip()
+    if ocr == "hosted" and not text_extracted:
+        api_url = os.getenv("PARSE_HOSTED_OCR_API_URL")
+        if not api_url:
+            raise HTTPException(
+                status_code=422,
+                detail="Hosted OCR is not configured; set PARSE_HOSTED_OCR_API_URL",
+            )
+        if not api_url.startswith(("http://", "https://")):
+            raise HTTPException(status_code=422, detail="Invalid hosted OCR API URL")
+        try:
+            api_key = os.getenv("PARSE_HOSTED_OCR_API_KEY") or os.getenv(
+                "FIRECRAWL_API_KEY"
+            )
+            kwargs = {"ocr": "hosted", "api_url": api_url}
+            if api_key:
+                kwargs["api_key"] = api_key
+            markdown = anydoc.to_markdown_bytes(content, **kwargs).strip()
+            metadata["extraction"] = "anydoc_hosted_ocr"
+        except anydoc.HostedError as e:
+            raise HTTPException(status_code=502, detail="Hosted OCR failed") from e
+        except anydoc.ConvertError as e:
+            raise HTTPException(
+                status_code=422, detail=f"Hosted OCR failed: {e}"
+            ) from e
+    return {"markdown": markdown, "metadata": metadata}
 
 
 def _parse_text(content: bytes, filename: str) -> dict:
@@ -224,7 +249,7 @@ async def metrics():
 
 
 @app.post("/parse", response_model=ParseResponse)
-async def parse_file(file: UploadFile):
+async def parse_file(file: UploadFile, ocr: str = "local"):
     """Upload a file and get its content as markdown."""
     if not file.filename:
         raise HTTPException(status_code=400, detail="No filename provided")
@@ -250,9 +275,15 @@ async def parse_file(file: UploadFile):
 
     logger.info("Parsing %s (%s, %d bytes)", file.filename, ext, len(content))
 
+    if ocr not in {"local", "hosted"}:
+        raise HTTPException(status_code=422, detail="ocr must be 'local' or 'hosted'")
+
     parser = PARSERS[ext]
     try:
-        result = parser(content, file.filename)
+        if ext == "pdf":
+            result = parser(content, file.filename, ocr=ocr)
+        else:
+            result = parser(content, file.filename)
         md = result.get("markdown", "")
         meta = result.get("metadata", {})
         meta["size_bytes"] = len(content)

--- a/parse-svc/parse_svc/app.py
+++ b/parse-svc/parse_svc/app.py
@@ -281,7 +281,7 @@ async def parse_file(file: UploadFile, ocr: str = "local"):
     parser = PARSERS[ext]
     try:
         if ext == "pdf":
-            result = parser(content, file.filename, ocr=ocr)
+            result = _parse_pdf(content, file.filename, ocr=ocr)
         else:
             result = parser(content, file.filename)
         md = result.get("markdown", "")

--- a/parse-svc/pyproject.toml
+++ b/parse-svc/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
     "pydantic>=2.10.0",
     "python-multipart>=0.0.20",
-    "firecrawl-anydoc==0.1.9",
+    "firecrawl-anydoc==0.2.4",
     "pypdf>=5.0.0",
     "tabulate>=0.9.0",
     "pillow>=10.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,7 @@ fast-tests = [
     "jsonschema>=4.23.0",
     # Service imports exercised by tests/unit and tests/service, excluding ML models.
     "cloakbrowser==0.5.3",
-    "firecrawl-anydoc==0.1.9",
+    "firecrawl-anydoc==0.2.4",
     "curl_cffi>=0.15.0",
     "jinja2>=3.1.0",
     "markdownify==1.2.3",

--- a/tests/service/test_cli.py
+++ b/tests/service/test_cli.py
@@ -870,7 +870,35 @@ class TestCmdBatchScrape:
 
 
 class TestClientParseUpload:
-    """Tests for Client.parse_upload_file() and Client.parse_with_upload_id()."""
+    """Tests for direct and staged parse client requests."""
+
+    def test_parse_file_sends_explicit_hosted_ocr_mode(self, client, tmp_path):
+        """parse_file sends the opt-in OCR mode as multipart form data."""
+        document = tmp_path / "scan.pdf"
+        document.write_bytes(b"%PDF-1.4 fake scan")
+
+        def _fake_post(url, files=None, data=None, timeout=None):
+            assert "/parse" in url
+            assert files is not None
+            assert data == {"ocr": "hosted"}
+
+            class FakeResp:
+                status_code = 200
+
+                def json(self):
+                    return {
+                        "success": True,
+                        "data": {"markdown": "# Hosted scan"},
+                    }
+
+            return FakeResp()
+
+        import requests as _requests_module
+
+        with patch.object(_requests_module, "post", side_effect=_fake_post):
+            result = client.parse_file(str(document), ocr="hosted")
+
+        assert result["data"]["markdown"] == "# Hosted scan"
 
     def test_parse_upload_file_sends_correct_data(self, client):
         """parse_upload_file sends PUT with correct URL, headers, and body."""

--- a/tests/unit/test_parse_svc_unit.py
+++ b/tests/unit/test_parse_svc_unit.py
@@ -5,7 +5,11 @@ conversion (including legacy/macro/ODF formats), encrypted-document errors,
 and the PDF OCR fallback path.
 """
 
+import json
 import sys
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import patch
@@ -19,6 +23,42 @@ _FIXTURES = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "anydoc
 
 def _load(name: str) -> bytes:
     return (_FIXTURES / name).read_bytes()
+
+
+@contextmanager
+def _hosted_parse_stub(status: int, body: dict):
+    """Serve one deterministic Firecrawl Parse-compatible endpoint."""
+    hits: list[dict[str, object]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            payload = self.rfile.read(int(self.headers.get("content-length", "0")))
+            hits.append(
+                {
+                    "path": self.path,
+                    "body": payload,
+                    "authorization": self.headers.get("authorization"),
+                }
+            )
+            reply = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(reply)))
+            self.end_headers()
+            self.wfile.write(reply)
+
+        def log_message(self, format: str, *args: object):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", hits
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
 
 
 # ── _ext ──────────────────────────────────────────────────────────────────
@@ -147,7 +187,7 @@ class TestParseAnyDoc:
 
 
 class TestParsePdf:
-    """PDF parsing with graceful degradation and OCR fallback tests."""
+    """PDF parsing with local-first and explicit hosted OCR behavior."""
 
     def _make_minimal_pdf(self):
         """Return a minimal valid PDF (no extractable text)."""
@@ -196,8 +236,90 @@ class TestParsePdf:
             {"pdf2image": fake_pdf2image, "pytesseract": fake_tesseract},
         ):
             result = _parse_pdf(content, "scan.pdf")
-        assert result["metadata"].get("extraction") == "ocr"
+        assert result["metadata"].get("extraction") == "local_ocr"
         assert "OCR-extracted" in result["markdown"]
+
+    def test_hosted_ocr_uses_real_anydoc_binding_and_sends_whole_pdf(self, monkeypatch):
+        content = _load("scanned-image-only.pdf")
+        reply = {"success": True, "data": {"markdown": "# Hosted scan\n"}}
+        with _hosted_parse_stub(200, reply) as (api_url, hits):
+            monkeypatch.setenv("PARSE_HOSTED_OCR_API_URL", api_url)
+            monkeypatch.setenv("PARSE_HOSTED_OCR_API_KEY", "test-only-api-key")
+
+            result = _parse_pdf(content, "scan.pdf", ocr="hosted")
+
+        assert result["markdown"] == "# Hosted scan"
+        assert result["metadata"]["extraction"] == "anydoc_hosted_ocr"
+        assert len(hits) == 1
+        assert hits[0]["path"] == "/v2/parse"
+        assert hits[0]["authorization"] == "Bearer test-only-api-key"
+        payload = hits[0]["body"]
+        assert isinstance(payload, bytes)
+        assert content in payload
+
+    def test_hosted_request_keeps_text_pdf_local(self, monkeypatch):
+        reply = {"success": True, "data": {"markdown": "must not be used"}}
+        with _hosted_parse_stub(200, reply) as (api_url, hits):
+            monkeypatch.setenv("PARSE_HOSTED_OCR_API_URL", api_url)
+
+            result = _parse_pdf(
+                _load("fixture-text.pdf"), "fixture-text.pdf", ocr="hosted"
+            )
+
+        assert "Fixture Document" in result["markdown"]
+        assert result["metadata"]["extraction"] == "pypdf"
+        assert hits == []
+
+    def test_hosted_ocr_requires_explicit_endpoint(self, monkeypatch):
+        monkeypatch.delenv("PARSE_HOSTED_OCR_API_URL", raising=False)
+        monkeypatch.delenv("PARSE_HOSTED_OCR_API_URL", raising=False)
+        with pytest.raises(HTTPException) as exc:
+            _parse_pdf(_load("scanned-image-only.pdf"), "scan.pdf", ocr="hosted")
+        assert exc.value.status_code == 422
+        assert "not configured" in exc.value.detail.lower()
+
+    def test_hosted_ocr_rejects_invalid_endpoint(self, monkeypatch):
+        monkeypatch.setenv("PARSE_HOSTED_OCR_API_URL", "file:///tmp/not-http")
+        with pytest.raises(HTTPException) as exc:
+            _parse_pdf(_load("scanned-image-only.pdf"), "scan.pdf", ocr="hosted")
+        assert exc.value.status_code == 422
+        assert "invalid" in exc.value.detail.lower()
+
+    def test_hosted_failure_redacts_credentials(self, monkeypatch, caplog):
+        credential = "test-only-api-key"
+        reply = {
+            "success": False,
+            "error": f"provider rejected {credential}",
+        }
+        with _hosted_parse_stub(401, reply) as (api_url, _hits):
+            monkeypatch.setenv("PARSE_HOSTED_OCR_API_URL", api_url)
+            monkeypatch.setenv("PARSE_HOSTED_OCR_API_KEY", credential)
+
+            with pytest.raises(HTTPException) as exc:
+                _parse_pdf(_load("scanned-image-only.pdf"), "scan.pdf", ocr="hosted")
+
+        assert exc.value.status_code == 502
+        assert credential not in exc.value.detail
+        assert credential not in caplog.text
+
+    def test_default_local_mode_never_hits_hosted_endpoint(self, monkeypatch):
+        content = _load("scanned-image-only.pdf")
+        fake_pdf2image = ModuleType("pdf2image")
+        fake_pdf2image.convert_from_bytes = lambda *a, **k: [object()]
+        fake_tesseract = ModuleType("pytesseract")
+        fake_tesseract.image_to_string = lambda *a, **k: "local text " * 20
+        reply = {"success": True, "data": {"markdown": "must not be used"}}
+
+        with _hosted_parse_stub(200, reply) as (api_url, hits):
+            monkeypatch.setenv("PARSE_HOSTED_OCR_API_URL", api_url)
+            with patch.dict(
+                sys.modules,
+                {"pdf2image": fake_pdf2image, "pytesseract": fake_tesseract},
+            ):
+                result = _parse_pdf(content, "scan.pdf")
+
+        assert result["metadata"]["extraction"] == "local_ocr"
+        assert hits == []
 
     def test_corrupt_pdf_graceful(self):
         result = _parse_pdf(b"not a pdf at all", "bad.pdf")

--- a/uv.lock
+++ b/uv.lock
@@ -698,17 +698,17 @@ wheels = [
 
 [[package]]
 name = "firecrawl-anydoc"
-version = "0.1.9"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/16/e37d4f284482a4f30e0502ce439a9fd8ccf013e6ae4438b4dfa209e48750/firecrawl_anydoc-0.1.9.tar.gz", hash = "sha256:0dfc64b82b4e971143dd6f0e4f39f8152fcc38be6523663682a241d8f3301b14", size = 197914, upload-time = "2026-08-13T21:48:27.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/54/ee43b1661a954e53eaed85878a7ccc37ed73e02e6577bb26437ec5f9de94/firecrawl_anydoc-0.2.4.tar.gz", hash = "sha256:3e29460272fea81cde08fd5af11f6b0f1ff05919214ddc939867f72362c83032", size = 270706, upload-time = "2026-08-27T19:13:58.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/37/866bf6270ad8552eaf6edf3b8e1a360acf3e8764140641361ae7b440514e/firecrawl_anydoc-0.1.9-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ebd956831822d3ea1831253406736e0e4d9b217e3471eb68c9bf2eba9302ce73", size = 3469321, upload-time = "2026-08-13T21:48:16.775Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/9a/8fbe0726cdf69154e1eb05c119332b1fdfd8200eeafcfd1675741ac5f03d/firecrawl_anydoc-0.1.9-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a2372d97826e8e7e68fd28cd415d08815f6aa66dcc09c6b423ac33dd2dfa91cf", size = 3287520, upload-time = "2026-08-13T21:48:18.37Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ce/86a626224c365d8de65699d6ac8f4626ac05e7e75c3ae76c82f4904a07d2/firecrawl_anydoc-0.1.9-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba1c19bdaa97f4850daf3fb4ca2855cefa146b5621ce7b22a71d158d3b84e54e", size = 3331094, upload-time = "2026-08-13T21:48:19.961Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/28/00d1d48fe205ab66eda4a2a22cce44aadf586ef1495e703349b791c8de32/firecrawl_anydoc-0.1.9-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:deea7a270fccda9be29c73235e938ca32e0f703e1ae120f08bf0fdb39301c6b4", size = 3555945, upload-time = "2026-08-13T21:48:21.822Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/25/ac52d98c5d082ef92396b2fcb398745a3b054816c67a12d19de86c1ba535/firecrawl_anydoc-0.1.9-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:de0858decd18188b0b88545689544fb3703ec08ade37f63c2857e4414e99bdf1", size = 3510861, upload-time = "2026-08-13T21:48:23.369Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/d3/e80314b5746c4ca85150f3ab2a527b2167012c16e706e148733211cb88b3/firecrawl_anydoc-0.1.9-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e4e1765ed5574fa502931f8bfaec1f87af913afa5bb432aaaf5f9c094efc7f43", size = 3797896, upload-time = "2026-08-13T21:48:25.061Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/d0/e7b35c2365498d5e9f1bdb4b3ded78571b6dafbaba1880538490d27b71c9/firecrawl_anydoc-0.1.9-cp310-abi3-win_amd64.whl", hash = "sha256:aa6a5ca2e10939a87c9bd21c918ef8b146ad0061fedae661d4483ef5a5bbdf60", size = 3642084, upload-time = "2026-08-13T21:48:26.702Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f1/5616b8d703b2bf5688eda86ede4b35620356d9c60346fe2d3efbec2a872d/firecrawl_anydoc-0.2.4-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e3745a8b108d6575beafd37bcefe52e3f6c7ab44138e05cbdf4c6adf63caba84", size = 3441281, upload-time = "2026-08-27T19:13:43.408Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7d/4b2a466c8953af3b9d94471081b04ce8636680111402d2140105f98c02e5/firecrawl_anydoc-0.2.4-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b2a01eecaa0b99f99ff6749a098f8c7a5250d41db9c53673eb93536ad575bfed", size = 3262365, upload-time = "2026-08-27T19:13:46.362Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b5/5784fc514f58ca19328faee701d2cc2e25961389c2d4908b2a51a1071ee4/firecrawl_anydoc-0.2.4-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17720ba093820654162891d7995fd2dbae948b16fe1c174ba799bddfc0b92ad6", size = 3265363, upload-time = "2026-08-27T19:13:48.425Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/16/feeca9705bfdb237f1cb69ede0b373b144c0d51df4297e595a74b815557e/firecrawl_anydoc-0.2.4-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e5aed01bf6d4e5c588d3363888293f2ceeb9feb00449a32e0ba993797cf0bd3", size = 3506751, upload-time = "2026-08-27T19:13:50.372Z" },
+    { url = "https://files.pythonhosted.org/packages/14/28/b4d0d3c5345cdd65c0b9113c6e6ff1b717fe360dccb658db2a9952315f9c/firecrawl_anydoc-0.2.4-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd162b5eb64478fcf02f53abe7765e26f4350ba657f36c25f055c4cc3dbade0a", size = 3443075, upload-time = "2026-08-27T19:13:52.417Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/29/50c52b0ea5dd645aea6d195da913c8d9e136601eec465bd9a590edd250c7/firecrawl_anydoc-0.2.4-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e57c79093c1592929dd8dfaf6c60b49eefe631721d96fb833c3f465472b37b9f", size = 3742860, upload-time = "2026-08-27T19:13:54.474Z" },
+    { url = "https://files.pythonhosted.org/packages/65/34/6d54fed906055e5507dd94efd63f4a05021f103dc684ea62a3b0876b7595/firecrawl_anydoc-0.2.4-cp310-abi3-win_amd64.whl", hash = "sha256:7c9ffc81946e6954c124560ed1d395e0103a1a08fdc0f6be382e2f35daf6dbc9", size = 3583555, upload-time = "2026-08-27T19:13:56.698Z" },
 ]
 
 [[package]]
@@ -886,7 +886,7 @@ dev = [
 fast-tests = [
     { name = "cloakbrowser", specifier = "==0.5.3" },
     { name = "curl-cffi", specifier = ">=0.15.0" },
-    { name = "firecrawl-anydoc", specifier = "==0.1.9" },
+    { name = "firecrawl-anydoc", specifier = "==0.2.4" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "markdownify", specifier = "==1.2.3" },
@@ -1724,7 +1724,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "firecrawl-anydoc", specifier = "==0.1.9" },
+    { name = "firecrawl-anydoc", specifier = "==0.2.4" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pypdf", specifier = ">=5.0.0" },


### PR DESCRIPTION
## Summary

Add explicit hosted OCR support for scanned PDFs through the AnyDoc 0.2.4 binding while preserving local-first parsing and making the document-upload boundary visible.

## Related Issue

Closes #615
Related skill issue: https://github.com/magnus919/agent-skills/issues/419

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [x] Test
- [ ] CI/DevOps

## Test Plan

- [x] Focused parser and CLI tests: `PYTHONPATH=/tmp/anydoc024:agent-svc:scraper-svc:llm-svc:parse-svc:portal-svc:browser-svc:semantic-svc:. pytest -q tests/unit/test_parse_svc_unit.py tests/service/test_cli.py --no-cov` (115 passed)
- [x] Added deterministic hosted-Parse stub tests for whole-document forwarding, local-first behavior, endpoint validation, failure handling, and credential redaction.
- [x] Added CLI `--ocr local|hosted` propagation and service multipart option handling.
- [ ] Full Docker integration test (requires Docker/runtime stack)

## Notes for Reviewers

- Hosted OCR is only selected when the caller passes `--ocr hosted`; local OCR remains the default service behavior.
- The service requires an explicit `PARSE_HOSTED_OCR_API_URL`; credentials are read from the trusted environment and are not included in errors.
- The test environment used a real `firecrawl-anydoc==0.2.4` wheel installed into an isolated temporary target, plus a deterministic local HTTP stub. No external OCR service was called.
- The repository's existing untracked test outcome artifacts were not included.

Filed by Jasper (AI agent on behalf of Magnus Hedemark)
