### PR TITLE
feat(mcp): expose plan consent workflow

### DIFF
--- a/docs/guides/features.md
+++ b/docs/guides/features.md
@@ -14,7 +14,7 @@ Search uses SlopSearX for discovery and supports content enrichment, `fast`, `ri
 
 ## Research, plans, sessions, and memory
 
-The agent plans queries, discovers/scrapes sources, synthesizes cited results, and can run a gap-filling second pass. `/v2/answer` is the lower-latency grounded-Q&A path. Plans support review/execute workflows; sessions retain stepwise research context; research memory reuses compatible past artifacts; citation resolution expands compact references. Streaming clients should render planning/source/token events incrementally and treat `done`/`error` as terminal.
+The agent plans queries, discovers/scrapes sources, synthesizes cited results, and can run a gap-filling second pass. `/v2/answer` is the lower-latency grounded-Q&A path. Plans support review/execute workflows; sessions retain stepwise research context; research memory reuses compatible past artifacts; citation resolution expands compact references. Through MCP, use `create_research_plan`, inspect it with `get_research_plan`, then call `execute_research_plan` with `approve=true`; execution is one-shot and returns a job ID. Streaming clients should render planning/source/token events incrementally and treat `done`/`error` as terminal.
 
 ## Browser, parse, portal, and MCP
 

--- a/mcp-svc/groktocrawl_client.py
+++ b/mcp-svc/groktocrawl_client.py
@@ -486,6 +486,35 @@ class GroktocrawlClient:
             f"/v2/session/{session_id}/resolve", {"ref_ids": ref_ids}
         )
 
+    async def create_research_plan(
+        self,
+        prompt: str,
+        model: str | None = None,
+        urls: list[str] | None = None,
+    ) -> dict:
+        """Generate a reviewable, one-shot research plan."""
+        body: dict[str, Any] = {"prompt": prompt}
+        if model and model != "default":
+            body["model"] = model
+        if urls:
+            body["urls"] = urls
+        return await self._post("/v2/agent/plan", body)
+
+    async def get_research_plan(self, plan_id: str) -> dict:
+        """Retrieve a generated research plan without executing it."""
+        return await self._get(f"/v2/agent/plan/{plan_id}")
+
+    async def execute_research_plan(
+        self,
+        plan_id: str,
+        modifications: list[dict[str, Any]] | dict[str, Any] | None = None,
+    ) -> dict:
+        """Execute an approved research plan and return its job ID."""
+        body: dict[str, Any] = {"plan_id": plan_id}
+        if modifications:
+            body["modifications"] = modifications
+        return await self._post("/v2/agent/execute", body)
+
     async def answer(
         self,
         question: str,

--- a/mcp-svc/mcp_server.py
+++ b/mcp-svc/mcp_server.py
@@ -639,6 +639,117 @@ async def delete_research_session(session_id: str) -> str:
     return _resp(result)
 
 
+# ── Tools 18–20: plan-consent research workflow ──────────────────
+
+
+@mcp.tool(annotations=_RO)
+async def create_research_plan(
+    prompt: str,
+    model: str | None = None,
+    urls: list[str] | None = None,
+) -> str:
+    """Generate a research plan for review without starting execution.
+
+    The response includes a one-shot ``plan_id`` plus proposed phases,
+    expected searches, estimated depth, and analysis dimensions. Review it
+    with get_research_plan before calling execute_research_plan.
+
+    Args:
+        prompt: Research question to decompose into an execution plan.
+        model: Optional LLM model override.
+        urls: Optional seed URLs to scope the plan.
+    """
+    result = await _client.create_research_plan(
+        prompt=prompt,
+        model=model,
+        urls=urls,
+    )
+    _ensure_success(result)
+    return _resp(result)
+
+
+@mcp.tool(annotations=_RO)
+async def get_research_plan(plan_id: str) -> str:
+    """Retrieve a proposed research plan for human or agent review."""
+    result = await _client.get_research_plan(plan_id)
+    _ensure_success(result)
+    return _resp(result)
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+async def execute_research_plan(
+    plan_id: str,
+    approve: bool,
+    narrow: str | None = None,
+    add_dimensions: list[str] | None = None,
+    remove_dimensions: list[str] | None = None,
+    query_overrides: dict[str, str] | None = None,
+) -> str:
+    """Execute a reviewed research plan after explicit approval.
+
+    Set ``approve`` to True only after inspecting get_research_plan. The
+    plan is one-shot: a successful execution consumes it and returns an
+    asynchronous research job ID. Optional typed fields narrow scope, add
+    or remove analysis dimensions, or replace phase queries. Rejected,
+    expired, already-executed, and invalid plan IDs return actionable errors.
+
+    Args:
+        plan_id: Plan ID returned by create_research_plan.
+        approve: Explicit approval gate; must be True to execute.
+        narrow: Optional focus text that narrows the research scope.
+        add_dimensions: Optional analysis dimensions to add.
+        remove_dimensions: Optional analysis dimensions to remove.
+        query_overrides: Optional mapping of zero-based phase indexes to new
+            search queries.
+    """
+    if not approve:
+        raise ToolError(
+            "execute_research_plan requires approve=True after reviewing the plan"
+        )
+
+    if remove_dimensions and query_overrides:
+        raise ToolError(
+            "remove_dimensions cannot be combined with query_overrides by the plan API"
+        )
+
+    modifications: list[dict[str, Any]] | dict[str, Any] = []
+    if remove_dimensions:
+        # The API's legacy dict form is the typed representation that supports
+        # remove_dimension alongside narrow/add_dimension.
+        modifications = {
+            "narrow": narrow,
+            "add_dimension": add_dimensions,
+            "remove_dimension": remove_dimensions,
+        }
+    else:
+        if narrow:
+            modifications.append({"type": "narrow", "params": {"focus": narrow}})
+        for dimension in add_dimensions or []:
+            modifications.append(
+                {"type": "add_dimension", "params": {"dimension": dimension}}
+            )
+    for phase_index, new_query in (query_overrides or {}).items():
+        if not new_query.strip():
+            raise ToolError("query_overrides values must be non-empty queries")
+        try:
+            phase_number = int(phase_index)
+        except ValueError as exc:
+            raise ToolError("query_overrides keys must be phase indexes") from exc
+        modifications.append(
+            {
+                "type": "modify_query",
+                "params": {"phase_index": phase_number, "new_query": new_query},
+            }
+        )
+
+    result = await _client.execute_research_plan(
+        plan_id=plan_id,
+        modifications=modifications or None,
+    )
+    _ensure_success(result)
+    return _resp(result)
+
+
 # ── Tool 10: answer ────────────────────────────────────────────────
 
 

--- a/mcp-svc/tests/test_client.py
+++ b/mcp-svc/tests/test_client.py
@@ -983,6 +983,50 @@ class TestExpandedSurface:
             ("DELETE", "/v2/session/rs-1", None),
         ]
 
+    def test_research_plan_lifecycle_requests(self):
+        captured: list[tuple[str, str, dict[str, Any] | None]] = []
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            body = json.loads(request.content) if request.content else None
+            captured.append((request.method, request.url.path, body))
+            return httpx.Response(200, json={"success": True}, request=request)
+
+        transport = httpx.MockTransport(_handler)
+        client = GroktocrawlClient(base_url="http://test:8080", api_key=None)
+        client._client = httpx.AsyncClient(
+            base_url=client._base_url, headers=client._headers(), transport=transport
+        )
+
+        async def run() -> None:
+            await client.create_research_plan(
+                "Compare vector databases", urls=["https://a.test"]
+            )
+            await client.get_research_plan("plan-1")
+            await client.execute_research_plan(
+                "plan-1",
+                [{"type": "narrow", "params": {"focus": "cost"}}],
+            )
+
+        asyncio.run(run())
+        assert captured == [
+            (
+                "POST",
+                "/v2/agent/plan",
+                {"prompt": "Compare vector databases", "urls": ["https://a.test"]},
+            ),
+            ("GET", "/v2/agent/plan/plan-1", None),
+            (
+                "POST",
+                "/v2/agent/execute",
+                {
+                    "plan_id": "plan-1",
+                    "modifications": [{"type": "narrow", "params": {"focus": "cost"}}],
+                },
+            ),
+        ]
+
     def test_monitor_get_verb(self):
         client = _make_matched_client(
             {

--- a/mcp-svc/tests/test_mcp_server.py
+++ b/mcp-svc/tests/test_mcp_server.py
@@ -132,12 +132,12 @@ class TestToolDiscovery:
     """VAL-MCP-B01: tools/list returns the complete MCP tool surface."""
 
     async def test_tool_count(self):
-        """tools/list returns exactly 41 tools."""
+        """tools/list returns exactly 44 tools."""
         tools = await mcp.list_tools()
-        assert len(tools) == 41, f"Expected 41 tools, got {len(tools)}"
+        assert len(tools) == 44, f"Expected 44 tools, got {len(tools)}"
 
     async def test_all_tool_names(self):
-        """All 41 expected tool names are present."""
+        """All 44 expected tool names are present."""
         tools = await mcp.list_tools()
         names = {t.name for t in tools}
         expected = {
@@ -182,6 +182,9 @@ class TestToolDiscovery:
             "export_research_session",
             "resolve_research_session",
             "delete_research_session",
+            "create_research_plan",
+            "get_research_plan",
+            "execute_research_plan",
         }
         missing = expected - names
         extra = names - expected
@@ -269,6 +272,9 @@ class TestToolDiscovery:
             "export_research_session": "session_id",
             "resolve_research_session": "session_id",
             "delete_research_session": "session_id",
+            "create_research_plan": "prompt",
+            "get_research_plan": "plan_id",
+            "execute_research_plan": "plan_id",
             "get_monitor": "monitor_id",
             "update_monitor": "monitor_id",
             "run_monitor": "monitor_id",
@@ -327,6 +333,8 @@ class TestToolAnnotations:
             "get_research_session",
             "export_research_session",
             "resolve_research_session",
+            "create_research_plan",
+            "get_research_plan",
         }
         for t in tools:
             if t.name in readonly_tools:
@@ -349,6 +357,7 @@ class TestToolAnnotations:
             "destroy_browser_session",
             "delete_monitor",
             "delete_research_session",
+            "execute_research_plan",
         }
         for t in tools:
             if t.name in destructive_tools:
@@ -809,6 +818,76 @@ class TestToolCallRouting:
             await mcp.call_tool(
                 "research_session_step",
                 {"session_id": "rs-1", "action": action, **arguments},
+            )
+
+    async def test_research_plan_lifecycle_routing(self, monkeypatch):
+        """Plan tools preserve review-before-execution and typed changes."""
+        import mcp_server as mod
+
+        captured: dict[str, Any] = {}
+
+        async def _fake_create(**kwargs: Any) -> dict:
+            captured["create"] = kwargs
+            return {"success": True, "plan_id": "plan-1", "plan": {"phases": []}}
+
+        async def _fake_get(plan_id: str) -> dict:
+            captured["get"] = plan_id
+            return {"success": True, "plan_id": plan_id}
+
+        async def _fake_execute(**kwargs: Any) -> dict:
+            captured["execute"] = kwargs
+            return {"success": True, "id": "job-1"}
+
+        monkeypatch.setattr(mod._client, "create_research_plan", _fake_create)
+        monkeypatch.setattr(mod._client, "get_research_plan", _fake_get)
+        monkeypatch.setattr(mod._client, "execute_research_plan", _fake_execute)
+
+        await mcp.call_tool(
+            "create_research_plan",
+            {"prompt": "Compare vector databases", "urls": ["https://a.test"]},
+        )
+        await mcp.call_tool("get_research_plan", {"plan_id": "plan-1"})
+        await mcp.call_tool(
+            "execute_research_plan",
+            {
+                "plan_id": "plan-1",
+                "approve": True,
+                "narrow": "focus on operational costs",
+                "add_dimensions": ["latency"],
+                "query_overrides": {"0": "vector database latency benchmarks"},
+            },
+        )
+
+        assert captured["create"] == {
+            "prompt": "Compare vector databases",
+            "model": None,
+            "urls": ["https://a.test"],
+        }
+        assert captured["get"] == "plan-1"
+        assert captured["execute"] == {
+            "plan_id": "plan-1",
+            "modifications": [
+                {
+                    "type": "narrow",
+                    "params": {"focus": "focus on operational costs"},
+                },
+                {"type": "add_dimension", "params": {"dimension": "latency"}},
+                {
+                    "type": "modify_query",
+                    "params": {
+                        "phase_index": 0,
+                        "new_query": "vector database latency benchmarks",
+                    },
+                },
+            ],
+        }
+
+    async def test_execute_research_plan_requires_explicit_approval(self):
+        """A plan cannot execute when the approval gate is false."""
+        with pytest.raises(Exception, match="approve=True"):
+            await mcp.call_tool(
+                "execute_research_plan",
+                {"plan_id": "plan-1", "approve": False},
             )
 
     async def test_crawl_passes_path_filters(self, monkeypatch):

--- a/scripts/check-mcp-coverage.py
+++ b/scripts/check-mcp-coverage.py
@@ -39,9 +39,6 @@ EXEMPT: dict[str, str] = {
     "POST /v2/crawl/params-preview": (
         "Internal helper for NL-parameter validation; crawl tool accepts prompt."
     ),
-    "POST /v2/agent/plan": "Plan subsystem — backlog; MCP TBD.",
-    "GET /v2/agent/plan/{plan_id}": "Plan subsystem — backlog; MCP TBD.",
-    "POST /v2/agent/execute": "Plan subsystem — backlog; MCP TBD.",
     "POST /v2/research-memory/query": "Research memory — backlog; MCP TBD.",
     "POST /v2/research-memory/store": "Research memory — backlog; MCP TBD.",
     "DELETE /v2/research-memory/{artifact_id}": ("Research memory — backlog; MCP TBD."),
@@ -58,6 +55,9 @@ PATH_TO_MCP_TOOL: dict[str, str] = {
     "POST /v2/agent": "agent",
     "GET /v2/agent/{job_id}": "get_agent_status",
     "DELETE /v2/agent/{job_id}": "cancel_agent",
+    "POST /v2/agent/plan": "create_research_plan",
+    "GET /v2/agent/plan/{plan_id}": "get_research_plan",
+    "POST /v2/agent/execute": "execute_research_plan",
     "POST /v2/answer": "answer",
     "POST /v2/batch/scrape": "batch_scrape",
     "GET /v2/batch/scrape/{job_id}": "get_batch_scrape_status",


### PR DESCRIPTION
## Summary

- expose typed create, get, and explicitly-approved execute research-plan tools
- preserve plan review before one-shot execution and return actionable invalid/expired-plan errors
- add typed plan modifications, client routing, coverage mapping, lifecycle tests, and documentation

## Verification

- `PYTHONPATH=mcp-svc python3 -m pytest --no-cov mcp-svc/tests/test_mcp_server.py mcp-svc/tests/test_client.py -q`
- `python3 scripts/check-mcp-coverage.py`
- targeted pre-commit hooks and full commit hooks

Closes #641