### PR TITLE
ci: publish multi-architecture container images (#617)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -268,6 +268,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -6,6 +6,11 @@
 
 `agent-svc` coordinates requests; `scraper-svc` fetches content; optional `semantic-svc` uses Qdrant; Valkey stores operational state; SlopSearX discovers web results; `browser-svc`, `parse-svc`, `portal-svc`, `mcp-svc`, `slopsearx-mcp`, and Ofelia provide specialized capabilities. `mcp-svc` exposes GroktoCrawl API tools; the opt-in `slopsearx-mcp` companion exposes direct SlopSearX search-engine tools when the `mcp` profile is enabled. The [architecture guide](../architecture.md) describes ownership and data flow.
 
+The published GroktoCrawl service images support both `linux/amd64` and
+`linux/arm64`, so arm64 hosts such as Apple Silicon Macs do not need to run
+these images under emulation. The optional Qdrant service remains explicitly
+configured for `linux/amd64` in Compose.
+
 ## Configuration
 
 For deterministic Compose integration runs, enable the fixture profile and send

--- a/tests/service/test_workflow_contract.py
+++ b/tests/service/test_workflow_contract.py
@@ -101,6 +101,19 @@ def test_workflows_have_structured_trusted_and_hosted_contracts():
     assert "twin-out" in twin_run and "junitxml" in twin_run
 
 
+def test_published_service_images_target_amd64_and_arm64():
+    root = Path(__file__).parents[2]
+    docker = yaml.safe_load((root / ".github/workflows/docker.yml").read_text())
+    build_steps = docker["jobs"]["build-and-push"]["steps"]
+    build_step = next(
+        step
+        for step in build_steps
+        if step.get("uses") == "docker/build-push-action@v6"
+    )
+
+    assert build_step["with"]["platforms"] == "linux/amd64,linux/arm64"
+
+
 def test_answer_evals_workflow_is_advisory_and_not_pr_gated():
     root = Path(__file__).parents[2]
     workflow = (root / ".github/workflows/answer-evals.yml").read_text()


### PR DESCRIPTION
## Summary

Publish every GroktoCrawl service image for both `linux/amd64` and `linux/arm64` through the existing QEMU/Buildx pipeline. This lets arm64 hosts, including Apple Silicon Macs, pull native images instead of relying on emulation. The deployment guide records the supported image platforms and the existing Qdrant caveat.

## Related Issue

Closes #617

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that changes existing behavior)
- [x] 📚 Documentation (README, AGENTS.md, CONTRIBUTING.md, or other docs)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 🧪 Test (adding or updating tests)
- [x] ⚡ CI/DevOps (CI pipeline, Docker, dependency updates)

## Test Plan

- [ ] Integration tests pass: `docker compose exec agent-svc python3 -m pytest /app/tests/integration/ /app/tests/service/`
- [x] New tests added for the change
- [x] Manual verification done (describe)

The Docker integration command was not run because this change does not modify
runtime services; the local broad service-suite attempt hit unrelated existing
collection/runtime failures. The focused workflow contract suite passed 9 tests.
Manual verification parsed `.github/workflows/docker.yml`, confirmed the
`docker/build-push-action@v6` step has `platforms: linux/amd64,linux/arm64`,
and passed docs-surface, Ruff, `git diff --check`, and all pre-commit hooks.

## Checklist

- [x] My code follows the project's coding conventions (type hints, async/await, minimal deps)
- [x] I have updated the relevant documentation (README, AGENTS.md, CHANGELOG)
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New API endpoints have a corresponding CLI subcommand (see ADR-0039)
- [x] If adding a new async endpoint, it accepts a `webhook` field and fires on completion/failure

## Notes for Reviewers

- The existing QEMU and Buildx setup was retained; the fix adds the missing multi-platform build declaration to the shared matrix publisher, so all seven published service images receive both manifests.
- The optional Qdrant Compose service remains explicitly pinned to `linux/amd64`; it is outside this issue's GroktoCrawl image-publishing scope.
- Prepared by Codex, an AI agent, on behalf of Magnus.
