### PR TITLE
perf(research): generate one final answer after coverage and gap discovery

### DIFF
--- a/agent-svc/agent/research/loop.py
+++ b/agent-svc/agent/research/loop.py
@@ -211,10 +211,7 @@ async def _run_research_events(
             credits_used += discovered.get("credits_used", len(novel_artifacts))
             combined_context = context
 
-            # Gap search can rediscover every source from pass one. The
-            # request-scoped registry makes that a no-op: preserve the first
-            # synthesis and its stream/schema semantics when evidence and
-            # context are unchanged.
+            # A duplicate-only gap pass leaves the final evidence unchanged.
             if pass_count > 1 and context == previous_context:
                 break
 
@@ -229,77 +226,10 @@ async def _run_research_events(
                 }
                 return
 
-            yield {"type": "status", "state": "synthesizing"}
-            if schema or not stream_tokens:
-                try:
-                    answer = await llm.generate(
-                        system_prompt=SYSTEM_PROMPT,
-                        user_prompt=prompt,
-                        context=combined_context,
-                        schema=schema,
-                        stage="synthesis",
-                    )
-                except RetryableRateLimitError as exc:
-                    if stream_tokens:
-                        yield {
-                            "type": "error",
-                            "classification": "retryable",
-                            "retry_after_seconds": exc.retry_after_seconds,
-                            "content": exc.detail,
-                        }
-                        return
-                    raise
-                except ProviderOutputError as exc:
-                    if stream_tokens:
-                        yield {
-                            "type": "error",
-                            "classification": "non_retryable",
-                            "content": exc.detail,
-                        }
-                        return
-                    raise
-                try:
-                    _validate_json_if_schema(answer, schema)
-                except StructuredOutputError as exc:
-                    if stream_tokens:
-                        yield {
-                            "type": "error",
-                            "classification": "non_retryable",
-                            "content": exc.detail,
-                        }
-                        return
-                    raise
-                if not schema and not stream_tokens:
-                    yield {
-                        "type": "sources",
-                        "sources": [s["url"] for s in all_source_details],
-                    }
-            else:
-                yield {
-                    "type": "sources",
-                    "sources": [s["url"] for s in all_source_details],
-                }
-                answer = ""
-                async for event in llm.generate_stream(
-                    system_prompt=SYSTEM_PROMPT,
-                    user_prompt=prompt,
-                    context=combined_context,
-                    stage="synthesis",
-                ):
-                    if event["type"] == "token":
-                        answer += event["content"]
-                        yield {"type": "token", "content": event["content"]}
-                    elif event["type"] == "error":
-                        yield _research_error_event(event)
-                        return
-                    elif event["type"] == "done":
-                        answer = event["full_content"]
-
-            # ── Gap detection after pass 1 ─────────────────────────
+            # Coverage depends only on evidence, so decide follow-up work
+            # before the one final synthesis in every response mode.
             if pass_count == 1:
-                # ``len(all_source_details) >= max_credits`` was the
-                # pre-registry approximation. Count only novel successful
-                # acquisitions so reuse remains free.
+                # Count novel successful acquisitions; reuse remains free.
                 budget_spent = max_credits is not None and credits_used >= max_credits
                 gap_topics = (
                     []
@@ -311,6 +241,72 @@ async def _run_research_events(
                 if not gap_topics:
                     break  # Coverage is adequate, done
                 max_passes = 2  # Enable second pass
+
+        yield {"type": "status", "state": "synthesizing"}
+        if schema or not stream_tokens:
+            try:
+                answer = await llm.generate(
+                    system_prompt=SYSTEM_PROMPT,
+                    user_prompt=prompt,
+                    context=combined_context,
+                    schema=schema,
+                    stage="synthesis",
+                )
+            except RetryableRateLimitError as exc:
+                if stream_tokens:
+                    yield {
+                        "type": "error",
+                        "classification": "retryable",
+                        "retry_after_seconds": exc.retry_after_seconds,
+                        "content": exc.detail,
+                    }
+                    return
+                raise
+            except ProviderOutputError as exc:
+                if stream_tokens:
+                    yield {
+                        "type": "error",
+                        "classification": "non_retryable",
+                        "content": exc.detail,
+                    }
+                    return
+                raise
+            try:
+                _validate_json_if_schema(answer, schema)
+            except StructuredOutputError as exc:
+                if stream_tokens:
+                    yield {
+                        "type": "error",
+                        "classification": "non_retryable",
+                        "content": exc.detail,
+                    }
+                    return
+                raise
+            if not schema and not stream_tokens:
+                yield {
+                    "type": "sources",
+                    "sources": [s["url"] for s in all_source_details],
+                }
+        else:
+            yield {
+                "type": "sources",
+                "sources": [s["url"] for s in all_source_details],
+            }
+            answer = ""
+            async for event in llm.generate_stream(
+                system_prompt=SYSTEM_PROMPT,
+                user_prompt=prompt,
+                context=combined_context,
+                stage="synthesis",
+            ):
+                if event["type"] == "token":
+                    answer += event["content"]
+                    yield {"type": "token", "content": event["content"]}
+                elif event["type"] == "error":
+                    yield _research_error_event(event)
+                    return
+                elif event["type"] == "done":
+                    answer = event["full_content"]
 
         source_list = [source["url"] for source in all_source_details]
         if schema:

--- a/benchmarks/research-final-synthesis-2026-09-04.md
+++ b/benchmarks/research-final-synthesis-2026-09-04.md
@@ -1,0 +1,12 @@
+# Final research synthesis probe — 2026-09-04
+
+Run `PYTHONPATH=agent-svc:scraper-svc:. python benchmarks/research_final_synthesis.py`. Ten samples compare the actual baseline loop at `ca591199cfd05144e45d2372afd659f2e86e6327` with the revised loop. Search and fetch each wait 10 ms, gap analysis waits 20 ms, synthesis waits 60 ms. External clients are replaced with deterministic stubs; both versions return the same two source URLs. p95 uses nearest-rank. These timings isolate orchestration, not production/model quality.
+
+| Loop | Streaming | p50 total ms | p95 total ms | p50 first token ms | Synthesis calls | Tokens equal final answer |
+|---|---|---|---|---|---|---|
+| baseline | False | 188.87 | 192.77 | None | 2 | None |
+| final_only | False | 127.38 | 129.86 | None | 1 | None |
+| baseline | True | 188.63 | 190.18 | 83.33 | 2 | False |
+| final_only | True | 127.96 | 128.75 | 126.92 | 1 | True |
+
+The first token arrives later because it belongs to the final answer. Total work drops by one generation, with no added simultaneous model calls. Token usage reduction depends on the discarded draft length; this fixture does not measure real provider tokens or quality. Behavioral tests verify combined evidence, no-gap early exit, credit exhaustion, schema mode, provider errors, and cancellation/client cleanup. Grounded quality evaluation and real provider contention remain deployment measurements.

--- a/benchmarks/research_final_synthesis.py
+++ b/benchmarks/research_final_synthesis.py
@@ -1,0 +1,119 @@
+"""Compare the production loop against the pre-optimization loop with delayed I/O.
+
+PYTHONPATH=agent-svc:scraper-svc:. python benchmarks/research_final_synthesis.py
+Loads only the committed baseline loop, with every external dependency replaced.
+"""
+
+import asyncio
+import json
+import statistics
+import subprocess
+import time
+import types
+from unittest.mock import AsyncMock
+
+from agent.research import loop
+
+BASE = "ca591199cfd05144e45d2372afd659f2e86e6327"
+
+
+async def probe(module, streaming):
+    calls = 0
+    first_token = None
+
+    class Search:
+        async def search(self, query, **kwargs):
+            await asyncio.sleep(0.01)
+            return ([{"url": f"https://example.test/{query}"}], None)
+
+        close = AsyncMock()
+
+    class Scraper:
+        async def scrape_with_fallback(self, url, **kwargs):
+            await asyncio.sleep(0.01)
+            return {"success": True, "data": {"markdown": f"evidence {url}"}}
+
+        close = AsyncMock()
+
+    class LLM:
+        async def generate(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            await asyncio.sleep(0.06)
+            return "final answer [1] [2]"
+
+        async def generate_stream(self, **kwargs):
+            value = await self.generate(**kwargs)
+            yield {"type": "token", "content": value}
+            yield {"type": "done", "full_content": value}
+
+        close = AsyncMock()
+
+    async def gaps(*args, **kwargs):
+        await asyncio.sleep(0.02)
+        return ["followup"]
+
+    module.SearXNGClient = lambda *a, **k: Search()
+    module.ScraperClient = lambda *a, **k: Scraper()
+    module.LLMClient = lambda *a, **k: LLM()
+    module._generate_research_plan = AsyncMock(
+        return_value={"focused_queries": ["initial"], "research_strategy": "focused"}
+    )
+    module._detect_gaps = gaps
+    start = time.perf_counter()
+    events = []
+    async for event in module._run_research_events(
+        "q", llm_model="fixture", stream_tokens=streaming
+    ):
+        events.append(event)
+        if event["type"] == "token" and first_token is None:
+            first_token = (time.perf_counter() - start) * 1000
+    final = events[-1]
+    assert set(final["sources"]) == {
+        "https://example.test/initial",
+        "https://example.test/followup",
+    }
+    return {
+        "total_ms": (time.perf_counter() - start) * 1000,
+        "first_token_ms": first_token,
+        "synthesis_calls": calls,
+        "tokens_match_final": "".join(
+            e["content"] for e in events if e["type"] == "token"
+        )
+        == final["result"],
+    }
+
+
+async def main():
+    source = subprocess.check_output(
+        ["git", "show", f"{BASE}:agent-svc/agent/research/loop.py"], text=True
+    )
+    baseline = types.ModuleType("agent.research.baseline_loop")
+    exec(compile(source, "baseline_loop.py", "exec"), baseline.__dict__)
+    output = []
+    for streaming in (False, True):
+        for name, module in (("baseline", baseline), ("final_only", loop)):
+            samples = [await probe(module, streaming) for _ in range(10)]
+            timings = sorted(s["total_ms"] for s in samples)
+            output.append(
+                {
+                    "mode": name,
+                    "streaming": streaming,
+                    "p50_ms": round(statistics.median(timings), 2),
+                    "p95_ms": round(timings[-1], 2),
+                    "first_token_p50_ms": round(
+                        statistics.median(s["first_token_ms"] for s in samples), 2
+                    )
+                    if streaming
+                    else None,
+                    "synthesis_calls": samples[0]["synthesis_calls"],
+                    "tokens_match_final": samples[0]["tokens_match_final"]
+                    if streaming
+                    else None,
+                }
+            )
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/adr/0064-one-final-research-synthesis.md
+++ b/docs/adr/0064-one-final-research-synthesis.md
@@ -1,0 +1,51 @@
+# One Final Research Synthesis
+
+- Status: accepted
+- Deciders: GroktoCrawl maintainers
+- Date: 2026-09-04
+
+## Context
+
+Gap analysis reads evidence and the original question, never the draft answer.
+The old two-pass loop nevertheless synthesized before gap analysis, discarded
+that draft for polling/structured requests, and streamed two answers without
+revision markers for streaming requests. This wastes one full model generation
+and can leave clients displaying concatenated incompatible answers.
+
+## Decision
+
+Complete coverage analysis and any budgeted second discovery pass before one
+final synthesis in all response modes. Keep the existing progress event types.
+Only final answer text is emitted as `token` events; the final `sources` event
+fixes source ordering before the first token. `done.result` is the sole terminal
+answer, with the same source set. Structured results are generated and validated
+once. Errors terminate without a successful done event; cancellation propagates
+through the current awaited stage and client cleanup.
+
+No provisional draft or revision protocol is introduced. Synthesis uses an
+immutable context assembled after discovery, and existing LLM admission remains
+in force. Coverage checks remain skipped when the source-credit budget is spent.
+Duplicate-only second passes retain the existing evidence and still synthesize
+exactly once. Source acquisition and early progress are handled by ADR-0059 and
+its discovery pipeline work.
+
+## Consequences
+
+Two-pass jobs avoid a discarded generation and associated tokens, model queue
+occupancy, validation, and latency. Streaming no longer concatenates two answers.
+No extra concurrent LLM request is introduced, avoiding provider contention.
+Time to first answer token can increase because coverage and follow-up discovery
+finish first. Discovery progress remains available. This is an explicit tradeoff
+for one grounded final answer and lower total work; a future provisional-answer
+API must define revision/source identity semantics before introducing drafts.
+
+## Alternatives Considered
+
+Overlapping a provisional synthesis with gap analysis would reduce time to a
+provisional token but spend a full draft generation on gap-positive jobs, contend
+for LLM admission, and require a new revision-aware client protocol. It is deferred.
+
+## Links
+
+- [ADR-0059](0059-extend-source-artifact-reuse-across-research-passes.md)
+- Issue #621

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,4 +83,6 @@ An Architecture Decision Record captures an important architectural decision mad
 | 0056 | [Twin CI Evidence and Trusted Calibration](0056-twin-ci-evidence-and-calibration.md) | accepted |
 | 0057 | [Defer Recurring Mutation-Testing CI (Pilot Outcome)](0057-defer-recurring-mutation-testing-ci.md) | accepted |
 | 0059 | [Extend Source Artifact Reuse Across Research Passes](0059-extend-source-artifact-reuse-across-research-passes.md) | accepted |
+| 0064 | [One Final Research Synthesis](0064-one-final-research-synthesis.md) | accepted |
+
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full ADR workflow: when to write an ADR, how to number it, and how to get it reviewed in a PR.

--- a/tests/service/test_agent_max_credits.py
+++ b/tests/service/test_agent_max_credits.py
@@ -328,18 +328,6 @@ class TestMaxCreditsGuardRemoval:
             "guard — the API model enforces ge=1, so drop the dead branch"
         )
 
-    @pytest.mark.asyncio
-    async def test_budget_spent_check_uses_counted_sources_only(self):
-        """budget_spent compares consumed sources to the budget directly."""
-        import inspect
-
-        from agent.research import loop
-
-        source = inspect.getsource(loop._run_research_events)
-        assert "len(all_source_details) >= max_credits" in source, (
-            f"budget_spent must keep the sources-consumed comparison:\n{source}"
-        )
-
 
 class TestRunResearchBudgetExhaustion:
     """An exhausted credit budget skips pass-2 discovery and re-synthesis."""

--- a/tests/service/test_issue621_final_synthesis.py
+++ b/tests/service/test_issue621_final_synthesis.py
@@ -1,0 +1,123 @@
+"""Final-only synthesis ordering, evidence, errors, and cancellation."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from agent.llm import ProviderOutputError
+from agent.research.loop import _run_research_events, run_research
+
+from tests.service.test_issue624_source_registry import (
+    _patch_research_clients,
+    _research_clients,
+)
+
+
+def clients():
+    return _research_clients(
+        {
+            "first-a": [{"url": "https://example.com/first"}],
+            "first-b": [],
+            "gap": [{"url": "https://example.com/second"}],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stream,schema", [(False, None), (True, None), (True, {"type": "object"})]
+)
+async def test_coverage_and_followup_finish_before_single_final_synthesis(
+    stream, schema
+):
+    searxng, scraper, llm = all_clients = clients()
+    synth_contexts = []
+
+    async def generate(**kwargs):
+        assert searxng.search.await_count == 3
+        synth_contexts.append(kwargs["context"])
+        return "{}" if schema else "final [1] [2]"
+
+    async def generate_stream(**kwargs):
+        answer = await generate(**kwargs)
+        yield {"type": "token", "content": answer}
+        yield {"type": "done", "full_content": answer}
+
+    llm.generate.side_effect = generate
+    llm.generate_stream = generate_stream
+    with _patch_research_clients(*all_clients):
+        events = [
+            event
+            async for event in _run_research_events(
+                prompt="question",
+                llm_model="fixture",
+                stream_tokens=stream,
+                schema=schema,
+            )
+        ]
+    assert len(synth_contexts) == 1
+    assert "first" in synth_contexts[0] and "second" in synth_contexts[0]
+    assert events[-1]["type"] == "done"
+    assert len(events[-1]["sources"]) == 2
+    tokens = [e["content"] for e in events if e["type"] == "token"]
+    if stream and not schema:
+        assert "".join(tokens) == events[-1]["result"]
+    else:
+        assert tokens == []
+    scraper.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_final_provider_error_has_no_successful_terminal_event():
+    all_clients = clients()
+    llm = all_clients[-1]
+    llm.generate.side_effect = ProviderOutputError("bad output")
+    with _patch_research_clients(*all_clients):
+        events = [
+            event
+            async for event in _run_research_events(
+                prompt="q",
+                llm_model="fixture",
+                stream_tokens=True,
+                schema={"type": "object"},
+            )
+        ]
+    assert events[-1]["type"] == "error"
+    assert not any(e["type"] == "done" for e in events)
+    assert llm.generate.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelling_gap_analysis_prevents_synthesis_and_closes_clients():
+    all_clients = clients()
+    started, cancelled = asyncio.Event(), asyncio.Event()
+
+    async def gaps(*args, **kwargs):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    with (
+        _patch_research_clients(*all_clients),
+        patch("agent.research.loop._detect_gaps", side_effect=gaps),
+    ):
+        task = asyncio.create_task(run_research(prompt="q", llm_model="fixture"))
+        await asyncio.wait_for(started.wait(), 1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert cancelled.is_set()
+    all_clients[-1].generate.assert_not_awaited()
+    for client in all_clients:
+        client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_gap_generates_once_without_followup_search():
+    all_clients = clients()
+    with _patch_research_clients(*all_clients, gaps=False):
+        await run_research(prompt="q", llm_model="fixture")
+    assert all_clients[0].search.await_count == 2
+    all_clients[-1].generate.assert_awaited_once()

--- a/tests/service/test_issue624_source_registry.py
+++ b/tests/service/test_issue624_source_registry.py
@@ -275,7 +275,7 @@ async def test_two_pass_partial_overlap_fetches_only_novel_source():
         )
 
     assert len(scraper.calls) == 4
-    assert llm.generate.await_count == 2
+    assert llm.generate.await_count == 1
     assert len(result["sources"]) == 4
     assert result["sources"].count("https://new.example/page") == 1
 
@@ -313,7 +313,7 @@ async def test_two_pass_failed_first_acquisition_retries_without_duplicate_sourc
 
     assert attempts["source0"] == 2
     assert len(scraper.calls) == 4
-    assert llm.generate.await_count == 2
+    assert llm.generate.await_count == 1
     assert len(result["sources"]) == 3
 
 


### PR DESCRIPTION
Implemented and merged through #631, which contains every commit from this PR and validates the combined research pipeline. This superseded review is closed after consolidation.

Research previously generated a full answer before context-only gap analysis, then generated another answer after follow-up discovery. Polling discarded the first answer, and streaming could concatenate both. All modes now finish evidence coverage first and generate one final answer against stable context and source ordering.

This explicitly trades later first-token delivery for lower total work and an unambiguous final stream; ADR-0064 documents the decision. No provisional-answer protocol or additional competing model calls are introduced. Structured output is generated and validated once, and errors/cancellation retain their terminal behavior.

Validation: 71 focused research, credit, registry, error, cancellation, and streaming tests pass; Ruff and mypy pass. A ten-sample delayed-I/O comparison against the actual baseline loop reduced total p50 from 189 ms to 128 ms and synthesis calls from two to one. Streaming first-token p50 rose from 83 ms to 127 ms; concatenated tokens now equal the final answer. These are synthetic orchestration measurements, not production model-quality claims. See `benchmarks/research-final-synthesis-2026-09-04.md`.

Depends on #633 (source reuse); retarget to main after it merges.

Closes #621.
