### PR TITLE
perf(research): reuse unique source artifacts across research passes

### DIFF
--- a/agent-svc/agent/research/discovery.py
+++ b/agent-svc/agent/research/discovery.py
@@ -114,11 +114,11 @@ async def _scrape_urls(
                 continue
         urls_to_scrape.append(url)
 
-    # A compatible artifact satisfies the source quota without consuming a
-    # credit or launching speculative work. Failed attempts are intentionally
-    # absent from the registry and remain in this fresh list for retry.
-    if len(artifacts) >= min_sources or not urls_to_scrape:
+    # Reused evidence remains free, but must not crowd novel gap results out
+    # of the fresh acquisition quota. A duplicate-only pass launches no work.
+    if not urls_to_scrape:
         return artifacts
+    min_sources += len(artifacts)
 
     urls = urls_to_scrape
     fresh_by_key: dict[str, SourceArtifact] = {}

--- a/agent-svc/agent/research/discovery.py
+++ b/agent-svc/agent/research/discovery.py
@@ -121,6 +121,24 @@ async def _scrape_urls(
         return artifacts
 
     urls = urls_to_scrape
+    fresh_by_key: dict[str, SourceArtifact] = {}
+
+    def finalize() -> list[SourceArtifact]:
+        """Register fresh artifacts in candidate order for stable output."""
+        if source_registry is None:
+            return artifacts
+        for url in urls:
+            key = normalize_source_url(url)
+            artifact = fresh_by_key.get(key)
+            if artifact is not None:
+                source_registry.register(artifact, scrape_options)
+        fresh = [
+            fresh_by_key[normalize_source_url(url)]
+            for url in urls
+            if normalize_source_url(url) in fresh_by_key
+        ]
+        return artifacts[: len(artifacts) - len(fresh)] + fresh
+
     max_attempts = max_attempts or len(urls)
     semaphore = asyncio.Semaphore(max_concurrent)
     url_timeout = 70  # Accommodates scrape_with_fallback (20s generic + 45s browser)
@@ -150,9 +168,8 @@ async def _scrape_urls(
         for task in done:
             artifact = task.result()
             if artifact is not None:
-                if source_registry is not None:
-                    artifact = source_registry.register(artifact, scrape_options)
                 artifacts.append(artifact)
+                fresh_by_key[normalize_source_url(artifact.url)] = artifact
                 if len(artifacts) >= min_sources:
                     # Cancel remaining speculative tasks and await them so no
                     # pending task is destroyed (or races browser cleanup).
@@ -160,9 +177,9 @@ async def _scrape_urls(
                         t.cancel()
                     if tasks:
                         await asyncio.gather(*tasks, return_exceptions=True)
-                    return artifacts
+                    return finalize()
 
-    return artifacts
+    return finalize()
 
 
 def _dedupe_urls(urls: list[str]) -> list[str]:

--- a/agent-svc/agent/research/discovery.py
+++ b/agent-svc/agent/research/discovery.py
@@ -9,7 +9,12 @@ from ..metrics import METRICS
 from ..scraper_client import ScraperClient
 from ..searxng_client import SearXNGClient
 from .scoring import _filter_and_rank_urls, _is_video_platform_url
-from .sources import SourceArtifact, artifacts_to_documents_and_details
+from .sources import (
+    SourceArtifact,
+    SourceRegistry,
+    artifacts_to_documents_and_details,
+    normalize_source_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +61,9 @@ async def _scrape_single(
                     markdown=md,
                     source=result["data"].get("source", "unknown"),
                     char_count=len(md),
+                    cache_state="live",
                     fetched_at=time.time(),
+                    fetch_options=scrape_options,
                 )
             else:
                 logger.warning("Failed to scrape %s: %s", url, result.get("error"))
@@ -76,6 +83,7 @@ async def _scrape_urls(
     max_attempts: int | None = None,
     max_concurrent: int = 5,
     scrape_options: dict | None = None,
+    source_registry: SourceRegistry | None = None,
 ) -> list[SourceArtifact]:
     """Scrape URLs with bounded concurrency and return ``SourceArtifact``s.
 
@@ -87,6 +95,32 @@ async def _scrape_urls(
     coroutine is left behind.
     """
     artifacts: list[SourceArtifact] = []
+    urls_to_scrape: list[str] = []
+    seen_keys: set[str] = set()
+    for url in urls:
+        key = normalize_source_url(url)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        if source_registry is not None:
+            reused = source_registry.get(url, scrape_options)
+            if reused is not None:
+                artifacts.append(reused)
+                METRICS.counter(
+                    "fetches_deduped_total",
+                    "Total scrapes avoided by reusing already-fetched content",
+                    ["reason"],
+                ).inc({"reason": "research_registry"})
+                continue
+        urls_to_scrape.append(url)
+
+    # A compatible artifact satisfies the source quota without consuming a
+    # credit or launching speculative work. Failed attempts are intentionally
+    # absent from the registry and remain in this fresh list for retry.
+    if len(artifacts) >= min_sources or not urls_to_scrape:
+        return artifacts
+
+    urls = urls_to_scrape
     max_attempts = max_attempts or len(urls)
     semaphore = asyncio.Semaphore(max_concurrent)
     url_timeout = 70  # Accommodates scrape_with_fallback (20s generic + 45s browser)
@@ -116,6 +150,8 @@ async def _scrape_urls(
         for task in done:
             artifact = task.result()
             if artifact is not None:
+                if source_registry is not None:
+                    artifact = source_registry.register(artifact, scrape_options)
                 artifacts.append(artifact)
                 if len(artifacts) >= min_sources:
                     # Cancel remaining speculative tasks and await them so no
@@ -129,11 +165,95 @@ async def _scrape_urls(
     return artifacts
 
 
+def _dedupe_urls(urls: list[str]) -> list[str]:
+    """Keep first URL spelling while deduplicating conservative identities."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for url in urls:
+        key = normalize_source_url(url)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        result.append(url)
+    return result
+
+
+def _apply_credit_budget(
+    urls: list[str],
+    max_credits: int | None,
+    source_registry: SourceRegistry | None,
+    scrape_options: dict | None,
+) -> list[str]:
+    """Bound only novel acquisitions; compatible registry hits are free."""
+    if max_credits is None or max_credits < 0:
+        return urls
+    if source_registry is None:
+        return urls[:max_credits]
+
+    result: list[str] = []
+    novel = 0
+    for url in urls:
+        if source_registry.get(url, scrape_options) is None:
+            if novel >= max_credits:
+                continue
+            novel += 1
+        result.append(url)
+    return result
+
+
+def _discovery_result(
+    *,
+    search_results: list[dict],
+    target_urls: list[str],
+    artifacts: list[SourceArtifact],
+    source_registry: SourceRegistry | None,
+    reusable_keys: set[str],
+    pass_number: int | None = None,
+) -> dict:
+    """Project discovery with unique context and acquisition accounting."""
+    all_artifacts = (
+        source_registry.artifacts() if source_registry is not None else artifacts
+    )
+    documents, source_details = artifacts_to_documents_and_details(all_artifacts)
+    context = "\n\n---\n\n".join(documents) if documents else ""
+    novel_artifacts = [
+        artifact
+        for artifact in artifacts
+        if normalize_source_url(artifact.url) not in reusable_keys
+    ]
+    reused_artifacts = [
+        artifact
+        for artifact in artifacts
+        if normalize_source_url(artifact.url) in reusable_keys
+    ]
+    if pass_number is not None:
+        METRICS.counter(
+            "research_novel_sources_total",
+            "Successfully acquired novel sources by research pass",
+            ["pass"],
+        ).inc({"pass": str(pass_number)}, len(novel_artifacts))
+    return {
+        "search_results": search_results,
+        "target_urls": target_urls,
+        "documents": documents,
+        "source_details": source_details,
+        "context": context,
+        "artifacts": all_artifacts,
+        "new_artifacts": novel_artifacts,
+        "reused_artifacts": reused_artifacts,
+        "novel_sources": [artifact.url for artifact in novel_artifacts],
+        "reused_sources": [artifact.url for artifact in reused_artifacts],
+        "credits_used": len(novel_artifacts),
+        "fetches_deduped": len(reused_artifacts),
+    }
+
+
 async def _scrape_with_fallback(
     urls: list[str],
     scraper: ScraperClient,
     min_sources: int = 3,
     scrape_options: dict | None = None,
+    source_registry: SourceRegistry | None = None,
 ) -> list[SourceArtifact]:
     """Scrape URLs with video-platform fallback strategy.
 
@@ -152,6 +272,7 @@ async def _scrape_with_fallback(
         min_sources=min_sources,
         max_attempts=len(preferred) or 10,
         scrape_options=scrape_options,
+        source_registry=source_registry,
     )
     logger.info(
         "Scrape with fallback: %d docs from %d preferred URLs (min_sources=%d)",
@@ -168,6 +289,7 @@ async def _scrape_with_fallback(
             min_sources=remaining,
             max_attempts=remaining * 2,
             scrape_options=scrape_options,
+            source_registry=source_registry,
         )
         artifacts.extend(extra)
 
@@ -182,6 +304,8 @@ async def _run_multi_query_discover_and_scrape(
     max_searches_per_request: int = 5,
     scrape_options: dict | None = None,
     max_credits: int | None = None,
+    source_registry: SourceRegistry | None = None,
+    pass_number: int | None = None,
 ) -> dict:
     """Search multiple sub-queries, deduplicate URLs, scrape, and merge context.
 
@@ -198,9 +322,10 @@ async def _run_multi_query_discover_and_scrape(
     Returns the same dict shape as ``_run_research_discover_and_scrape()``:
         search_results, target_urls, documents, source_details, context
     """
-    target_urls = list(urls) if urls else []
+    source_registry = source_registry or SourceRegistry()
+    target_urls = _dedupe_urls(list(urls) if urls else [])
     all_search_results: list[dict] = []
-    seen_urls: set[str] = set(target_urls)
+    seen_urls: set[str] = {normalize_source_url(url) for url in target_urls}
 
     # Truncate to search budget
     budget = min(len(queries), max_searches_per_request)
@@ -238,37 +363,47 @@ async def _run_multi_query_discover_and_scrape(
             results, _health = result_tuple  # type: ignore[misc]
             for r in results:
                 url = r.get("url", "")
-                if url and url not in seen_urls:
-                    seen_urls.add(url)
+                normalized = normalize_source_url(url)
+                if url and normalized not in seen_urls:
+                    seen_urls.add(normalized)
                     all_search_results.append(r)
                     target_urls.append(url)
 
     if not target_urls and not queries_to_run:
-        return {
-            "search_results": [],
-            "target_urls": [],
-            "documents": [],
-            "source_details": [],
-            "context": "",
-        }
+        return _discovery_result(
+            search_results=[],
+            target_urls=[],
+            artifacts=[],
+            source_registry=source_registry,
+            reusable_keys=set(),
+            pass_number=pass_number,
+        )
 
     # Score and rank URLs before scraping (F1: source pre-filtering)
-    target_urls = _filter_and_rank_urls(target_urls, max_urls=20)
-    if max_credits is not None and max_credits >= 0:
-        target_urls = target_urls[:max_credits]
-    artifacts = await _scrape_with_fallback(
-        target_urls, scraper, min_sources=3, scrape_options=scrape_options
-    )
-    documents, source_details = artifacts_to_documents_and_details(artifacts)
-    context = "\n\n---\n\n".join(documents) if documents else ""
-
-    return {
-        "search_results": all_search_results,
-        "target_urls": target_urls,
-        "documents": documents,
-        "source_details": source_details,
-        "context": context,
+    target_urls = _dedupe_urls(_filter_and_rank_urls(target_urls, max_urls=20))
+    reusable_keys = {
+        normalize_source_url(url)
+        for url in target_urls
+        if source_registry.get(url, scrape_options) is not None
     }
+    target_urls = _apply_credit_budget(
+        target_urls, max_credits, source_registry, scrape_options
+    )
+    artifacts = await _scrape_with_fallback(
+        target_urls,
+        scraper,
+        min_sources=3,
+        scrape_options=scrape_options,
+        source_registry=source_registry,
+    )
+    return _discovery_result(
+        search_results=all_search_results,
+        target_urls=target_urls,
+        artifacts=artifacts,
+        source_registry=source_registry,
+        reusable_keys=reusable_keys,
+        pass_number=pass_number,
+    )
 
 
 async def _run_research_discover_and_scrape(
@@ -279,6 +414,8 @@ async def _run_research_discover_and_scrape(
     max_searches_per_request: int = 5,
     scrape_options: dict | None = None,
     max_credits: int | None = None,
+    source_registry: SourceRegistry | None = None,
+    pass_number: int | None = None,
 ) -> dict:
     """Search → filter → scrape → context-building phase for research.
 
@@ -290,32 +427,41 @@ async def _run_research_discover_and_scrape(
     the candidate list handed to the scraper is truncated to that budget so
     discovery can never exceed the requested credit allowance.
     """
-    target_urls = list(urls) if urls else []
+    source_registry = source_registry or SourceRegistry()
+    target_urls = _dedupe_urls(list(urls) if urls else [])
     search_results: list[dict] = []
     if not target_urls:
         logger.info("No URLs provided. Searching for: %s", prompt)
         search_results, _health = await searxng.search(
             prompt, limit=10, raise_on_rate_limit=True
         )
-        target_urls = [r["url"] for r in search_results if r.get("url")]
+        target_urls = _dedupe_urls([r["url"] for r in search_results if r.get("url")])
 
     # Score and rank URLs before scraping (F1: source pre-filtering)
-    target_urls = _filter_and_rank_urls(target_urls, max_urls=20)
-    if max_credits is not None and max_credits >= 0:
-        target_urls = target_urls[:max_credits]
-    artifacts = await _scrape_with_fallback(
-        target_urls, scraper, min_sources=3, scrape_options=scrape_options
-    )
-    documents, source_details = artifacts_to_documents_and_details(artifacts)
-    context = "\n\n---\n\n".join(documents) if documents else ""
-
-    return {
-        "search_results": search_results,
-        "target_urls": target_urls,
-        "documents": documents,
-        "source_details": source_details,
-        "context": context,
+    target_urls = _dedupe_urls(_filter_and_rank_urls(target_urls, max_urls=20))
+    reusable_keys = {
+        normalize_source_url(url)
+        for url in target_urls
+        if source_registry.get(url, scrape_options) is not None
     }
+    target_urls = _apply_credit_budget(
+        target_urls, max_credits, source_registry, scrape_options
+    )
+    artifacts = await _scrape_with_fallback(
+        target_urls,
+        scraper,
+        min_sources=3,
+        scrape_options=scrape_options,
+        source_registry=source_registry,
+    )
+    return _discovery_result(
+        search_results=search_results,
+        target_urls=target_urls,
+        artifacts=artifacts,
+        source_registry=source_registry,
+        reusable_keys=reusable_keys,
+        pass_number=pass_number,
+    )
 
 
 async def _scrape_answer_sources(

--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -297,9 +297,7 @@ async def _run_research_events(
 
             # ── Gap detection after pass 1 ─────────────────────────
             if pass_count == 1:
-                # ``len(all_source_details) >= max_credits`` was the
-                # pre-registry approximation. Count only novel successful
-                # acquisitions so reuse remains free.
+                # Count novel successful acquisitions; reuse remains free.
                 budget_spent = max_credits is not None and credits_used >= max_credits
                 gap_topics = (
                     []

--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -31,7 +31,11 @@ from .events import ResearchEvent
 from .gaps import _detect_gaps
 from .plan import _generate_research_plan
 from .prompts import ANSWER_SYSTEM_PROMPT, EXTRACT_SYSTEM_PROMPT, SYSTEM_PROMPT
-from .sources import SourceArtifact, artifacts_to_documents_and_details
+from .sources import (
+    SourceArtifact,
+    SourceRegistry,
+    artifacts_to_documents_and_details,
+)
 from .utils import _validate_json_if_schema
 
 logger = logging.getLogger(__name__)
@@ -103,7 +107,9 @@ async def _run_research_events(
 
         pass_count = 0
         max_passes = 2 if search_type == "deep" else 1
+        source_registry = SourceRegistry()
         all_source_details: list[dict] = []
+        credits_used = 0
         combined_context = ""
         gap_topics: list[str] = []
         answer = ""
@@ -128,6 +134,8 @@ async def _run_research_events(
                         max_searches_per_request=max_searches_per_request,
                         scrape_options=scrape_opts,
                         max_credits=max_credits,
+                        source_registry=source_registry,
+                        pass_number=pass_count,
                     )
                 else:
                     query = queries[0] if queries else prompt
@@ -138,6 +146,8 @@ async def _run_research_events(
                         scraper=scraper,
                         scrape_options=scrape_opts,
                         max_credits=max_credits,
+                        source_registry=source_registry,
+                        pass_number=pass_count,
                     )
             else:
                 # ── Pass 2: gap-focused discovery ─────────────────
@@ -151,14 +161,16 @@ async def _run_research_events(
                     ),
                     scrape_options=scrape_opts,
                     max_credits=(
-                        max_credits - len(all_source_details)
-                        if max_credits is not None
-                        else None
+                        max_credits - credits_used if max_credits is not None else None
                     ),
+                    source_registry=source_registry,
+                    pass_number=pass_count,
                 )
 
             context = discovered["context"]
             source_details = discovered["source_details"]
+            novel_artifacts = discovered.get("new_artifacts", [])
+            previous_context = combined_context
             search_results = discovered["search_results"]
             pending_sources = (
                 [
@@ -174,12 +186,15 @@ async def _run_research_events(
                 else [{"url": url, "title": "", "relevance": ""} for url in urls]
             )
             yield {"type": "sources_pending", "sources": pending_sources}
-            for source in source_details:
+            # A registry hit is already known to the client. Emit progress
+            # only for newly acquired artifacts so a duplicate-only pass does
+            # not replay scrape events for the same source.
+            for artifact in novel_artifacts:
                 yield {
                     "type": "source_scraped",
-                    "url": source["url"],
-                    "source": source["source"],
-                    "chars": source["char_count"],
+                    "url": artifact.url,
+                    "source": artifact.source,
+                    "chars": artifact.char_count,
                 }
             if not context and not combined_context:
                 yield {"type": "sources", "sources": []}
@@ -192,16 +207,16 @@ async def _run_research_events(
                 }
                 return
 
-            all_source_details.extend(source_details)
-            if pass_count == 1:
-                combined_context = context
-            else:
-                if context:
-                    combined_context = (
-                        combined_context
-                        + "\n\n---\n\nAdditional sources (pass 2):\n\n"
-                        + context
-                    )
+            all_source_details = list(source_details)
+            credits_used += discovered.get("credits_used", len(novel_artifacts))
+            combined_context = context
+
+            # Gap search can rediscover every source from pass one. The
+            # request-scoped registry makes that a no-op: preserve the first
+            # synthesis and its stream/schema semantics when evidence and
+            # context are unchanged.
+            if pass_count > 1 and context == previous_context:
+                break
 
             if not combined_context:
                 yield {"type": "sources", "sources": []}
@@ -282,9 +297,10 @@ async def _run_research_events(
 
             # ── Gap detection after pass 1 ─────────────────────────
             if pass_count == 1:
-                budget_spent = (
-                    max_credits is not None and len(all_source_details) >= max_credits
-                )
+                # ``len(all_source_details) >= max_credits`` was the
+                # pre-registry approximation. Count only novel successful
+                # acquisitions so reuse remains free.
+                budget_spent = max_credits is not None and credits_used >= max_credits
                 gap_topics = (
                     []
                     if budget_spent

--- a/agent-svc/agent/research/sources.py
+++ b/agent-svc/agent/research/sources.py
@@ -9,7 +9,10 @@ artifact is never persisted into the replayable event state.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
 
 from common.url import extract_domain
 
@@ -37,6 +40,11 @@ class SourceArtifact:
     retrieval: str = "web"  # "web" / "vector" / "both"
     score: float | None = None
     cache_age_ms: int | None = None
+    # Request options are retained so later stages can validate reuse against
+    # the same extraction contract.
+    fetch_options: dict[str, Any] | None = None
+    contents_options: dict[str, Any] | None = None
+    extras: dict[str, Any] | None = None
 
     def to_document(self, max_chars: int = DOCUMENT_MAX_CHARS) -> str:
         """Render the source into a ``Source: url (domain: ...)`` context block."""
@@ -51,6 +59,160 @@ class SourceArtifact:
             "source": self.source,
             "char_count": self.char_count,
         }
+
+    def compatible_with(
+        self,
+        *,
+        fetch_options: dict[str, Any] | None = None,
+        contents_options: dict[str, Any] | None = None,
+    ) -> bool:
+        """Return whether this artifact satisfies an extraction contract."""
+        return _options_fingerprint(self.fetch_options, self.contents_options) == (
+            _options_fingerprint(fetch_options, contents_options)
+        )
+
+
+def normalize_source_url(url: str) -> str:
+    """Return a conservative identity key for a request-scoped source.
+
+    Only URL spelling that cannot identify a different resource is folded:
+    scheme and host case, default ports, fragments, and a trailing path slash.
+    Query strings (including their order and case) and path case are retained
+    because either can be significant to a resource. Invalid or relative URLs
+    are returned trimmed rather than guessed at.
+    """
+    raw = url.strip()
+    if not raw:
+        return raw
+    try:
+        parsed = urlparse(raw)
+        host = parsed.hostname
+        if not host or not parsed.scheme:
+            return raw
+        port = parsed.port
+    except ValueError:
+        return raw
+
+    scheme = parsed.scheme.lower()
+    host = host.lower()
+    if parsed.username or parsed.password:
+        # Credentials are unusual for search results. Preserve the complete
+        # spelling rather than accidentally treating two authenticated URLs as
+        # the same source.
+        return raw
+    if (
+        port is None
+        or (scheme == "http" and port == 80)
+        or (scheme == "https" and port == 443)
+    ):
+        netloc = f"[{host}]" if ":" in host else host
+    else:
+        netloc = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+    path = parsed.path or "/"
+    if len(path) > 1:
+        path = path.rstrip("/")
+    result = f"{scheme}://{netloc}{path}"
+    if parsed.query:
+        result += f"?{parsed.query}"
+    return result
+
+
+# Short alias used by discovery callers and convenient for tests.
+_normalize_source_url = normalize_source_url
+
+
+def _options_fingerprint(
+    fetch_options: dict[str, Any] | None,
+    contents_options: dict[str, Any] | None,
+) -> str:
+    """Build a stable compatibility fingerprint for extraction options."""
+    try:
+        return json.dumps(
+            {"fetch": fetch_options or {}, "contents": contents_options or {}},
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+    except (TypeError, ValueError):
+        return repr((fetch_options, contents_options))
+
+
+@dataclass
+class _RegistryEntry:
+    artifact: SourceArtifact
+    scrape_options_key: str
+
+
+class SourceRegistry:
+    """Request-scoped successful source artifacts.
+
+    The registry intentionally has no failure entries. A failed or barrier
+    refused acquisition therefore remains eligible for a later retry. An
+    artifact is reusable only when its extraction-option fingerprint matches
+    the requested fingerprint exactly.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, _RegistryEntry] = {}
+
+    def key(self, url: str) -> str:
+        """Return the normalized identity key for *url*."""
+        return normalize_source_url(url)
+
+    def get(
+        self, url: str, scrape_options: dict | None = None
+    ) -> SourceArtifact | None:
+        """Return compatible non-empty content, if present."""
+        entry = self._entries.get(self.key(url))
+        if entry is None or not entry.artifact.markdown:
+            return None
+        if entry.scrape_options_key != _options_fingerprint(scrape_options, None):
+            return None
+        return entry.artifact
+
+    def register(
+        self, artifact: SourceArtifact, scrape_options: dict | None = None
+    ) -> SourceArtifact:
+        """Store a successful artifact and return the stored artifact.
+
+        Empty artifacts are ignored so they never suppress a future retry.
+        Existing metadata is retained when a later alias has less metadata.
+        """
+        if not artifact.markdown:
+            return artifact
+        if artifact.fetch_options is None:
+            artifact.fetch_options = scrape_options
+        key = self.key(artifact.url)
+        previous = self._entries.get(key)
+        if previous is not None:
+            old = previous.artifact
+            if not artifact.title:
+                artifact.title = old.title
+            if not artifact.relevance:
+                artifact.relevance = old.relevance
+        self._entries[key] = _RegistryEntry(
+            artifact=artifact,
+            scrape_options_key=_options_fingerprint(
+                artifact.fetch_options, artifact.contents_options
+            ),
+        )
+        return artifact
+
+    def artifacts(self) -> list[SourceArtifact]:
+        """Return unique artifacts in first-seen order."""
+        return [
+            entry.artifact
+            for entry in self._entries.values()
+            if entry.artifact.markdown
+        ]
+
+    def documents(self) -> list[str]:
+        """Render the unique registry contents as synthesis documents."""
+        return [artifact.to_document() for artifact in self.artifacts()]
+
+    def context(self) -> str:
+        """Render a stable, duplicate-free synthesis context."""
+        return "\n\n---\n\n".join(self.documents())
 
 
 def artifacts_to_documents_and_details(

--- a/agent-svc/agent/research/sources.py
+++ b/agent-svc/agent/research/sources.py
@@ -76,8 +76,8 @@ def normalize_source_url(url: str) -> str:
     """Return a conservative identity key for a request-scoped source.
 
     Only URL spelling that cannot identify a different resource is folded:
-    scheme and host case, default ports, fragments, and a trailing path slash.
-    Query strings (including their order and case) and path case are retained
+    scheme and host case, default ports, fragments, and an empty path. Query
+    strings (including their order and case) and path spelling are retained
     because either can be significant to a resource. Invalid or relative URLs
     are returned trimmed rather than guessed at.
     """
@@ -109,16 +109,10 @@ def normalize_source_url(url: str) -> str:
     else:
         netloc = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
     path = parsed.path or "/"
-    if len(path) > 1:
-        path = path.rstrip("/")
     result = f"{scheme}://{netloc}{path}"
     if parsed.query:
         result += f"?{parsed.query}"
     return result
-
-
-# Short alias used by discovery callers and convenient for tests.
-_normalize_source_url = normalize_source_url
 
 
 def _options_fingerprint(

--- a/agent-svc/agent/research/sources.py
+++ b/agent-svc/agent/research/sources.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlsplit, urlunsplit
 
 from common.url import extract_domain
 
@@ -73,46 +73,20 @@ class SourceArtifact:
 
 
 def normalize_source_url(url: str) -> str:
-    """Return a conservative identity key for a request-scoped source.
-
-    Only URL spelling that cannot identify a different resource is folded:
-    scheme and host case, default ports, fragments, and an empty path. Query
-    strings (including their order and case) and path spelling are retained
-    because either can be significant to a resource. Invalid or relative URLs
-    are returned trimmed rather than guessed at.
-    """
+    """Fold transport-equivalent spelling without changing resource identity."""
     raw = url.strip()
-    if not raw:
-        return raw
     try:
-        parsed = urlparse(raw)
-        host = parsed.hostname
-        if not host or not parsed.scheme:
+        parsed = urlsplit(raw)
+        host, port = parsed.hostname, parsed.port
+        if not host or not parsed.scheme or parsed.username or parsed.password:
             return raw
-        port = parsed.port
+        scheme = parsed.scheme.lower()
+        netloc = f"[{host.lower()}]" if ":" in host else host.lower()
+        if port is not None and (scheme, port) not in {("http", 80), ("https", 443)}:
+            netloc += f":{port}"
+        return urlunsplit((scheme, netloc, parsed.path or "/", parsed.query, ""))
     except ValueError:
         return raw
-
-    scheme = parsed.scheme.lower()
-    host = host.lower()
-    if parsed.username or parsed.password:
-        # Credentials are unusual for search results. Preserve the complete
-        # spelling rather than accidentally treating two authenticated URLs as
-        # the same source.
-        return raw
-    if (
-        port is None
-        or (scheme == "http" and port == 80)
-        or (scheme == "https" and port == 443)
-    ):
-        netloc = f"[{host}]" if ":" in host else host
-    else:
-        netloc = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
-    path = parsed.path or "/"
-    result = f"{scheme}://{netloc}{path}"
-    if parsed.query:
-        result += f"?{parsed.query}"
-    return result
 
 
 def _options_fingerprint(

--- a/docs/adr/0059-extend-source-artifact-reuse-across-research-passes.md
+++ b/docs/adr/0059-extend-source-artifact-reuse-across-research-passes.md
@@ -28,8 +28,8 @@ context, or source accounting.
 Discovery accepts an optional request-scoped `SourceRegistry`. The registry
 maps a normalized URL identity to the latest successful, nonempty
 `SourceArtifact`. Normalization lowercases scheme and host, removes default
-ports, fragments, and non-root trailing slashes; it preserves path case and
-the complete query string. A registry hit is reusable only when its exact
+ports and fragments, and maps an empty path to `/`; it preserves path case,
+trailing slashes, and the complete query string. A registry hit is reusable only when its exact
 fetch/contents option fingerprint matches the requested extraction contract.
 
 Failed or refused acquisitions are never registered. A later pass can retry

--- a/docs/adr/0059-extend-source-artifact-reuse-across-research-passes.md
+++ b/docs/adr/0059-extend-source-artifact-reuse-across-research-passes.md
@@ -1,0 +1,59 @@
+# Extend Source Artifact Reuse Across Research Passes
+
+- Status: accepted
+- Deciders: GroktoCrawl maintainers
+- Date: 2026-09-04
+
+## Context
+
+The canonical deep research loop can run a gap-focused discovery pass after
+its initial pass. Before this decision, each discovery invocation tracked its
+own URLs and scraped Markdown, so a follow-up search could fetch the same page
+again, append duplicate context, and report duplicate sources. A warm scraper
+cache could reduce network work but did not remove duplicate extraction,
+context, or source accounting.
+
+## Decision Drivers
+
+- Avoid duplicate fetch and extraction work within one request.
+- Keep source identity conservative because query parameters and path case can
+  identify different resources.
+- Preserve retry behavior after failed or barrier-refused acquisition.
+- Make credit use reflect novel successful acquisitions while allowing reuse.
+- Keep extraction-option changes observable and compatible with streaming and
+  structured-output callers.
+
+## Decision
+
+Discovery accepts an optional request-scoped `SourceRegistry`. The registry
+maps a normalized URL identity to the latest successful, nonempty
+`SourceArtifact`. Normalization lowercases scheme and host, removes default
+ports, fragments, and non-root trailing slashes; it preserves path case and
+the complete query string. A registry hit is reusable only when its exact
+fetch/contents option fingerprint matches the requested extraction contract.
+
+Failed or refused acquisitions are never registered. A later pass can retry
+them. New successful artifacts consume one credit each; compatible registry
+hits consume none. Discovery returns unique registry-wide artifacts and
+explicit novel/reused accounting so the loop can build one context and source
+list. The loop compares the resulting context/evidence before deciding whether
+another synthesis call is necessary.
+
+The registry lifetime is one request. It is not a replacement for the
+cross-session research-memory or scraper-cache freshness policies.
+
+## Consequences
+
+- Positive: duplicate-only follow-up passes perform no compatible scrape and
+  retain stable unique context and source details.
+- Positive: partial overlap acquires only novel compatible candidates, and
+  option changes trigger an observable fresh acquisition.
+- Positive: failure remains retryable and metrics expose registry reuse and
+  novel sources by pass.
+- Negative: the canonical loop must carry the registry and use its unique
+  context/accounting when merging passes.
+
+## Links
+
+- [ADR-0050](0050-source-artifact-and-lightweight-only-scrape.md)
+- Issue #624 — Cross-pass source artifact reuse

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,7 @@ An Architecture Decision Record captures an important architectural decision mad
 
 **Status legend:** accepted ADRs describe decisions used by the current implementation. Proposed ADRs are design work, not promises of current behavior. Superseded ADRs are historical context only; use their successor when documenting current behavior.
 
-**Current accepted decisions:** ADR-0001–0007, 0009–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, 0049, 0050, 0051, 0052, 0053, 0054, 0055, 0056, and 0057.
+**Current accepted decisions:** ADR-0001–0007, 0009–0012, 0014–0022, 0026, 0029–0035, 0038, 0039, 0043, 0044, 0045, 0046, 0047, 0048, 0049, 0050, 0051, 0052, 0053, 0054, 0055, 0056, 0057, and 0059.
 
 **Proposed work:** ADR-0023–0025, 0027, 0028, 0036, 0037, and 0040–0042.
 
@@ -82,4 +82,5 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0055 | [Deterministic LLM Contract Fixture](0055-deterministic-llm-contract-fixture.md) | accepted |
 | 0056 | [Twin CI Evidence and Trusted Calibration](0056-twin-ci-evidence-and-calibration.md) | accepted |
 | 0057 | [Defer Recurring Mutation-Testing CI (Pilot Outcome)](0057-defer-recurring-mutation-testing-ci.md) | accepted |
+| 0059 | [Extend Source Artifact Reuse Across Research Passes](0059-extend-source-artifact-reuse-across-research-passes.md) | accepted |
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/tests/service/test_agent_max_credits.py
+++ b/tests/service/test_agent_max_credits.py
@@ -328,18 +328,6 @@ class TestMaxCreditsGuardRemoval:
             "guard — the API model enforces ge=1, so drop the dead branch"
         )
 
-    @pytest.mark.asyncio
-    async def test_budget_spent_check_uses_counted_sources_only(self):
-        """budget_spent compares consumed sources to the budget directly."""
-        import inspect
-
-        from agent.research import loop
-
-        source = inspect.getsource(loop._run_research_events)
-        assert "len(all_source_details) >= max_credits" in source, (
-            f"budget_spent must keep the sources-consumed comparison:\n{source}"
-        )
-
 
 class TestRunResearchBudgetExhaustion:
     """An exhausted credit budget skips pass-2 discovery and re-synthesis."""

--- a/tests/service/test_issue624_source_registry.py
+++ b/tests/service/test_issue624_source_registry.py
@@ -362,3 +362,28 @@ async def test_two_pass_schema_and_streaming_preserve_single_synthesis_on_duplic
     assert len(scraper.calls) == 3
     assert llm.generate.await_count == 1
     assert events[-1]["type"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_reused_evidence_does_not_crowd_out_novel_gap_sources():
+    from agent.research.discovery import _scrape_urls
+    from agent.research.sources import SourceArtifact, SourceRegistry
+
+    registry = SourceRegistry()
+    old = [f"https://example.com/old{i}" for i in range(3)]
+    for url in old:
+        registry.register(SourceArtifact(url=url, markdown="old evidence"))
+    scraper = _scraper_for({})
+    fresh = "https://example.com/gap"
+    artifacts = await _scrape_urls([*old, fresh], scraper, source_registry=registry)
+    assert [url for url, _ in scraper.calls] == [fresh]
+    assert len(artifacts) == 4
+    assert len(registry.artifacts()) == 4
+
+
+def test_source_identity_preserves_path_parameters():
+    from agent.research.sources import normalize_source_url
+
+    assert normalize_source_url("https://example.com/page;a=1") != normalize_source_url(
+        "https://example.com/page;a=2"
+    )

--- a/tests/service/test_issue624_source_registry.py
+++ b/tests/service/test_issue624_source_registry.py
@@ -33,7 +33,10 @@ def test_source_identity_is_conservative():
 
     assert (
         normalize_source_url("HTTPS://EXAMPLE.COM:443/docs/#section")
-        == "https://example.com/docs"
+        == "https://example.com/docs/"
+    )
+    assert normalize_source_url("https://example.com/docs") != normalize_source_url(
+        "https://example.com/docs/"
     )
     assert normalize_source_url(
         "https://example.com/docs?a=1&b=2"
@@ -142,7 +145,7 @@ async def test_discovery_accounts_novel_and_reused_sources_with_credit_budget():
     searxng.search = AsyncMock(
         return_value=(
             [
-                {"url": "HTTPS://EXAMPLE.COM:443/old/#x", "title": "old"},
+                {"url": "HTTPS://EXAMPLE.COM:443/old#x", "title": "old"},
                 {"url": "https://new.example/page", "title": "new"},
             ],
             MagicMock(),
@@ -173,3 +176,189 @@ async def test_discovery_accounts_novel_and_reused_sources_with_credit_budget():
     assert len(result["reused_sources"]) == 1
     assert len(result["source_details"]) == 2
     assert result["context"].count("Source:") == 2
+
+
+def _research_clients(search_by_query: dict[str, list[dict]], markdown_by_url=None):
+    """Build deterministic clients for mocked two-pass loop tests."""
+    searxng = MagicMock()
+
+    async def search(query: str, **kwargs):
+        return search_by_query[query], MagicMock()
+
+    searxng.search = AsyncMock(side_effect=search)
+    searxng.close = AsyncMock()
+    scraper = MagicMock()
+    scraper.base_url = "http://scraper"
+    scraper.calls: list[str] = []
+    markdown_by_url = markdown_by_url or {}
+
+    async def scrape_with_fallback(url: str, **kwargs):
+        scraper.calls.append(url)
+        return {
+            "success": True,
+            "data": {
+                "markdown": markdown_by_url.get(url, f"markdown for {url}"),
+                "source": "fixture",
+            },
+        }
+
+    scraper.scrape_with_fallback = AsyncMock(side_effect=scrape_with_fallback)
+    scraper.close = AsyncMock()
+    llm = MagicMock()
+    llm.generate = AsyncMock(return_value="answer [1]")
+    llm.close = AsyncMock()
+    return searxng, scraper, llm
+
+
+def _patch_research_clients(searxng, scraper, llm, *, gaps=True):
+    from unittest.mock import patch
+
+    plan = {
+        "focused_queries": ["first-a", "first-b"],
+        "research_strategy": "deep",
+        "reasoning": "fixture",
+    }
+    return patch.multiple(
+        "agent.research.loop",
+        SearXNGClient=MagicMock(return_value=searxng),
+        ScraperClient=MagicMock(return_value=scraper),
+        LLMClient=MagicMock(return_value=llm),
+        _generate_research_plan=AsyncMock(return_value=plan),
+        _detect_gaps=AsyncMock(return_value=["gap"] if gaps else []),
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_pass_duplicate_only_reuses_and_synthesizes_once():
+    from agent.research.loop import run_research
+
+    first = [
+        {"url": f"https://source{i}.example/page", "title": f"S{i}"} for i in range(3)
+    ]
+    duplicate_aliases = [
+        {"url": "HTTPS://SOURCE0.EXAMPLE:443/page#section"},
+        {"url": "https://SOURCE1.EXAMPLE/page#part"},
+        {"url": "https://source2.example/page#part"},
+    ]
+    clients = _research_clients(
+        {"first-a": first, "first-b": [], "gap": duplicate_aliases}
+    )
+    _searxng, scraper, llm = clients
+    with _patch_research_clients(*clients):
+        result = await run_research(
+            prompt="question", llm_model="fixture", search_type="deep"
+        )
+
+    assert len(scraper.calls) == 3
+    assert llm.generate.await_count == 1
+    assert result["sources"] == [item["url"] for item in first]
+    assert len(result["source_details"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_two_pass_partial_overlap_fetches_only_novel_source():
+    from agent.research.loop import run_research
+
+    first = [
+        {"url": f"https://source{i}.example/page", "title": f"S{i}"} for i in range(3)
+    ]
+    second = [
+        {"url": "HTTPS://SOURCE0.EXAMPLE:443/page#section"},
+        {"url": "https://SOURCE1.EXAMPLE/page#part"},
+        {"url": "https://new.example/page"},
+    ]
+    clients = _research_clients({"first-a": first, "first-b": [], "gap": second})
+    _searxng, scraper, llm = clients
+    with _patch_research_clients(*clients):
+        result = await run_research(
+            prompt="question", llm_model="fixture", search_type="deep"
+        )
+
+    assert len(scraper.calls) == 4
+    assert llm.generate.await_count == 2
+    assert len(result["sources"]) == 4
+    assert result["sources"].count("https://new.example/page") == 1
+
+
+@pytest.mark.asyncio
+async def test_two_pass_failed_first_acquisition_retries_without_duplicate_source():
+    from agent.research.loop import run_research
+
+    first = [{"url": f"https://source{i}.example/page"} for i in range(3)]
+    second = [
+        {"url": "HTTPS://SOURCE0.EXAMPLE:443/page#retry"},
+        {"url": "https://source1.example/page"},
+        {"url": "https://source2.example/page"},
+    ]
+    clients = _research_clients({"first-a": first, "first-b": [], "gap": second})
+    _searxng, scraper, llm = clients
+    attempts: dict[str, int] = {}
+
+    async def scrape_with_retry(url: str, **kwargs):
+        key = "source0" if "source0" in url.lower() else url
+        attempts[key] = attempts.get(key, 0) + 1
+        scraper.calls.append(url)
+        if key == "source0" and attempts[key] == 1:
+            return {"success": False, "error": "transient"}
+        return {
+            "success": True,
+            "data": {"markdown": f"markdown for {url}", "source": "fixture"},
+        }
+
+    scraper.scrape_with_fallback = AsyncMock(side_effect=scrape_with_retry)
+    with _patch_research_clients(*clients):
+        result = await run_research(
+            prompt="question", llm_model="fixture", search_type="deep"
+        )
+
+    assert attempts["source0"] == 2
+    assert len(scraper.calls) == 4
+    assert llm.generate.await_count == 2
+    assert len(result["sources"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_two_pass_schema_and_streaming_preserve_single_synthesis_on_duplicate_pass():
+    from agent.research.loop import run_research_stream
+
+    first = [{"url": f"https://source{i}.example/page"} for i in range(3)]
+    second = [{"url": f"HTTPS://SOURCE{i}.EXAMPLE:443/page#part"} for i in range(3)]
+    clients = _research_clients({"first-a": first, "first-b": [], "gap": second})
+    _searxng, scraper, llm = clients
+
+    async def generate_stream(**kwargs):
+        yield {"type": "token", "content": "streamed"}
+        yield {"type": "done", "full_content": "streamed"}
+
+    llm.generate_stream = generate_stream
+    with _patch_research_clients(*clients):
+        events = [
+            event
+            async for event in run_research_stream(
+                prompt="question", llm_model="fixture", search_type="deep"
+            )
+        ]
+
+    assert len(scraper.calls) == 3
+    assert [event["type"] for event in events].count("token") == 1
+    assert events[-1]["type"] == "done"
+
+    # Structured output uses the non-streaming synthesis branch even through
+    # the stream adapter, and duplicate pass reuse still avoids a second call.
+    clients = _research_clients({"first-a": first, "first-b": [], "gap": second})
+    _searxng, scraper, llm = clients
+    llm.generate.return_value = "{}"
+    with _patch_research_clients(*clients):
+        events = [
+            event
+            async for event in run_research_stream(
+                prompt="question",
+                llm_model="fixture",
+                search_type="deep",
+                schema={"type": "object"},
+            )
+        ]
+
+    assert len(scraper.calls) == 3
+    assert llm.generate.await_count == 1
+    assert events[-1]["type"] == "done"

--- a/tests/service/test_issue624_source_registry.py
+++ b/tests/service/test_issue624_source_registry.py
@@ -1,0 +1,175 @@
+"""Regression coverage for request-scoped cross-pass source reuse (#624)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _scraper_for(markdown_by_url: dict[str, str | None]) -> MagicMock:
+    scraper = MagicMock()
+    scraper.base_url = "http://scraper"
+    scraper.calls: list[tuple[str, dict | None]] = []
+
+    async def scrape_with_fallback(
+        url: str, scrape_options: dict | None = None
+    ) -> dict:
+        scraper.calls.append((url, scrape_options))
+        markdown = markdown_by_url.get(url, f"markdown for {url}")
+        if markdown is None:
+            return {"success": False, "error": "fixture failure"}
+        return {
+            "success": True,
+            "data": {"markdown": markdown, "source": "fixture"},
+        }
+
+    scraper.scrape_with_fallback = AsyncMock(side_effect=scrape_with_fallback)
+    return scraper
+
+
+def test_source_identity_is_conservative():
+    from agent.research.sources import normalize_source_url
+
+    assert (
+        normalize_source_url("HTTPS://EXAMPLE.COM:443/docs/#section")
+        == "https://example.com/docs"
+    )
+    assert normalize_source_url(
+        "https://example.com/docs?a=1&b=2"
+    ) != normalize_source_url("https://example.com/docs?b=2&a=1")
+    assert normalize_source_url("https://example.com/Docs") != normalize_source_url(
+        "https://example.com/docs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_registry_reuses_alias_without_duplicate_context():
+    from agent.research.discovery import _scrape_urls
+    from agent.research.sources import SourceRegistry
+
+    scraper = _scraper_for({})
+    registry = SourceRegistry()
+    first = await _scrape_urls(
+        ["https://example.com/page/"],
+        scraper,
+        min_sources=1,
+        source_registry=registry,
+    )
+    second = await _scrape_urls(
+        ["HTTPS://EXAMPLE.COM:443/page/#part"],
+        scraper,
+        min_sources=1,
+        source_registry=registry,
+    )
+
+    assert len(first) == len(second) == 1
+    assert len(scraper.calls) == 1
+    assert len(registry.artifacts()) == 1
+    assert registry.context().count("markdown for") == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_acquisition_is_retryable_and_not_registered():
+    from agent.research.discovery import _scrape_urls
+    from agent.research.sources import SourceRegistry
+
+    scraper = _scraper_for({"https://retry.example/page": None})
+    registry = SourceRegistry()
+    failed = await _scrape_urls(
+        ["https://retry.example/page"],
+        scraper,
+        min_sources=1,
+        source_registry=registry,
+    )
+
+    # Replace the failing fixture with a coroutine so this is a real retry,
+    # rather than a cache hit.
+    async def recovered(url: str, scrape_options: dict | None = None) -> dict:
+        scraper.calls.append((url, scrape_options))
+        return {"success": True, "data": {"markdown": "recovered", "source": "fixture"}}
+
+    scraper.scrape_with_fallback.side_effect = recovered
+    retried = await _scrape_urls(
+        ["https://retry.example/page"],
+        scraper,
+        min_sources=1,
+        source_registry=registry,
+    )
+
+    assert failed == []
+    assert len(retried) == 1
+    assert len(scraper.calls) == 2
+    assert registry.artifacts()[0].markdown == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_changed_scrape_options_force_new_acquisition():
+    from agent.research.discovery import _scrape_urls
+    from agent.research.sources import SourceRegistry
+
+    scraper = _scraper_for({})
+    registry = SourceRegistry()
+    url = "https://example.com/page"
+    await _scrape_urls(
+        [url],
+        scraper,
+        min_sources=1,
+        source_registry=registry,
+        scrape_options={"formats": ["markdown"]},
+    )
+    await _scrape_urls(
+        [url],
+        scraper,
+        min_sources=1,
+        source_registry=registry,
+        scrape_options={"formats": ["markdown", "images"]},
+    )
+
+    assert len(scraper.calls) == 2
+    assert len(registry.artifacts()) == 1
+
+
+@pytest.mark.asyncio
+async def test_discovery_accounts_novel_and_reused_sources_with_credit_budget():
+    from agent.research.discovery import (
+        _run_multi_query_discover_and_scrape,
+        _scrape_urls,
+    )
+    from agent.research.sources import SourceRegistry
+
+    searxng = MagicMock()
+    searxng.search = AsyncMock(
+        return_value=(
+            [
+                {"url": "HTTPS://EXAMPLE.COM:443/old/#x", "title": "old"},
+                {"url": "https://new.example/page", "title": "new"},
+            ],
+            MagicMock(),
+        )
+    )
+    scraper = _scraper_for({})
+    registry = SourceRegistry()
+    await _scrape_urls(
+        ["https://example.com/old"],
+        scraper,
+        min_sources=1,
+        source_registry=registry,
+    )
+
+    result = await _run_multi_query_discover_and_scrape(
+        queries=["gap"],
+        urls=None,
+        searxng=searxng,
+        scraper=scraper,
+        max_credits=1,
+        source_registry=registry,
+        pass_number=2,
+    )
+
+    assert len(scraper.calls) == 2
+    assert result["credits_used"] == 1
+    assert result["novel_sources"] == ["https://new.example/page"]
+    assert len(result["reused_sources"]) == 1
+    assert len(result["source_details"]) == 2
+    assert result["context"].count("Source:") == 2


### PR DESCRIPTION
Two-pass research could fetch and cite the same page repeatedly, charge reused sources again, and synthesize again when the gap search found no new evidence. A request-scoped registry now retains successful page artifacts with conservative URL identities and extraction-option compatibility.

Discovery reuses compatible evidence, keeps unique context/source order, leaves failures retryable, and counts only novel successful acquisitions. Novel gap results still receive acquisition slots even when earlier sources reappear. The canonical polling, streaming, and structured-output loop shares the registry and skips synthesis when the second pass does not change context.

Validation: 66 focused research, source-registry, and credit-budget tests pass; Ruff and mypy pass. Tests cover repeated URLs, case/query/path distinctions, option changes, retryable failures, mixed old/new evidence, streaming, structured output, and no-change second passes. The delayed duplicate-pass probe reduced fetches from six to three; this is synthetic acquisition evidence, not a production latency estimate.

Closes #624.
